### PR TITLE
Integrar OAuth, roles de usuario y API v1

### DIFF
--- a/DOCUMENTACION_TECNICA.md
+++ b/DOCUMENTACION_TECNICA.md
@@ -153,32 +153,49 @@ El sistema OAuth implementa un flujo de autorización con PKCE y refresh tokens 
 
 ### Endpoints OAuth
 
-- `GET /auth/oauth/authorize` - inicia el flujo de autorización.
-- `POST /auth/oauth/token` - intercambia authorization code por tokens.
-- `GET /auth/oauth/refresh` - renueva el access token.
-- `GET /auth/oauth/me` - obtiene la información del usuario autenticado.
-- `GET /auth/oauth/discord` - integración con Discord OAuth.
+- `GET /auth/authorize` - inicia el flujo de autorización.
+- `POST /auth/token` - intercambia authorization code por tokens.
+- `POST /auth/refresh` - renueva el access token.
+- `POST /auth/me` - obtiene la información del usuario autenticado según scopes.
+- `GET /auth/discord` - integración con Discord OAuth.
 
 ### Modelo de datos clave
 
 - `User` - usuario canónico del sistema que une `DiscordUser` y `Player`.
-- `Client` - aplicación OAuth autorizada con URIs de redirección.
-- `AuthorizationCode` - códigos temporales con `code_challenge` para PKCE.
-- `Session` - sesiones con `refresh_token` para renovar accesos.
+- `Client` - aplicación OAuth autorizada con URIs de redirección y scopes permitidos.
+- `AuthorizationCode` - códigos temporales con `code_challenge` y scopes concedidos para PKCE.
+- `Session` - sesiones con `refresh_token` y scopes para renovar accesos.
+
+### Scopes OAuth
+
+Los scopes se piden en `GET /auth/authorize` mediante `scope`, separados por espacio. El servidor valida que todos los scopes sean conocidos y que el cliente esté autorizado a solicitarlos.
+
+- `openid` - habilita claims de identidad en `/auth/me`: `sub`, `iss`, `aud`, `exp`.
+- `identify` - habilita datos generales del usuario: `id`, `rank`, `created_at`, `discord_user`.
+- `minecraft` - habilita datos del jugador vinculado: `mc_player` con `digs`, `nickname`, `uuid`, `rank`, `user_id`, `medias`, `roles`.
+
+Ejemplo de solicitud:
+
+```text
+scope=openid identify minecraft
+```
 
 ### Flujo de autorización
 
 1. El cliente genera `code_verifier` y `code_challenge`.
-2. Redirige a `/auth/oauth/authorize` con `client_id`, `redirect_uri` y `code_challenge`.
-3. El servidor valida el cliente y emite un authorization code.
-4. El cliente intercambia el code en `/auth/oauth/token` enviando el `code_verifier`.
+2. Redirige a `/auth/authorize` con `client_id`, `redirect_uri`, `code_challenge` y `scope`.
+3. El servidor valida el cliente, redirect URI y scopes, y emite un authorization code.
+4. El cliente intercambia el code en `/auth/token` enviando el `code_verifier`.
 5. El servidor valida la firma PKCE y devuelve `access_token` + `refresh_token`.
+6. El access token conserva los scopes concedidos; `/auth/me` arma la respuesta sólo con las secciones permitidas.
 
 ### Seguridad OAuth
 
 - PKCE evita que un authorization code interceptado sea reutilizado.
 - `Client.redirect_uris` se valida estrictamente.
-- `Session.refresh_token` está almacenado como valor único para revocación.
+- `Client.scopes` limita qué datos puede solicitar cada aplicación.
+- `Session.refresh_token` está almacenado como hash único para revocación.
+- `Session.scope` conserva los permisos al renovar tokens.
 - `access_token` es un JWT firmado por el servidor.
 
 ---

--- a/docs/01-arquitectura-general.md
+++ b/docs/01-arquitectura-general.md
@@ -47,11 +47,12 @@ Este bot unifica cuatro necesidades operativas de la comunidad:
 ## 5) Autenticación OAuth 2.0
 
 - **`src/api/oauth/`** expone endpoints de autenticación con PKCE:
-    - `GET /auth/oauth/authorize` - Iniciar flujo de autorización
-    - `POST /auth/oauth/token` - Intercambiar código por tokens
-    - `GET /auth/oauth/refresh` - Renovar access tokens
-    - `GET /auth/oauth/me` - Información del usuario autenticado
+    - `GET /auth/authorize` - Iniciar flujo de autorización
+    - `POST /auth/token` - Intercambiar código por tokens
+    - `POST /auth/refresh` - Renovar access tokens
+    - `POST /auth/me` - Información del usuario autenticado según scopes
 - **Tablas asociadas**: `users`, `clients`, `authorization_codes`, `sessions`
+- **Scopes disponibles**: `openid`, `identify`, `minecraft`
 - **Integración con Discord OAuth** para autenticación transparente
 
 **Por qué existe:** permite que aplicaciones terceras accedan al sistema de forma segura sin exponer credenciales.

--- a/docs/06-oauth-y-autenticacion.md
+++ b/docs/06-oauth-y-autenticacion.md
@@ -32,6 +32,7 @@ model OAuthClient {
   id             String   @id @default(cuid())
   client_secret  String   @unique
   redirect_uris  String[] // URIs permitidas para redirección post-auth
+  scopes         String[] // Scopes que la aplicación puede solicitar
   created_at     DateTime @default(now())
   updated_at     DateTime @updatedAt
 }
@@ -50,6 +51,7 @@ model AuthorizationCode {
   redirect_uri    String
   code_challenge  String   // PKCE: hash del code_verifier
   expires_at      DateTime
+  scope           String   // Scopes concedidos, separados por espacio
   created_at      DateTime @default(now())
 }
 ```
@@ -64,6 +66,7 @@ model Session {
   user_id        String
   refresh_token  String   @unique
   client_id      String
+  scope          String   // Scopes de la sesión, separados por espacio
   expires_at     DateTime
   created_at     DateTime @default(now())
 }
@@ -80,7 +83,7 @@ sequenceDiagram
 
     %% ===== PKCE + STATE =====
     Client->>Client: Genera code_verifier, code_challenge y state
-    Client->>Auth: GET /authorize?client_id&redirect_uri&state&code_challenge
+    Client->>Auth: GET /authorize?client_id&redirect_uri&state&code_challenge&scope
 
     %% ===== LOGIN FLOW =====
     Auth->>Auth: Valida parámetros
@@ -91,7 +94,7 @@ sequenceDiagram
     %% ===== SESIÓN =====
     Auth->>DB: Crear/obtener usuario
     Auth->>DB: Crear sesión
-    Auth->>DB: Guardar authorization_code + code_challenge
+    Auth->>DB: Guardar authorization_code + code_challenge + scopes
 
     %% ===== REDIRECT FINAL =====
     Auth->>Client: Redirect redirect_uri?code=auth_code&state=state
@@ -107,7 +110,7 @@ sequenceDiagram
 
     %% ===== TOKENS =====
     Auth->>Auth: Generar access_token (JWT)
-    Auth->>DB: Crear refresh_token
+    Auth->>DB: Crear refresh_token con scopes
 
     Auth-->>Client: access_token + refresh_token
 
@@ -118,9 +121,27 @@ sequenceDiagram
     Auth-->>Client: Datos del usuario
 ```
 
+## Scopes disponibles
+
+Los scopes se solicitan en `GET /auth/authorize` usando el parámetro `scope` con valores separados por espacio. El servidor valida que todos los scopes pedidos existan y estén permitidos por `Client.scopes`.
+
+| Scope | Qué habilita en `/auth/me` |
+| --- | --- |
+| `openid` | Claims de identidad del access token: `sub`, `iss`, `aud`, `exp`. |
+| `identify` | Información general del usuario del sistema: `id`, `rank`, `created_at` y `discord_user`. |
+| `minecraft` | Información del jugador vinculado: `mc_player` con `digs`, `nickname`, `uuid`, `rank`, `user_id`, `medias` y `roles`. |
+
+Ejemplo:
+
+```http
+GET /auth/authorize?response_type=code&client_id=api-panel&redirect_uri=https%3A%2F%2Fapp.example.com%2Fcallback&code_challenge=...&code_challenge_method=S256&scope=openid%20identify%20minecraft
+```
+
+Si no se solicita ningún scope, el token no obtiene permisos para leer datos en `/auth/me`.
+
 ## Endpoints
 
-### `GET /auth/oauth/authorize`
+### `GET /auth/authorize`
 
 **Propósito:** Iniciar flujo de autorización y presentar consentimiento.
 
@@ -131,6 +152,7 @@ sequenceDiagram
 - `response_type` (requerido): debe ser `"code"`
 - `code_challenge` (requerido): SHA256 del code_verifier (PKCE)
 - `code_challenge_method` (requerido): debe ser `"S256"`
+- `scope` (opcional): lista de scopes separados por espacio (`openid`, `identify`, `minecraft`)
 - `state` (recomendado): nonce para evitar CSRF
 
 **Respuesta:**
@@ -141,9 +163,9 @@ sequenceDiagram
 **Respuesta:**
 
 - Redirección a `redirect_uri?code=...&state=...`
-- Code válido por 10 minutos
+- Code válido por 5 minutos
 
-### `POST /auth/oauth/token`
+### `POST /auth/token`
 
 **Propósito:** Intercambiar authorization_code por access_token y refresh_token.
 
@@ -165,20 +187,23 @@ sequenceDiagram
 {
     "access_token": "eyJ...",
     "token_type": "Bearer",
-    "expires_in": 3600,
-    "refresh_token": "ref_...",
-    "scope": "openid profile email"
+    "expires_in": 86400,
+    "refresh_token": "ref_..."
 }
 ```
 
-### `GET /auth/oauth/refresh`
+El `access_token` es un JWT firmado que incluye `sub`, `iss`, `aud`, `exp`, `session_id`, `client_id` y `scope`.
+
+### `POST /auth/refresh`
 
 **Propósito:** Renovar access_token usando refresh_token.
 
-**Parámetros query:**
+**Body:**
 
 - `refresh_token` (requerido): refresh token de sesión anterior
 - `client_id` (requerido): ID de la aplicación
+- `grant_type` (requerido): debe ser `"refresh_token"`
+- `redirect_uri` (requerido): URI usada por el cliente
 
 **Respuesta:**
 
@@ -186,12 +211,13 @@ sequenceDiagram
 {
     "access_token": "eyJ...",
     "token_type": "Bearer",
-    "expires_in": 3600,
-    "refresh_token": "ref_..."
+    "expires_in": 86400,
+    "refresh_token": "ref_...",
+    "scope": "openid identify minecraft"
 }
 ```
 
-### `GET /auth/oauth/me`
+### `POST /auth/me`
 
 **Propósito:** Obtener información del usuario autenticado.
 
@@ -199,25 +225,50 @@ sequenceDiagram
 
 - `Authorization: Bearer <access_token>`
 
-**Respuesta:**
+**Respuesta con `openid`:**
 
 ```json
 {
-  "id": "123",
-  "rank": "Admin",
-  "created_at": "2026-04-30T10:00:00Z",
-  "discord_user": {
-    "id": "123",
-    "username: "user_123"
-  },
-  "mc_player": {
-    "uuid": "123",
-    "nickname": "user123"
-  }
+    "sub": "123456789",
+    "iss": "https://api.example.com",
+    "aud": "api-panel",
+    "exp": 1234567890
 }
 ```
 
-### `GET /auth/oauth/discord`
+**Respuesta con `identify`:**
+
+```json
+{
+    "id": "123",
+    "rank": "Admin",
+    "created_at": 1780000000000,
+    "discord_user": {
+        "id": "123",
+        "username": "user_123"
+    }
+}
+```
+
+**Respuesta con `minecraft`:**
+
+```json
+{
+    "mc_player": {
+        "digs": 123,
+        "nickname": "user123",
+        "uuid": "00000000-0000-0000-0000-000000000000",
+        "rank": "Miembro",
+        "user_id": "123",
+        "medias": [{ "type": "youtube", "url": "https://..." }],
+        "roles": ["Builder", "Streamer"]
+    }
+}
+```
+
+Cuando se combinan scopes, `/auth/me` combina las secciones correspondientes en el mismo objeto JSON.
+
+### `GET /auth/discord`
 
 **Propósito:** Callback de autenticación con Discord OAuth integrada.
 
@@ -241,7 +292,8 @@ sequenceDiagram
 2. **Redirect URI whitelist:** solo acepta URIs registradas
 3. **Code expiration:** codes válidos 5 minutos
 4. **JWT firma:** access tokens firmados con clave privada en el servidor
-5. **Refresh token rotation (futuro):** revocar refresh tokens antiguos
+5. **Scopes por cliente:** cada scope solicitado debe existir y estar permitido para el `Client`
+6. **Refresh token rotation:** cada refresh exitoso emite un nuevo refresh token y reemplaza el hash anterior
 
 ### Almacenamiento de secretos
 
@@ -254,10 +306,10 @@ Con el nuevo sistema OAuth, la vinculación funciona así:
 
 1. Usuario accede a webapp externa
 2. Hace clic "iniciar sesion"
-3. Se redirige a `/auth/oauth/authorize?client_id=xxx&...`
+3. Se redirige a `/auth/authorize?client_id=xxx&...`
 4. Confirma y recibe `code`
 5. Cliente intercambia por `access_token`
-6. Con el token, puede acceder a `/v1/users/me` para obtener su usuario
+6. Con el token, puede acceder a `/auth/me` para obtener su usuario según scopes
 7. El usuario queda creado/actualizado en tabla `users`
 
 ## Integración con Discord
@@ -273,7 +325,8 @@ Cuando un usuario se autentica vía OAuth:
 
 ✅ Tablas y migraciones completadas  
 ✅ Endpoints OAuth implementados  
+✅ Scopes `openid`, `identify` y `minecraft` implementados  
 ⏳ UI de consentimiento (desarrollo en progreso)
-⏳ Refresh token rotation (futuro)
+✅ Refresh token rotation
 
 > Vease https://github.com/Triskcraft/triskcraft-bot/issues/41

--- a/src/api/oauth/authorize/route.ts
+++ b/src/api/oauth/authorize/route.ts
@@ -206,6 +206,7 @@ router.get('/', cookieParser(), async (req, res) => {
             }),
         )
     }
+    const serializedScopes = serializeScopes(requestedScopes)
 
     const session = await getSession(req)
 
@@ -231,6 +232,9 @@ router.get('/', cookieParser(), async (req, res) => {
         },
     })
     const discordUser = (await request.json()) as APIUser
+    const roleName =
+        discordUser.id === envs.SUPER_USER_DISCORD_ID ? 'super' : 'user'
+    const rolePermissions = roleName === 'super' ? 1n : 0n
 
     const user = await db.user.upsert({
         create: {
@@ -240,6 +244,19 @@ router.get('/', cookieParser(), async (req, res) => {
                     create: {
                         id: discordUser.id,
                         username: discordUser.username,
+                    },
+                },
+            },
+            linked_roles: {
+                create: {
+                    role: {
+                        connectOrCreate: {
+                            where: { name: roleName },
+                            create: {
+                                name: roleName,
+                                permissions: rolePermissions,
+                            },
+                        },
                     },
                 },
             },
@@ -258,6 +275,7 @@ router.get('/', cookieParser(), async (req, res) => {
 
     const jwt = await new SignJWT({
         sub: user.id,
+        scope: serializedScopes,
     })
         .setProtectedHeader({ alg: 'RS256' })
         .setIssuedAt()
@@ -283,7 +301,7 @@ router.get('/', cookieParser(), async (req, res) => {
             code_challenge,
             expires_at: new Date(Date.now() + 5 * 60 * 1000), // 5 min
             client_id: client.id,
-            scope: serializeScopes(requestedScopes),
+            scope: serializedScopes,
         },
     })
 

--- a/src/api/oauth/authorize/route.ts
+++ b/src/api/oauth/authorize/route.ts
@@ -1,6 +1,12 @@
 import { envs, PRIVATE_KEY } from '#/config.ts'
 import { db } from '#/db/prisma.ts'
-import { getSession, refreshToken } from '#/utils/api.ts'
+import {
+    OAUTH_SCOPES,
+    getSession,
+    parseScopes,
+    refreshToken,
+    serializeScopes,
+} from '#/utils/api.ts'
 import { render } from '#/utils/html.ts'
 import { ErrorCard } from '#/web/components/error-card.ts'
 import { Layout } from '#/web/components/layout.ts'
@@ -19,6 +25,7 @@ router.get('/', cookieParser(), async (req, res) => {
         redirect_uri,
         code_challenge,
         code_challenge_method,
+        scope,
         state,
     } = req.query
 
@@ -125,6 +132,7 @@ router.get('/', cookieParser(), async (req, res) => {
         select: {
             id: true,
             redirect_uris: true,
+            scopes: true,
         },
     })
 
@@ -151,6 +159,49 @@ router.get('/', cookieParser(), async (req, res) => {
                     title: 'Bad Request',
                     message:
                         'Invalid redirect_uri. The provided redirect_uri is not registered for the given client_id.',
+                }),
+            }),
+        )
+    }
+
+    const requestedScopes = parseScopes(scope)
+    const requestedScopeNames = new Set(
+        typeof scope === 'string' ?
+            scope
+                .split(/\s+/)
+                .map(s => s.trim())
+                .filter(Boolean)
+        :   [],
+    )
+
+    if (requestedScopes.length !== requestedScopeNames.size) {
+        return render(
+            res,
+            Layout({
+                children: ErrorCard({
+                    code: 400,
+                    title: 'Bad Request',
+                    message: 'Invalid scope.',
+                }),
+            }),
+        )
+    }
+
+    const allowedScopes =
+        client.scopes?.length > 0 ? client.scopes : [...OAUTH_SCOPES]
+    const invalidClientScopes = requestedScopes.filter(
+        scope => !allowedScopes.includes(scope),
+    )
+
+    if (invalidClientScopes.length) {
+        return render(
+            res,
+            Layout({
+                children: ErrorCard({
+                    code: 400,
+                    title: 'Bad Request',
+                    message:
+                        'Invalid scope. The client is not allowed to request one or more scopes.',
                 }),
             }),
         )
@@ -232,6 +283,7 @@ router.get('/', cookieParser(), async (req, res) => {
             code_challenge,
             expires_at: new Date(Date.now() + 5 * 60 * 1000), // 5 min
             client_id: client.id,
+            scope: serializeScopes(requestedScopes),
         },
     })
 

--- a/src/api/oauth/me/route.ts
+++ b/src/api/oauth/me/route.ts
@@ -43,7 +43,15 @@ router.post('/', async (req, res) => {
         },
         select: {
             created_at: true,
-            rank: scopes.includes('identify'),
+            linked_roles: {
+                select: {
+                    role: {
+                        select: {
+                            name: true,
+                        },
+                    },
+                },
+            },
             discord_user: {
                 select: {
                     id: true,
@@ -55,7 +63,6 @@ router.post('/', async (req, res) => {
                     uuid: true,
                     nickname: true,
                     digs: true,
-                    rank: true,
                     medias: {
                         select: {
                             type: true,
@@ -81,6 +88,7 @@ router.post('/', async (req, res) => {
     }
 
     const response: Record<string, unknown> = {}
+    const rank = user.linked_roles[0]?.role.name ?? 'User'
 
     if (scopes.includes('openid')) {
         response.sub = payload.sub
@@ -91,7 +99,7 @@ router.post('/', async (req, res) => {
 
     if (scopes.includes('identify')) {
         response.id = payload.sub
-        response.rank = user.rank
+        response.rank = rank
         response.created_at = user.created_at.getTime()
         response.discord_user = user.discord_user
     }
@@ -103,7 +111,7 @@ router.post('/', async (req, res) => {
                     digs: user.mc_player.digs,
                     nickname: user.mc_player.nickname,
                     uuid: user.mc_player.uuid,
-                    rank: user.mc_player.rank,
+                    rank,
                     user_id: payload.sub,
                     medias: user.mc_player.medias,
                     roles: user.mc_player.linked_roles.map(lr => lr.role.name),

--- a/src/api/oauth/me/route.ts
+++ b/src/api/oauth/me/route.ts
@@ -10,7 +10,7 @@ router.post('/', async (req, res) => {
     if (!authorization) {
         throw new UnauthorizedError()
     }
-    if (/Bearer\s.+/.test(authorization)) {
+    if (!/Bearer\s.+/.test(authorization)) {
         throw new UnauthorizedError()
     }
     const token = authorization.replace('Bearer ', '')

--- a/src/api/oauth/me/route.ts
+++ b/src/api/oauth/me/route.ts
@@ -1,6 +1,7 @@
-import { InternalServerError, UnauthorizedError } from '#/api/errors.ts'
+import { ForbiddenError, InternalServerError, UnauthorizedError } from '#/api/errors.ts'
 import { db } from '#/db/prisma.ts'
 import { verifyToken } from '#/utils/encript.ts'
+import { parseScopes } from '#/utils/api.ts'
 import { Router } from 'express'
 
 const router = Router()
@@ -19,6 +20,10 @@ router.post('/', async (req, res) => {
         sub: string
         session_id: string
         client_id: string
+        aud: string
+        exp?: number
+        iss?: string
+        scope: string
     }>(token)
 
     if (!verify) {
@@ -26,24 +31,46 @@ router.post('/', async (req, res) => {
     }
 
     const { payload } = verify
+    const scopes = parseScopes(payload.scope)
+
+    if (!scopes.length) {
+        throw new ForbiddenError('Missing required scope.')
+    }
 
     const user = await db.user.findUnique({
         where: {
             id: verify.payload.sub,
         },
         select: {
-            rank: true,
             created_at: true,
+            rank: scopes.includes('identify'),
             discord_user: {
                 select: {
                     id: true,
-                    username: true,
+                    username: scopes.includes('identify'),
                 },
             },
             mc_player: {
                 select: {
                     uuid: true,
                     nickname: true,
+                    digs: true,
+                    rank: true,
+                    medias: {
+                        select: {
+                            type: true,
+                            url: true,
+                        },
+                    },
+                    linked_roles: {
+                        select: {
+                            role: {
+                                select: {
+                                    name: true,
+                                },
+                            },
+                        },
+                    },
                 },
             },
         },
@@ -53,13 +80,38 @@ router.post('/', async (req, res) => {
         throw new InternalServerError()
     }
 
-    return res.json({
-        id: payload.sub,
-        rank: user.rank,
-        created_at: user.created_at.getTime(),
-        discord_user: user.discord_user,
-        mc_player: user.mc_player,
-    })
+    const response: Record<string, unknown> = {}
+
+    if (scopes.includes('openid')) {
+        response.sub = payload.sub
+        response.iss = payload.iss
+        response.aud = payload.aud
+        response.exp = payload.exp
+    }
+
+    if (scopes.includes('identify')) {
+        response.id = payload.sub
+        response.rank = user.rank
+        response.created_at = user.created_at.getTime()
+        response.discord_user = user.discord_user
+    }
+
+    if (scopes.includes('minecraft')) {
+        response.mc_player =
+            user.mc_player ?
+                {
+                    digs: user.mc_player.digs,
+                    nickname: user.mc_player.nickname,
+                    uuid: user.mc_player.uuid,
+                    rank: user.mc_player.rank,
+                    user_id: payload.sub,
+                    medias: user.mc_player.medias,
+                    roles: user.mc_player.linked_roles.map(lr => lr.role.name),
+                }
+            :   null
+    }
+
+    return res.json(response)
 })
 
 export default router

--- a/src/api/oauth/refresh/route.ts
+++ b/src/api/oauth/refresh/route.ts
@@ -31,11 +31,16 @@ router.post('/', async (req, res) => {
         where: { refresh_token: weakHash(refresh_token) },
         select: {
             id: true,
+            client_id: true,
+            scope: true,
             user_id: true,
         },
     })
 
     if (!session) {
+        throw new UnauthorizedError()
+    }
+    if (session.client_id !== client_id) {
         throw new UnauthorizedError()
     }
 
@@ -48,8 +53,9 @@ router.post('/', async (req, res) => {
     const access_token = await createJWT({
         session_id: session.id,
         sub: session.user_id,
-        client_id,
-        aud: client_id,
+        client_id: session.client_id,
+        aud: session.client_id,
+        scope: session.scope,
     })
 
     const new_refresh_token = generateCodeVerifier()
@@ -67,6 +73,7 @@ router.post('/', async (req, res) => {
         token_type: 'Bearer',
         expires_in: 60 * 60 * 24,
         refresh_token: new_refresh_token,
+        scope: session.scope,
     })
 })
 

--- a/src/api/oauth/refresh/route.ts
+++ b/src/api/oauth/refresh/route.ts
@@ -1,7 +1,7 @@
 import { BadRequestError, UnauthorizedError } from '#/api/errors.ts'
 import { db } from '#/db/prisma.ts'
 import { createJWT } from '#/utils/api.ts'
-import { generateCodeVerifier, hash, weakHash } from '#/utils/encript.ts'
+import { generateCodeVerifier, weakHash } from '#/utils/encript.ts'
 import { Router } from 'express'
 
 const router = Router()
@@ -58,7 +58,7 @@ router.post('/', async (req, res) => {
         where: { id: session.id },
         data: {
             expires_at,
-            refresh_token: await hash(new_refresh_token),
+            refresh_token: weakHash(new_refresh_token),
         },
     })
 

--- a/src/api/oauth/refresh/route.ts
+++ b/src/api/oauth/refresh/route.ts
@@ -8,9 +8,9 @@ const router = Router()
 
 router.post('/', async (req, res) => {
     const { grant_type, redirect_uri, client_id, refresh_token } = req.body
-    if (grant_type !== 'authorization_code') {
+    if (grant_type !== 'refresh_token') {
         throw new BadRequestError(
-            'Invalid grant_type. Expected "authorization_code".',
+            'Invalid grant_type. Expected "refresh_token".',
         )
     }
     if (!client_id) {

--- a/src/api/oauth/route.ts
+++ b/src/api/oauth/route.ts
@@ -1,12 +1,16 @@
 import { Router } from 'express'
 import authorize from '#/api/oauth/authorize/route.ts'
 import discord from '#/api/oauth/discord/route.ts'
+import me from '#/api/oauth/me/route.ts'
+import refresh from '#/api/oauth/refresh/route.ts'
 import token from '#/api/oauth/token/route.ts'
 
 const router = Router()
 
 router.use('/authorize', authorize)
 router.use('/discord', discord)
+router.use('/me', me)
+router.use('/refresh', refresh)
 router.use('/token', token)
 
 export default router

--- a/src/api/oauth/token/route.ts
+++ b/src/api/oauth/token/route.ts
@@ -43,6 +43,7 @@ router.post<'/', null, OAuthTokenResponse, OAuthTokenRequest>(
             select: {
                 expires_at: true,
                 code_challenge: true,
+                scope: true,
                 user_id: true,
             },
         })
@@ -83,6 +84,7 @@ router.post<'/', null, OAuthTokenResponse, OAuthTokenRequest>(
                 expires_at,
                 client_id,
                 user_id,
+                scope: authCode.scope,
                 refresh_token: weakHash(refresh_token),
             },
         })
@@ -92,6 +94,7 @@ router.post<'/', null, OAuthTokenResponse, OAuthTokenRequest>(
             sub: authCode.user_id,
             client_id,
             aud: client_id,
+            scope: authCode.scope,
         })
 
         return res.json({

--- a/src/api/v1/games/[game]/players/get.ts
+++ b/src/api/v1/games/[game]/players/get.ts
@@ -37,13 +37,26 @@ export const getPlayers: RequestHandler<
         },
     } as const
 
+    const includeRankJoin = {
+        select: {
+            role: {
+                select: {
+                    name: true,
+                },
+            },
+        },
+    }
+
     const members = await db.player.findMany({
         where: { status: PLAYER_STATUS.ACTIVE, user: { is: {} } },
         include: {
             user: {
                 select: {
                     id: true,
-                    rank: includeRank,
+                    linked_roles:
+                        includeRank ? includeRankJoin : (
+                            ({} as typeof includeRankJoin)
+                        ),
                 },
             },
             medias:
@@ -60,12 +73,11 @@ export const getPlayers: RequestHandler<
         },
     })
     const pobled = members.map(
-        ({ digs, rank, linked_roles, medias, nickname, uuid, user }) => {
+        ({ digs, linked_roles, medias, nickname, uuid, user }) => {
             const member: MinecraftPlayer = {
                 digs,
                 nickname,
                 uuid,
-                rank,
                 user_id: user!.id,
             }
             if (includeMedias) {
@@ -75,7 +87,7 @@ export const getPlayers: RequestHandler<
                 member.roles = linked_roles.map(lr => lr.role.name)
             }
             if (includeRank) {
-                member.rank = rank
+                member.rank = user?.linked_roles[0]?.role.name ?? 'User'
             }
             return member
         },

--- a/src/api/v1/members/get.ts
+++ b/src/api/v1/members/get.ts
@@ -28,13 +28,26 @@ export async function getMembers(req: Request, res: Response) {
                     },
                 },
             },
+            user: {
+                select: {
+                    linked_roles: {
+                        select: {
+                            role: {
+                                select: {
+                                    name: true,
+                                },
+                            },
+                        },
+                    },
+                },
+            },
         },
     })
     const pobled = members.map(
         ({
             description,
             digs,
-            rank,
+            user,
             linked_roles,
             medias,
             nickname: mc_name,
@@ -47,7 +60,7 @@ export async function getMembers(req: Request, res: Response) {
                 mc_name,
                 mc_uuid,
                 medias,
-                rank,
+                rank: user?.linked_roles[0]?.role.name ?? 'User',
                 roles,
             } satisfies Member
         },

--- a/src/classes/minecraft-role.ts
+++ b/src/classes/minecraft-role.ts
@@ -51,7 +51,7 @@ export class MinecraftRole {
     }
 
     async editName(name: string) {
-        const { linked_roles } = await db.role.update({
+        const { linked_roles } = await db.minecraftRole.update({
             data: { name },
             where: { id: this.#id },
             select: {
@@ -165,7 +165,7 @@ export class MinecraftRole {
     }
 
     async fetch() {
-        const role = await db.role.findUnique({
+        const role = await db.minecraftRole.findUnique({
             where: { id: this.#id },
             include: {
                 linked_roles: {

--- a/src/classes/minecraft-role.ts
+++ b/src/classes/minecraft-role.ts
@@ -58,12 +58,13 @@ export class MinecraftRole {
                 linked_roles: {
                     select: {
                         player: true,
+                        role_id: true,
                     },
                 },
             },
         })
         logger.info(`[ROLE SERVICE] Rol ${this.#name} renombrado a ${name}`)
-        for (const { player } of linked_roles.filter(
+        for (const { player, role_id } of linked_roles.filter(
             l => l.player.status === PLAYER_STATUS.ACTIVE,
         )) {
             this.#players.getOrInsert(
@@ -75,7 +76,7 @@ export class MinecraftRole {
                             discord_user_id: player.discord_user_id,
                             nickname: player.nickname,
                             uuid: player.uuid,
-                            rank: player.rank,
+                            role: role_id,
                         })
                     },
                 ),
@@ -90,7 +91,7 @@ export class MinecraftRole {
 
     async removePlayer(uuid: string) {
         try {
-            const response = await db.linkedRole.delete({
+            const response = await db.linkedMinecraftRole.delete({
                 where: {
                     mc_user_uuid_role_id: {
                         mc_user_uuid: uuid,
@@ -118,7 +119,7 @@ export class MinecraftRole {
         try {
             const {
                 player: { nickname },
-            } = await db.linkedRole.create({
+            } = await db.linkedMinecraftRole.create({
                 data: {
                     role: {
                         connect: {
@@ -183,16 +184,16 @@ export class MinecraftRole {
             discord_user_id,
             nickname,
             uuid,
-            rank,
+            role: role_id,
         } of role.linked_roles
-            .map(l => l.player)
+            .map(l => ({ ...l.player, role: l.role_id }))
             .filter(p => p.status === PLAYER_STATUS.ACTIVE)) {
             this.#players.getOrInsertComputed(uuid, () => {
                 return new Player({
                     discord_user_id,
                     nickname,
                     uuid,
-                    rank,
+                    role: role_id,
                 })
             })
         }

--- a/src/classes/minecraft-roles-manager.ts
+++ b/src/classes/minecraft-roles-manager.ts
@@ -39,7 +39,7 @@ export class MinecraftRolesManager {
                                                     l.player.discord_user_id,
                                                 nickname: l.player.nickname,
                                                 uuid: l.mc_user_uuid,
-                                                rank: l.player.rank,
+                                                role: r.id,
                                             })
                                         },
                                     ),

--- a/src/classes/minecraft-roles-manager.ts
+++ b/src/classes/minecraft-roles-manager.ts
@@ -7,7 +7,7 @@ import { PLAYER_STATUS } from '#/db/generated/enums.ts'
 
 export class MinecraftRolesManager {
     async fetch() {
-        const roles = await db.role.findMany({
+        const roles = await db.minecraftRole.findMany({
             include: {
                 linked_roles: {
                     include: {

--- a/src/classes/player.ts
+++ b/src/classes/player.ts
@@ -1,6 +1,5 @@
 import { envs } from '#/config.ts'
 import { db } from '#/db/prisma.ts'
-import { PLAYER_STATUS } from '#/db/generated/enums.ts'
 import { inspect } from 'node:util'
 
 export class Player {
@@ -22,34 +21,34 @@ export class Player {
         return this.#discord_user_id
     }
 
-    #rank: string
+    #role: string
 
-    get rank() {
-        return this.#rank
+    get role() {
+        return this.#role
     }
 
     constructor({
         discord_user_id,
         nickname,
         uuid,
-        rank = envs.DEFAULT_RANK,
+        role = envs.DEFAULT_RANK,
     }: {
         uuid: string
         nickname: string
         discord_user_id: string
-        rank?: string
+        role?: string
     }) {
         this.#uuid = uuid
         this.#nicknname = nickname
         this.#discord_user_id = discord_user_id
-        this.#rank = rank
+        this.#role = role
     }
 
     toJSON() {
         return {
             uuid: this.#uuid,
             nicknname: this.#nicknname,
-            rank: this.#rank,
+            rank: this.#role,
             discord_user_id: this.#discord_user_id,
         }
     }
@@ -58,12 +57,19 @@ export class Player {
         return this.toJSON()
     }
 
-    async setRank(rank: string) {
-        await db.player.update({
-            where: { uuid: this.#uuid, status: PLAYER_STATUS.ACTIVE },
-            data: { rank },
+    async setRole(role: string) {
+        await db.linkedMinecraftRole.deleteMany({
+            where: {
+                mc_user_uuid: this.#uuid,
+            },
         })
-        this.#rank = rank
+        await db.linkedMinecraftRole.create({
+            data: {
+                mc_user_uuid: this.#uuid,
+                role_id: role,
+            },
+        })
+        this.#role = role
         return this
     }
 }

--- a/src/classes/players-manager.ts
+++ b/src/classes/players-manager.ts
@@ -33,7 +33,7 @@ export class PlayersManager {
                         discord_user_id: m.discord_user_id,
                         nickname: m.nickname,
                         uuid: m.uuid,
-                        rank: m.rank,
+                        role: m.rank,
                     }),
                 )
             }
@@ -58,7 +58,7 @@ export class PlayersManager {
                     discord_user_id: memberData.discord_user_id,
                     nickname: memberData.nickname,
                     uuid: memberData.uuid,
-                    rank: memberData.rank,
+                    role: memberData.rank,
                 })
                 this.#cache.set(member.uuid, member)
             }

--- a/src/classes/posts-manager.ts
+++ b/src/classes/posts-manager.ts
@@ -53,7 +53,7 @@ export class PostsManager {
     }
 
     async delete(id: string) {
-        await db.role.delete({
+        await db.post.delete({
             where: { id },
         })
         this.#cache.delete(id)

--- a/src/config.ts
+++ b/src/config.ts
@@ -38,6 +38,7 @@ export function loadConfig() {
         'DISCORD_CLIENT_SECRET',
         'DISCORD_REDIRECT_URI',
         'API_URL',
+        'SUPER_USER_DISCORD_ID',
     ]
 
     const recomended = [
@@ -71,6 +72,7 @@ export function loadConfig() {
         DISCORD_REDIRECT_URI = '',
         DISCORD_CLIENT_ID = '',
         API_URL = '',
+        SUPER_USER_DISCORD_ID = '',
     } = process.env
 
     const recommendedMissing = recomended.filter(key => !process.env[key])
@@ -126,6 +128,7 @@ export function loadConfig() {
         DISCORD_CLIENT_SECRET,
         DISCORD_REDIRECT_URI,
         API_URL,
+        SUPER_USER_DISCORD_ID,
     }
 }
 

--- a/src/db/migrations/20260603052836_scopes/migration.sql
+++ b/src/db/migrations/20260603052836_scopes/migration.sql
@@ -1,0 +1,11 @@
+/*
+  Warnings:
+
+  - Added the required column `scope` to the `authorization_codes` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "authorization_codes" ADD COLUMN     "scope" TEXT NOT NULL;
+
+-- AlterTable
+ALTER TABLE "clients" ADD COLUMN     "scopes" TEXT[];

--- a/src/db/migrations/20260603055719_scopes_sesion/migration.sql
+++ b/src/db/migrations/20260603055719_scopes_sesion/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "sessions" ADD COLUMN     "scope" TEXT NOT NULL DEFAULT '';

--- a/src/db/migrations/20260603201228_user_roles/migration.sql
+++ b/src/db/migrations/20260603201228_user_roles/migration.sql
@@ -1,0 +1,38 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `rank` on the `minecraft_users` table. All the data in the column will be lost.
+  - You are about to drop the column `rank` on the `users` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE "minecraft_users" DROP COLUMN "rank";
+
+-- AlterTable
+ALTER TABLE "users" DROP COLUMN "rank";
+
+-- CreateTable
+CREATE TABLE "user_roles" (
+    "id" TEXT NOT NULL DEFAULT snowflake(),
+    "name" TEXT NOT NULL,
+    "permissions" BIGINT NOT NULL DEFAULT 0,
+
+    CONSTRAINT "user_roles_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "linked_user_roles" (
+    "user_id" TEXT NOT NULL,
+    "role_id" TEXT NOT NULL,
+
+    CONSTRAINT "linked_user_roles_pkey" PRIMARY KEY ("user_id","role_id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "user_roles_name_key" ON "user_roles"("name");
+
+-- AddForeignKey
+ALTER TABLE "linked_user_roles" ADD CONSTRAINT "linked_user_roles_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "linked_user_roles" ADD CONSTRAINT "linked_user_roles_role_id_fkey" FOREIGN KEY ("role_id") REFERENCES "user_roles"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/src/db/schema.erd
+++ b/src/db/schema.erd
@@ -2,8 +2,8 @@
   "$schema": "https://raw.githubusercontent.com/dineug/erd-editor/main/json-schema/schema.json",
   "version": "3.0.0",
   "settings": {
-    "width": 2000,
-    "height": 2000,
+    "width": 2200,
+    "height": 2200,
     "scrollTop": 0,
     "scrollLeft": 0,
     "zoomLevel": 1,
@@ -31,979 +31,634 @@
   },
   "doc": {
     "tableIds": [
-      "b8nl1d9q1L_OVrVyFu5Ep",
-      "n9NjBRzd61itcrapIFLdG",
-      "pECNhZMNZeVe28wxGPj1Q",
-      "UGhWVLlojdQeC5QLHkbwZ",
-      "zqLzFlMfEfTSYFAHoKV-p",
-      "hosHFkkJm_RzAUmJnWa0R",
-      "8M0iaeBZJGmInhPC2TgAp",
-      "awFsLieJv3UqMDztul_Yc",
-      "3_9V8n4eraYwE5RkJdFhU"
+      "tbl_inactivity_periods",
+      "tbl_tracked_roles",
+      "tbl_role_statistics",
+      "tbl_link_codes",
+      "tbl_roles",
+      "tbl_linked_roles",
+      "tbl_medias",
+      "tbl_minecraft_users",
+      "tbl_discord_users",
+      "tbl_webhook_tokens",
+      "tbl_states",
+      "tbl_posts",
+      "tbl_post_blocks",
+      "tbl_users",
+      "tbl_clients",
+      "tbl_authorization_codes",
+      "tbl_sessions"
     ],
     "relationshipIds": [
-      "eiQBxShrsROfyvboYNA7r",
-      "D4HikRXg9FXHU_phCLZIl",
-      "cK9echvGHTWDTgzHuV-cd",
-      "V6E_kuyiRyjza_LPaXapf",
-      "of1cZ1Ty6LzXmoibaVcus",
-      "pE3Hxm8mdUNxWXjICby8x"
+      "rel_inactivity_discord_user",
+      "rel_link_codes_discord_user",
+      "rel_linked_roles_role",
+      "rel_linked_roles_player",
+      "rel_medias_player",
+      "rel_player_discord_user",
+      "rel_webhook_tokens_discord_user",
+      "rel_posts_discord_user",
+      "rel_posts_player",
+      "rel_post_blocks_author",
+      "rel_post_blocks_post",
+      "rel_users_player",
+      "rel_users_discord_user",
+      "rel_authorization_codes_user",
+      "rel_authorization_codes_client",
+      "rel_sessions_user",
+      "rel_sessions_client"
     ],
     "indexIds": [],
     "memoIds": []
   },
   "collections": {
     "tableEntities": {
-      "b8nl1d9q1L_OVrVyFu5Ep": {
-        "id": "b8nl1d9q1L_OVrVyFu5Ep",
-        "name": "minecraft_users",
-        "comment": "",
-        "columnIds": [
-          "-BJV0uOld_8HZt9w8zPOd",
-          "lt0_uZCC3BZBmw9_BSqVH",
-          "WACI1derDfi1hPPAfF_tb",
-          "WJav6Xez5pGjuX4UquVnX",
-          "bgUkrLbKPT5dymHDOaLSv"
-        ],
-        "seqColumnIds": [
-          "-BJV0uOld_8HZt9w8zPOd",
-          "lt0_uZCC3BZBmw9_BSqVH",
-          "WACI1derDfi1hPPAfF_tb",
-          "WJav6Xez5pGjuX4UquVnX",
-          "54djxzshkvmOHdJa5mvhh",
-          "bgUkrLbKPT5dymHDOaLSv"
-        ],
-        "ui": {
-          "x": 672,
-          "y": 518,
-          "zIndex": 2,
-          "widthName": 84,
-          "widthComment": 60,
-          "color": ""
-        },
-        "meta": {
-          "updateAt": 1767139216794,
-          "createAt": 1767137352135
-        }
-      },
-      "n9NjBRzd61itcrapIFLdG": {
-        "id": "n9NjBRzd61itcrapIFLdG",
-        "name": "discord_users",
-        "comment": "",
-        "columnIds": [
-          "bAdyL9_ezfWdFJLmp8jCO",
-          "rM3je-3Wc5X89te384cj1"
-        ],
-        "seqColumnIds": [
-          "bAdyL9_ezfWdFJLmp8jCO",
-          "X2I-k6dOU4FbKU3N-dzDZ",
-          "rM3je-3Wc5X89te384cj1"
-        ],
-        "ui": {
-          "x": 571,
-          "y": 340,
-          "zIndex": 14,
-          "widthName": 73,
-          "widthComment": 60,
-          "color": ""
-        },
-        "meta": {
-          "updateAt": 1768957711215,
-          "createAt": 1767137449769
-        }
-      },
-      "pECNhZMNZeVe28wxGPj1Q": {
-        "id": "pECNhZMNZeVe28wxGPj1Q",
-        "name": "medias",
-        "comment": "",
-        "columnIds": [
-          "F83h9cDgTJNFwPvW6rC_n",
-          "FOllJdUixUCosKvDYWEdV",
-          "lDw1pB_f2ObHHLF8se_QI",
-          "1TLnO2uHEQni_nV0dWJcz"
-        ],
-        "seqColumnIds": [
-          "F83h9cDgTJNFwPvW6rC_n",
-          "t6faPlYpfmwypDObpi_ZE",
-          "FOllJdUixUCosKvDYWEdV",
-          "lDw1pB_f2ObHHLF8se_QI",
-          "1TLnO2uHEQni_nV0dWJcz"
-        ],
-        "ui": {
-          "x": 46,
-          "y": 337,
-          "zIndex": 21,
-          "widthName": 60,
-          "widthComment": 60,
-          "color": ""
-        },
-        "meta": {
-          "updateAt": 1767138944935,
-          "createAt": 1767137500424
-        }
-      },
-      "UGhWVLlojdQeC5QLHkbwZ": {
-        "id": "UGhWVLlojdQeC5QLHkbwZ",
-        "name": "roles",
-        "comment": "",
-        "columnIds": [
-          "m8JV99-cnhEqf4sUQyB5s",
-          "CbzKBwOGry8UgEYn7b01o"
-        ],
-        "seqColumnIds": [
-          "m8JV99-cnhEqf4sUQyB5s",
-          "CbzKBwOGry8UgEYn7b01o"
-        ],
-        "ui": {
-          "x": 76.2691,
-          "y": 920.7896,
-          "zIndex": 56,
-          "widthName": 60,
-          "widthComment": 60,
-          "color": ""
-        },
-        "meta": {
-          "updateAt": 1767138024544,
-          "createAt": 1767137677710
-        }
-      },
-      "zqLzFlMfEfTSYFAHoKV-p": {
-        "id": "zqLzFlMfEfTSYFAHoKV-p",
-        "name": "linked_roles",
-        "comment": "",
-        "columnIds": [
-          "IvrQCRfUxfhGb-aVJjXS-",
-          "_GXQZrFym0YOUBp52caKp"
-        ],
-        "seqColumnIds": [
-          "rXO18qH1foUW0_qN6VTB5",
-          "IvrQCRfUxfhGb-aVJjXS-",
-          "_GXQZrFym0YOUBp52caKp"
-        ],
-        "ui": {
-          "x": 71.2691,
-          "y": 663.7896,
-          "zIndex": 69,
-          "widthName": 64,
-          "widthComment": 60,
-          "color": ""
-        },
-        "meta": {
-          "updateAt": 1767138024544,
-          "createAt": 1767137722010
-        }
-      },
-      "hosHFkkJm_RzAUmJnWa0R": {
-        "id": "hosHFkkJm_RzAUmJnWa0R",
-        "name": "link_codes",
-        "comment": "",
-        "columnIds": [
-          "lfwpEgOxezbyyN5F8_Y82",
-          "IqieScUqN_PR0VFGaDDZw",
-          "FxUNIZ0c9zT4IAP77Eh50",
-          "U1ZLFoZG_J0TD0YJFgIIo"
-        ],
-        "seqColumnIds": [
-          "lfwpEgOxezbyyN5F8_Y82",
-          "IqieScUqN_PR0VFGaDDZw",
-          "FxUNIZ0c9zT4IAP77Eh50",
-          "U1ZLFoZG_J0TD0YJFgIIo"
-        ],
-        "ui": {
-          "x": 69.2691,
-          "y": 45.7896,
-          "zIndex": 81,
-          "widthName": 60,
-          "widthComment": 60,
-          "color": ""
-        },
-        "meta": {
-          "updateAt": 1767139178856,
-          "createAt": 1767137792345
-        }
-      },
-      "8M0iaeBZJGmInhPC2TgAp": {
-        "id": "8M0iaeBZJGmInhPC2TgAp",
-        "name": "tracked_roles",
-        "comment": "",
-        "columnIds": [
-          "LQYbZL1pkrNYgxjMNoSMP",
-          "DURl41_l80oZLyouDCwPD",
-          "Cwch3_8KcHayjd2ZuY2F_"
-        ],
-        "seqColumnIds": [
-          "LQYbZL1pkrNYgxjMNoSMP",
-          "DURl41_l80oZLyouDCwPD",
-          "Cwch3_8KcHayjd2ZuY2F_"
-        ],
-        "ui": {
-          "x": 652.2691,
-          "y": 1045.7896,
-          "zIndex": 126,
-          "widthName": 72,
-          "widthComment": 60,
-          "color": ""
-        },
-        "meta": {
-          "updateAt": 1767138941582,
-          "createAt": 1767138738072
-        }
-      },
-      "awFsLieJv3UqMDztul_Yc": {
-        "id": "awFsLieJv3UqMDztul_Yc",
-        "name": "role_statistics",
-        "comment": "",
-        "columnIds": [
-          "C2dendjTE5RYAtKmVp_3E",
-          "JBEeYtztWHavGJueUvk8r",
-          "0Folm2MYXg3lfOjTpdcF0",
-          "hTfMtdY7--GVA7T0KK_m7",
-          "iBCltc_AEGtGhvkYN4dD3",
-          "nDKlmERmdbil5dxLnfwjZ"
-        ],
-        "seqColumnIds": [
-          "C2dendjTE5RYAtKmVp_3E",
-          "JBEeYtztWHavGJueUvk8r",
-          "0Folm2MYXg3lfOjTpdcF0",
-          "hTfMtdY7--GVA7T0KK_m7",
-          "iBCltc_AEGtGhvkYN4dD3",
-          "nDKlmERmdbil5dxLnfwjZ"
-        ],
-        "ui": {
-          "x": 642.2691,
-          "y": 788.7896,
-          "zIndex": 150,
-          "widthName": 72,
-          "widthComment": 60,
-          "color": ""
-        },
-        "meta": {
-          "updateAt": 1767138921980,
-          "createAt": 1767138800050
-        }
-      },
-      "3_9V8n4eraYwE5RkJdFhU": {
-        "id": "3_9V8n4eraYwE5RkJdFhU",
+      "tbl_inactivity_periods": {
+        "id": "tbl_inactivity_periods",
         "name": "inactivity_periods",
         "comment": "",
         "columnIds": [
-          "NiLZV0OKzNna4sM1hXXmL",
-          "UbZsBH8MtHlIV7u0qG7u8",
-          "43Mi1_wFB75gQNu4ggqWM",
-          "oXWLYZltldatqiV5rpqNs",
-          "pcnA95P_YKPr0VhlNiAii",
-          "fiz6bECWrOAi9ydcvcnEu",
-          "1tUVmA07rNOyXYrj5owsU"
+          "col_inactivity_user_id",
+          "col_inactivity_guild_id",
+          "col_inactivity_role_snapshot",
+          "col_inactivity_started_at",
+          "col_inactivity_ends_at",
+          "col_inactivity_source",
+          "col_inactivity_notified"
         ],
         "seqColumnIds": [
-          "Z4inzBrV_0oL9LFVhEgSW",
-          "NiLZV0OKzNna4sM1hXXmL",
-          "UbZsBH8MtHlIV7u0qG7u8",
-          "rx21Y93ASz3cJUgEEfIha",
-          "43Mi1_wFB75gQNu4ggqWM",
-          "oXWLYZltldatqiV5rpqNs",
-          "pcnA95P_YKPr0VhlNiAii",
-          "fiz6bECWrOAi9ydcvcnEu",
-          "1tUVmA07rNOyXYrj5owsU"
+          "col_inactivity_user_id",
+          "col_inactivity_guild_id",
+          "col_inactivity_role_snapshot",
+          "col_inactivity_started_at",
+          "col_inactivity_ends_at",
+          "col_inactivity_source",
+          "col_inactivity_notified"
         ],
         "ui": {
-          "x": 606.2691,
-          "y": 35.7896,
-          "zIndex": 192,
+          "x": 225.7936,
+          "y": 1159.7889,
+          "zIndex": 1,
           "widthName": 93,
           "widthComment": 60,
           "color": ""
         },
         "meta": {
-          "updateAt": 1767139212847,
-          "createAt": 1767138954865
+          "updateAt": 1780469989375,
+          "createAt": 1780469686502
+        }
+      },
+      "tbl_tracked_roles": {
+        "id": "tbl_tracked_roles",
+        "name": "tracked_roles",
+        "comment": "",
+        "columnIds": [
+          "col_tracked_roles_guild_id",
+          "col_tracked_roles_role_id",
+          "col_tracked_roles_created_at"
+        ],
+        "seqColumnIds": [
+          "col_tracked_roles_guild_id",
+          "col_tracked_roles_role_id",
+          "col_tracked_roles_created_at"
+        ],
+        "ui": {
+          "x": 1665.767,
+          "y": 501.2097,
+          "zIndex": 1,
+          "widthName": 72,
+          "widthComment": 60,
+          "color": ""
+        },
+        "meta": {
+          "updateAt": 1780469989375,
+          "createAt": 1780469686502
+        }
+      },
+      "tbl_role_statistics": {
+        "id": "tbl_role_statistics",
+        "name": "role_statistics",
+        "comment": "",
+        "columnIds": [
+          "col_role_statistics_id",
+          "col_role_statistics_guild_id",
+          "col_role_statistics_role_id",
+          "col_role_statistics_inactive_count",
+          "col_role_statistics_active_count",
+          "col_role_statistics_captured_at"
+        ],
+        "seqColumnIds": [
+          "col_role_statistics_id",
+          "col_role_statistics_guild_id",
+          "col_role_statistics_role_id",
+          "col_role_statistics_inactive_count",
+          "col_role_statistics_active_count",
+          "col_role_statistics_captured_at"
+        ],
+        "ui": {
+          "x": 1662.2538,
+          "y": 720.5749,
+          "zIndex": 1,
+          "widthName": 72,
+          "widthComment": 60,
+          "color": ""
+        },
+        "meta": {
+          "updateAt": 1780469989375,
+          "createAt": 1780469686502
+        }
+      },
+      "tbl_link_codes": {
+        "id": "tbl_link_codes",
+        "name": "link_codes",
+        "comment": "",
+        "columnIds": [
+          "col_link_codes_id",
+          "col_link_codes_discord_id",
+          "col_link_codes_discord_nickname",
+          "col_link_codes_code"
+        ],
+        "seqColumnIds": [
+          "col_link_codes_id",
+          "col_link_codes_discord_id",
+          "col_link_codes_discord_nickname",
+          "col_link_codes_code"
+        ],
+        "ui": {
+          "x": 705.7057,
+          "y": 1210.5703,
+          "zIndex": 1,
+          "widthName": 60,
+          "widthComment": 60,
+          "color": ""
+        },
+        "meta": {
+          "updateAt": 1780469989375,
+          "createAt": 1780469686502
+        }
+      },
+      "tbl_roles": {
+        "id": "tbl_roles",
+        "name": "roles",
+        "comment": "",
+        "columnIds": [
+          "col_roles_id",
+          "col_roles_name"
+        ],
+        "seqColumnIds": [
+          "col_roles_id",
+          "col_roles_name"
+        ],
+        "ui": {
+          "x": 1272.5811,
+          "y": 64.726,
+          "zIndex": 1,
+          "widthName": 60,
+          "widthComment": 60,
+          "color": ""
+        },
+        "meta": {
+          "updateAt": 1780469989375,
+          "createAt": 1780469686502
+        }
+      },
+      "tbl_linked_roles": {
+        "id": "tbl_linked_roles",
+        "name": "linked_roles",
+        "comment": "",
+        "columnIds": [
+          "col_linked_roles_mc_user_uuid",
+          "col_linked_roles_role_id"
+        ],
+        "seqColumnIds": [
+          "col_linked_roles_mc_user_uuid",
+          "col_linked_roles_role_id"
+        ],
+        "ui": {
+          "x": 731.6355,
+          "y": 71.0749,
+          "zIndex": 1,
+          "widthName": 64,
+          "widthComment": 60,
+          "color": ""
+        },
+        "meta": {
+          "updateAt": 1780469989375,
+          "createAt": 1780469686502
+        }
+      },
+      "tbl_medias": {
+        "id": "tbl_medias",
+        "name": "medias",
+        "comment": "",
+        "columnIds": [
+          "col_medias_id",
+          "col_medias_mc_user_uuid",
+          "col_medias_type",
+          "col_medias_url"
+        ],
+        "seqColumnIds": [
+          "col_medias_id",
+          "col_medias_mc_user_uuid",
+          "col_medias_type",
+          "col_medias_url"
+        ],
+        "ui": {
+          "x": 217.2881,
+          "y": 285.1608,
+          "zIndex": 1,
+          "widthName": 60,
+          "widthComment": 60,
+          "color": ""
+        },
+        "meta": {
+          "updateAt": 1780469989375,
+          "createAt": 1780469686502
+        }
+      },
+      "tbl_minecraft_users": {
+        "id": "tbl_minecraft_users",
+        "name": "minecraft_users",
+        "comment": "",
+        "columnIds": [
+          "col_minecraft_users_uuid",
+          "col_minecraft_users_nickname",
+          "col_minecraft_users_digs",
+          "col_minecraft_users_description",
+          "col_minecraft_users_discord_user_id",
+          "col_minecraft_users_rank",
+          "col_minecraft_users_status",
+          "col_minecraft_users_last_seen"
+        ],
+        "seqColumnIds": [
+          "col_minecraft_users_uuid",
+          "col_minecraft_users_nickname",
+          "col_minecraft_users_digs",
+          "col_minecraft_users_description",
+          "col_minecraft_users_discord_user_id",
+          "col_minecraft_users_rank",
+          "col_minecraft_users_status",
+          "col_minecraft_users_last_seen"
+        ],
+        "ui": {
+          "x": 685.4367,
+          "y": 429.3502,
+          "zIndex": 1,
+          "widthName": 84,
+          "widthComment": 60,
+          "color": ""
+        },
+        "meta": {
+          "updateAt": 1780469989375,
+          "createAt": 1780469686502
+        }
+      },
+      "tbl_discord_users": {
+        "id": "tbl_discord_users",
+        "name": "discord_users",
+        "comment": "",
+        "columnIds": [
+          "col_discord_users_id",
+          "col_discord_users_username"
+        ],
+        "seqColumnIds": [
+          "col_discord_users_id",
+          "col_discord_users_username"
+        ],
+        "ui": {
+          "x": 590.1255,
+          "y": 954.3817,
+          "zIndex": 1,
+          "widthName": 73,
+          "widthComment": 60,
+          "color": ""
+        },
+        "meta": {
+          "updateAt": 1780469989375,
+          "createAt": 1780469686502
+        }
+      },
+      "tbl_webhook_tokens": {
+        "id": "tbl_webhook_tokens",
+        "name": "webhook_tokens",
+        "comment": "",
+        "columnIds": [
+          "col_webhook_tokens_id",
+          "col_webhook_tokens_name",
+          "col_webhook_tokens_discord_user_id",
+          "col_webhook_tokens_secret",
+          "col_webhook_tokens_permissions",
+          "col_webhook_tokens_created_at"
+        ],
+        "seqColumnIds": [
+          "col_webhook_tokens_id",
+          "col_webhook_tokens_name",
+          "col_webhook_tokens_discord_user_id",
+          "col_webhook_tokens_secret",
+          "col_webhook_tokens_permissions",
+          "col_webhook_tokens_created_at"
+        ],
+        "ui": {
+          "x": 1206.6065,
+          "y": 1148.1812,
+          "zIndex": 1,
+          "widthName": 91,
+          "widthComment": 60,
+          "color": ""
+        },
+        "meta": {
+          "updateAt": 1780469989375,
+          "createAt": 1780469686502
+        }
+      },
+      "tbl_states": {
+        "id": "tbl_states",
+        "name": "states",
+        "comment": "",
+        "columnIds": [
+          "col_states_id",
+          "col_states_key",
+          "col_states_value",
+          "col_states_updated_at"
+        ],
+        "seqColumnIds": [
+          "col_states_id",
+          "col_states_key",
+          "col_states_value",
+          "col_states_updated_at"
+        ],
+        "ui": {
+          "x": 221.0103,
+          "y": 65.8567,
+          "zIndex": 1,
+          "widthName": 60,
+          "widthComment": 60,
+          "color": ""
+        },
+        "meta": {
+          "updateAt": 1780469989375,
+          "createAt": 1780469686502
+        }
+      },
+      "tbl_posts": {
+        "id": "tbl_posts",
+        "name": "posts",
+        "comment": "",
+        "columnIds": [
+          "col_posts_id",
+          "col_posts_title",
+          "col_posts_discord_user_id",
+          "col_posts_minecraft_player_uuid",
+          "col_posts_thread_id",
+          "col_posts_status",
+          "col_posts_created_at",
+          "col_posts_updated_at"
+        ],
+        "seqColumnIds": [
+          "col_posts_id",
+          "col_posts_title",
+          "col_posts_discord_user_id",
+          "col_posts_minecraft_player_uuid",
+          "col_posts_thread_id",
+          "col_posts_status",
+          "col_posts_created_at",
+          "col_posts_updated_at"
+        ],
+        "ui": {
+          "x": 146.753,
+          "y": 514.3631,
+          "zIndex": 1,
+          "widthName": 60,
+          "widthComment": 60,
+          "color": ""
+        },
+        "meta": {
+          "updateAt": 1780469989375,
+          "createAt": 1780469686502
+        }
+      },
+      "tbl_post_blocks": {
+        "id": "tbl_post_blocks",
+        "name": "post_blocks",
+        "comment": "",
+        "columnIds": [
+          "col_post_blocks_message_id",
+          "col_post_blocks_post_id",
+          "col_post_blocks_timestamp",
+          "col_post_blocks_content",
+          "col_post_blocks_components",
+          "col_post_blocks_embeds",
+          "col_post_blocks_attachments",
+          "col_post_blocks_author_id"
+        ],
+        "seqColumnIds": [
+          "col_post_blocks_message_id",
+          "col_post_blocks_post_id",
+          "col_post_blocks_timestamp",
+          "col_post_blocks_content",
+          "col_post_blocks_components",
+          "col_post_blocks_embeds",
+          "col_post_blocks_attachments",
+          "col_post_blocks_author_id"
+        ],
+        "ui": {
+          "x": 62.7683,
+          "y": 834.6504,
+          "zIndex": 1,
+          "widthName": 64,
+          "widthComment": 60,
+          "color": ""
+        },
+        "meta": {
+          "updateAt": 1780469989375,
+          "createAt": 1780469686502
+        }
+      },
+      "tbl_users": {
+        "id": "tbl_users",
+        "name": "users",
+        "comment": "",
+        "columnIds": [
+          "col_users_id",
+          "col_users_rank",
+          "col_users_mc_player_uuid",
+          "col_users_discord_user_id",
+          "col_users_created_at",
+          "col_users_updated_at"
+        ],
+        "seqColumnIds": [
+          "col_users_id",
+          "col_users_rank",
+          "col_users_mc_player_uuid",
+          "col_users_discord_user_id",
+          "col_users_created_at",
+          "col_users_updated_at"
+        ],
+        "ui": {
+          "x": 1201.8646,
+          "y": 562.1676,
+          "zIndex": 1,
+          "widthName": 60,
+          "widthComment": 60,
+          "color": ""
+        },
+        "meta": {
+          "updateAt": 1780469989375,
+          "createAt": 1780469686502
+        }
+      },
+      "tbl_clients": {
+        "id": "tbl_clients",
+        "name": "clients",
+        "comment": "",
+        "columnIds": [
+          "col_clients_id",
+          "col_clients_client_secret",
+          "col_clients_redirect_uris",
+          "col_clients_created_at",
+          "col_clients_updated_at",
+          "col_clients_scopes"
+        ],
+        "seqColumnIds": [
+          "col_clients_id",
+          "col_clients_client_secret",
+          "col_clients_redirect_uris",
+          "col_clients_created_at",
+          "col_clients_updated_at",
+          "col_clients_scopes"
+        ],
+        "ui": {
+          "x": 1638.4039,
+          "y": 253.9996,
+          "zIndex": 1,
+          "widthName": 60,
+          "widthComment": 60,
+          "color": ""
+        },
+        "meta": {
+          "updateAt": 1780469989375,
+          "createAt": 1780469686502
+        }
+      },
+      "tbl_authorization_codes": {
+        "id": "tbl_authorization_codes",
+        "name": "authorization_codes",
+        "comment": "",
+        "columnIds": [
+          "col_authorization_codes_id",
+          "col_authorization_codes_code",
+          "col_authorization_codes_user_id",
+          "col_authorization_codes_client_id",
+          "col_authorization_codes_redirect_uri",
+          "col_authorization_codes_code_challenge",
+          "col_authorization_codes_expires_at",
+          "col_authorization_codes_created_at",
+          "col_authorization_codes_scope"
+        ],
+        "seqColumnIds": [
+          "col_authorization_codes_id",
+          "col_authorization_codes_code",
+          "col_authorization_codes_user_id",
+          "col_authorization_codes_client_id",
+          "col_authorization_codes_redirect_uri",
+          "col_authorization_codes_code_challenge",
+          "col_authorization_codes_expires_at",
+          "col_authorization_codes_created_at",
+          "col_authorization_codes_scope"
+        ],
+        "ui": {
+          "x": 1212.4555,
+          "y": 830.833,
+          "zIndex": 1,
+          "widthName": 108,
+          "widthComment": 60,
+          "color": ""
+        },
+        "meta": {
+          "updateAt": 1780469989375,
+          "createAt": 1780469686502
+        }
+      },
+      "tbl_sessions": {
+        "id": "tbl_sessions",
+        "name": "sessions",
+        "comment": "",
+        "columnIds": [
+          "col_sessions_id",
+          "col_sessions_user_id",
+          "col_sessions_refresh_token",
+          "col_sessions_client_id",
+          "col_sessions_scope",
+          "col_sessions_expires_at",
+          "col_sessions_created_at"
+        ],
+        "seqColumnIds": [
+          "col_sessions_id",
+          "col_sessions_user_id",
+          "col_sessions_refresh_token",
+          "col_sessions_client_id",
+          "col_sessions_scope",
+          "col_sessions_expires_at",
+          "col_sessions_created_at"
+        ],
+        "ui": {
+          "x": 1135.8656,
+          "y": 213.6437,
+          "zIndex": 1,
+          "widthName": 60,
+          "widthComment": 60,
+          "color": ""
+        },
+        "meta": {
+          "updateAt": 1780469989375,
+          "createAt": 1780469686502
         }
       }
     },
     "tableColumnEntities": {
-      "-BJV0uOld_8HZt9w8zPOd": {
-        "id": "-BJV0uOld_8HZt9w8zPOd",
-        "tableId": "b8nl1d9q1L_OVrVyFu5Ep",
-        "name": "uuid",
-        "comment": "",
-        "dataType": "text",
-        "default": "",
-        "options": 14,
-        "ui": {
-          "keys": 1,
-          "widthName": 60,
-          "widthComment": 60,
-          "widthDataType": 60,
-          "widthDefault": 60
-        },
-        "meta": {
-          "updateAt": 1767137409476,
-          "createAt": 1767137361366
-        }
-      },
-      "lt0_uZCC3BZBmw9_BSqVH": {
-        "id": "lt0_uZCC3BZBmw9_BSqVH",
-        "tableId": "b8nl1d9q1L_OVrVyFu5Ep",
-        "name": "nickname",
-        "comment": "",
-        "dataType": "text",
-        "default": "",
-        "options": 8,
-        "ui": {
-          "keys": 0,
-          "widthName": 60,
-          "widthComment": 60,
-          "widthDataType": 60,
-          "widthDefault": 60
-        },
-        "meta": {
-          "updateAt": 1767137414651,
-          "createAt": 1767137393105
-        }
-      },
-      "WACI1derDfi1hPPAfF_tb": {
-        "id": "WACI1derDfi1hPPAfF_tb",
-        "tableId": "b8nl1d9q1L_OVrVyFu5Ep",
-        "name": "digs",
-        "comment": "",
-        "dataType": "int",
-        "default": "0",
-        "options": 8,
-        "ui": {
-          "keys": 0,
-          "widthName": 60,
-          "widthComment": 60,
-          "widthDataType": 60,
-          "widthDefault": 60
-        },
-        "meta": {
-          "updateAt": 1767137428559,
-          "createAt": 1767137418951
-        }
-      },
-      "WJav6Xez5pGjuX4UquVnX": {
-        "id": "WJav6Xez5pGjuX4UquVnX",
-        "tableId": "b8nl1d9q1L_OVrVyFu5Ep",
-        "name": "description",
-        "comment": "",
-        "dataType": "text",
-        "default": "",
-        "options": 8,
-        "ui": {
-          "keys": 0,
-          "widthName": 61,
-          "widthComment": 60,
-          "widthDataType": 60,
-          "widthDefault": 60
-        },
-        "meta": {
-          "updateAt": 1767137437159,
-          "createAt": 1767137430210
-        }
-      },
-      "bAdyL9_ezfWdFJLmp8jCO": {
-        "id": "bAdyL9_ezfWdFJLmp8jCO",
-        "tableId": "n9NjBRzd61itcrapIFLdG",
-        "name": "id",
-        "comment": "",
-        "dataType": "text",
-        "default": "",
-        "options": 14,
-        "ui": {
-          "keys": 1,
-          "widthName": 60,
-          "widthComment": 60,
-          "widthDataType": 60,
-          "widthDefault": 60
-        },
-        "meta": {
-          "updateAt": 1767137548887,
-          "createAt": 1767137456973
-        }
-      },
-      "F83h9cDgTJNFwPvW6rC_n": {
-        "id": "F83h9cDgTJNFwPvW6rC_n",
-        "tableId": "pECNhZMNZeVe28wxGPj1Q",
-        "name": "id",
-        "comment": "",
-        "dataType": "text",
-        "default": "snowflake()",
-        "options": 14,
-        "ui": {
-          "keys": 1,
-          "widthName": 60,
-          "widthComment": 60,
-          "widthDataType": 60,
-          "widthDefault": 62
-        },
-        "meta": {
-          "updateAt": 1767137565750,
-          "createAt": 1767137531716
-        }
-      },
-      "t6faPlYpfmwypDObpi_ZE": {
-        "id": "t6faPlYpfmwypDObpi_ZE",
-        "tableId": "pECNhZMNZeVe28wxGPj1Q",
-        "name": "mc_user_uuid",
-        "comment": "",
-        "dataType": "",
-        "default": "",
-        "options": 0,
-        "ui": {
-          "keys": 0,
-          "widthName": 74,
-          "widthComment": 60,
-          "widthDataType": 60,
-          "widthDefault": 60
-        },
-        "meta": {
-          "updateAt": 1767137576359,
-          "createAt": 1767137563296
-        }
-      },
-      "FOllJdUixUCosKvDYWEdV": {
-        "id": "FOllJdUixUCosKvDYWEdV",
-        "tableId": "pECNhZMNZeVe28wxGPj1Q",
-        "name": "mc_user_uuid",
-        "comment": "",
-        "dataType": "text",
-        "default": "",
-        "options": 8,
-        "ui": {
-          "keys": 2,
-          "widthName": 74,
-          "widthComment": 60,
-          "widthDataType": 60,
-          "widthDefault": 60
-        },
-        "meta": {
-          "updateAt": 1767137615266,
-          "createAt": 1767137606121
-        }
-      },
-      "lDw1pB_f2ObHHLF8se_QI": {
-        "id": "lDw1pB_f2ObHHLF8se_QI",
-        "tableId": "pECNhZMNZeVe28wxGPj1Q",
-        "name": "type",
-        "comment": "",
-        "dataType": "text",
-        "default": "",
-        "options": 8,
-        "ui": {
-          "keys": 0,
-          "widthName": 60,
-          "widthComment": 60,
-          "widthDataType": 60,
-          "widthDefault": 60
-        },
-        "meta": {
-          "updateAt": 1767137639211,
-          "createAt": 1767137628282
-        }
-      },
-      "1TLnO2uHEQni_nV0dWJcz": {
-        "id": "1TLnO2uHEQni_nV0dWJcz",
-        "tableId": "pECNhZMNZeVe28wxGPj1Q",
-        "name": "url",
-        "comment": "",
-        "dataType": "text",
-        "default": "",
-        "options": 8,
-        "ui": {
-          "keys": 0,
-          "widthName": 60,
-          "widthComment": 60,
-          "widthDataType": 60,
-          "widthDefault": 60
-        },
-        "meta": {
-          "updateAt": 1767137669077,
-          "createAt": 1767137660315
-        }
-      },
-      "m8JV99-cnhEqf4sUQyB5s": {
-        "id": "m8JV99-cnhEqf4sUQyB5s",
-        "tableId": "UGhWVLlojdQeC5QLHkbwZ",
-        "name": "id",
-        "comment": "",
-        "dataType": "text",
-        "default": "snowflake()",
-        "options": 14,
-        "ui": {
-          "keys": 1,
-          "widthName": 60,
-          "widthComment": 60,
-          "widthDataType": 60,
-          "widthDefault": 62
-        },
-        "meta": {
-          "updateAt": 1767137694681,
-          "createAt": 1767137685087
-        }
-      },
-      "CbzKBwOGry8UgEYn7b01o": {
-        "id": "CbzKBwOGry8UgEYn7b01o",
-        "tableId": "UGhWVLlojdQeC5QLHkbwZ",
-        "name": "name",
-        "comment": "",
-        "dataType": "text",
-        "default": "",
-        "options": 12,
-        "ui": {
-          "keys": 0,
-          "widthName": 60,
-          "widthComment": 60,
-          "widthDataType": 60,
-          "widthDefault": 60
-        },
-        "meta": {
-          "updateAt": 1767137706982,
-          "createAt": 1767137698159
-        }
-      },
-      "rXO18qH1foUW0_qN6VTB5": {
-        "id": "rXO18qH1foUW0_qN6VTB5",
-        "tableId": "zqLzFlMfEfTSYFAHoKV-p",
-        "name": "",
-        "comment": "",
-        "dataType": "",
-        "default": "",
-        "options": 0,
-        "ui": {
-          "keys": 0,
-          "widthName": 60,
-          "widthComment": 60,
-          "widthDataType": 60,
-          "widthDefault": 60
-        },
-        "meta": {
-          "updateAt": 1767137728652,
-          "createAt": 1767137728652
-        }
-      },
-      "IvrQCRfUxfhGb-aVJjXS-": {
-        "id": "IvrQCRfUxfhGb-aVJjXS-",
-        "tableId": "zqLzFlMfEfTSYFAHoKV-p",
-        "name": "id",
-        "comment": "",
-        "dataType": "text",
-        "default": "snowflake()",
-        "options": 10,
-        "ui": {
-          "keys": 3,
-          "widthName": 60,
-          "widthComment": 60,
-          "widthDataType": 60,
-          "widthDefault": 62
-        },
-        "meta": {
-          "updateAt": 1767138031567,
-          "createAt": 1767137745009
-        }
-      },
-      "_GXQZrFym0YOUBp52caKp": {
-        "id": "_GXQZrFym0YOUBp52caKp",
-        "tableId": "zqLzFlMfEfTSYFAHoKV-p",
-        "name": "uuid",
-        "comment": "",
-        "dataType": "text",
-        "default": "",
-        "options": 10,
-        "ui": {
-          "keys": 3,
-          "widthName": 60,
-          "widthComment": 60,
-          "widthDataType": 60,
-          "widthDefault": 60
-        },
-        "meta": {
-          "updateAt": 1767138034328,
-          "createAt": 1767137749926
-        }
-      },
-      "lfwpEgOxezbyyN5F8_Y82": {
-        "id": "lfwpEgOxezbyyN5F8_Y82",
-        "tableId": "hosHFkkJm_RzAUmJnWa0R",
-        "name": "id",
-        "comment": "",
-        "dataType": "text",
-        "default": "snowflake()",
-        "options": 14,
-        "ui": {
-          "keys": 1,
-          "widthName": 60,
-          "widthComment": 60,
-          "widthDataType": 60,
-          "widthDefault": 62
-        },
-        "meta": {
-          "updateAt": 1767137809580,
-          "createAt": 1767137806476
-        }
-      },
-      "IqieScUqN_PR0VFGaDDZw": {
-        "id": "IqieScUqN_PR0VFGaDDZw",
-        "tableId": "hosHFkkJm_RzAUmJnWa0R",
-        "name": "discord_nickname",
-        "comment": "",
-        "dataType": "text",
-        "default": "",
-        "options": 8,
-        "ui": {
-          "keys": 0,
-          "widthName": 97,
-          "widthComment": 60,
-          "widthDataType": 60,
-          "widthDefault": 60
-        },
-        "meta": {
-          "updateAt": 1767137828951,
-          "createAt": 1767137814874
-        }
-      },
-      "FxUNIZ0c9zT4IAP77Eh50": {
-        "id": "FxUNIZ0c9zT4IAP77Eh50",
-        "tableId": "hosHFkkJm_RzAUmJnWa0R",
-        "name": "discord_id",
-        "comment": "",
-        "dataType": "text",
-        "default": "",
-        "options": 8,
-        "ui": {
-          "keys": 2,
-          "widthName": 60,
-          "widthComment": 60,
-          "widthDataType": 60,
-          "widthDefault": 60
-        },
-        "meta": {
-          "updateAt": 1767137846066,
-          "createAt": 1767137840933
-        }
-      },
-      "U1ZLFoZG_J0TD0YJFgIIo": {
-        "id": "U1ZLFoZG_J0TD0YJFgIIo",
-        "tableId": "hosHFkkJm_RzAUmJnWa0R",
-        "name": "code",
-        "comment": "",
-        "dataType": "text",
-        "default": "",
-        "options": 12,
-        "ui": {
-          "keys": 0,
-          "widthName": 60,
-          "widthComment": 60,
-          "widthDataType": 60,
-          "widthDefault": 60
-        },
-        "meta": {
-          "updateAt": 1767137863274,
-          "createAt": 1767137856276
-        }
-      },
-      "54djxzshkvmOHdJa5mvhh": {
-        "id": "54djxzshkvmOHdJa5mvhh",
-        "tableId": "b8nl1d9q1L_OVrVyFu5Ep",
-        "name": "discord_user_id",
-        "comment": "",
-        "dataType": "",
-        "default": "",
-        "options": 0,
-        "ui": {
-          "keys": 0,
-          "widthName": 83,
-          "widthComment": 60,
-          "widthDataType": 60,
-          "widthDefault": 60
-        },
-        "meta": {
-          "updateAt": 1767138630141,
-          "createAt": 1767138625181
-        }
-      },
-      "X2I-k6dOU4FbKU3N-dzDZ": {
-        "id": "X2I-k6dOU4FbKU3N-dzDZ",
-        "tableId": "n9NjBRzd61itcrapIFLdG",
-        "name": "uuid",
-        "comment": "",
-        "dataType": "text",
-        "default": "",
-        "options": 8,
-        "ui": {
-          "keys": 0,
-          "widthName": 60,
-          "widthComment": 60,
-          "widthDataType": 60,
-          "widthDefault": 60
-        },
-        "meta": {
-          "updateAt": 1767138653322,
-          "createAt": 1767138653322
-        }
-      },
-      "bgUkrLbKPT5dymHDOaLSv": {
-        "id": "bgUkrLbKPT5dymHDOaLSv",
-        "tableId": "b8nl1d9q1L_OVrVyFu5Ep",
-        "name": "discord_user_id",
-        "comment": "",
-        "dataType": "text",
-        "default": "",
-        "options": 8,
-        "ui": {
-          "keys": 2,
-          "widthName": 83,
-          "widthComment": 60,
-          "widthDataType": 60,
-          "widthDefault": 60
-        },
-        "meta": {
-          "updateAt": 1767138669529,
-          "createAt": 1767138660060
-        }
-      },
-      "LQYbZL1pkrNYgxjMNoSMP": {
-        "id": "LQYbZL1pkrNYgxjMNoSMP",
-        "tableId": "8M0iaeBZJGmInhPC2TgAp",
-        "name": "guild_id",
-        "comment": "",
-        "dataType": "text",
-        "default": "",
-        "options": 10,
-        "ui": {
-          "keys": 1,
-          "widthName": 60,
-          "widthComment": 60,
-          "widthDataType": 60,
-          "widthDefault": 60
-        },
-        "meta": {
-          "updateAt": 1767138849455,
-          "createAt": 1767138745373
-        }
-      },
-      "DURl41_l80oZLyouDCwPD": {
-        "id": "DURl41_l80oZLyouDCwPD",
-        "tableId": "8M0iaeBZJGmInhPC2TgAp",
-        "name": "role_id",
-        "comment": "",
-        "dataType": "text",
-        "default": "",
-        "options": 10,
-        "ui": {
-          "keys": 1,
-          "widthName": 60,
-          "widthComment": 60,
-          "widthDataType": 60,
-          "widthDefault": 60
-        },
-        "meta": {
-          "updateAt": 1767138851188,
-          "createAt": 1767138756920
-        }
-      },
-      "Cwch3_8KcHayjd2ZuY2F_": {
-        "id": "Cwch3_8KcHayjd2ZuY2F_",
-        "tableId": "8M0iaeBZJGmInhPC2TgAp",
-        "name": "created_at",
-        "comment": "",
-        "dataType": "date",
-        "default": "now()",
-        "options": 8,
-        "ui": {
-          "keys": 0,
-          "widthName": 60,
-          "widthComment": 60,
-          "widthDataType": 60,
-          "widthDefault": 60
-        },
-        "meta": {
-          "updateAt": 1767138785192,
-          "createAt": 1767138771080
-        }
-      },
-      "C2dendjTE5RYAtKmVp_3E": {
-        "id": "C2dendjTE5RYAtKmVp_3E",
-        "tableId": "awFsLieJv3UqMDztul_Yc",
-        "name": "id",
-        "comment": "",
-        "dataType": "text",
-        "default": "snowflake()",
-        "options": 14,
-        "ui": {
-          "keys": 1,
-          "widthName": 60,
-          "widthComment": 60,
-          "widthDataType": 60,
-          "widthDefault": 62
-        },
-        "meta": {
-          "updateAt": 1767138816996,
-          "createAt": 1767138806131
-        }
-      },
-      "JBEeYtztWHavGJueUvk8r": {
-        "id": "JBEeYtztWHavGJueUvk8r",
-        "tableId": "awFsLieJv3UqMDztul_Yc",
-        "name": "guild_id",
-        "comment": "",
-        "dataType": "text",
-        "default": "",
-        "options": 8,
-        "ui": {
-          "keys": 0,
-          "widthName": 60,
-          "widthComment": 60,
-          "widthDataType": 60,
-          "widthDefault": 60
-        },
-        "meta": {
-          "updateAt": 1767138828882,
-          "createAt": 1767138826314
-        }
-      },
-      "0Folm2MYXg3lfOjTpdcF0": {
-        "id": "0Folm2MYXg3lfOjTpdcF0",
-        "tableId": "awFsLieJv3UqMDztul_Yc",
-        "name": "role_id",
-        "comment": "",
-        "dataType": "text",
-        "default": "",
-        "options": 8,
-        "ui": {
-          "keys": 0,
-          "widthName": 60,
-          "widthComment": 60,
-          "widthDataType": 60,
-          "widthDefault": 60
-        },
-        "meta": {
-          "updateAt": 1767138841141,
-          "createAt": 1767138837499
-        }
-      },
-      "hTfMtdY7--GVA7T0KK_m7": {
-        "id": "hTfMtdY7--GVA7T0KK_m7",
-        "tableId": "awFsLieJv3UqMDztul_Yc",
-        "name": "inactive_count",
-        "comment": "",
-        "dataType": "int",
-        "default": "0",
-        "options": 8,
-        "ui": {
-          "keys": 0,
-          "widthName": 78,
-          "widthComment": 60,
-          "widthDataType": 60,
-          "widthDefault": 60
-        },
-        "meta": {
-          "updateAt": 1767138879817,
-          "createAt": 1767138860444
-        }
-      },
-      "iBCltc_AEGtGhvkYN4dD3": {
-        "id": "iBCltc_AEGtGhvkYN4dD3",
-        "tableId": "awFsLieJv3UqMDztul_Yc",
-        "name": "active_count",
-        "comment": "",
-        "dataType": "int",
-        "default": "0",
-        "options": 8,
-        "ui": {
-          "keys": 0,
-          "widthName": 68,
-          "widthComment": 60,
-          "widthDataType": 60,
-          "widthDefault": 60
-        },
-        "meta": {
-          "updateAt": 1767138906245,
-          "createAt": 1767138902096
-        }
-      },
-      "nDKlmERmdbil5dxLnfwjZ": {
-        "id": "nDKlmERmdbil5dxLnfwjZ",
-        "tableId": "awFsLieJv3UqMDztul_Yc",
-        "name": "captured_at",
-        "comment": "",
-        "dataType": "date",
-        "default": "now()",
-        "options": 8,
-        "ui": {
-          "keys": 0,
-          "widthName": 64,
-          "widthComment": 60,
-          "widthDataType": 60,
-          "widthDefault": 60
-        },
-        "meta": {
-          "updateAt": 1767138919180,
-          "createAt": 1767138913888
-        }
-      },
-      "UbZsBH8MtHlIV7u0qG7u8": {
-        "id": "UbZsBH8MtHlIV7u0qG7u8",
-        "tableId": "3_9V8n4eraYwE5RkJdFhU",
-        "name": "guild_id",
-        "comment": "",
-        "dataType": "text",
-        "default": "",
-        "options": 8,
-        "ui": {
-          "keys": 0,
-          "widthName": 60,
-          "widthComment": 60,
-          "widthDataType": 60,
-          "widthDefault": 60
-        },
-        "meta": {
-          "updateAt": 1767138966370,
-          "createAt": 1767138958339
-        }
-      },
-      "rx21Y93ASz3cJUgEEfIha": {
-        "id": "rx21Y93ASz3cJUgEEfIha",
-        "tableId": "3_9V8n4eraYwE5RkJdFhU",
-        "name": "role_id",
-        "comment": "",
-        "dataType": "text",
-        "default": "",
-        "options": 8,
-        "ui": {
-          "keys": 0,
-          "widthName": 60,
-          "widthComment": 60,
-          "widthDataType": 60,
-          "widthDefault": 60
-        },
-        "meta": {
-          "updateAt": 1767138987416,
-          "createAt": 1767138982760
-        }
-      },
-      "Z4inzBrV_0oL9LFVhEgSW": {
-        "id": "Z4inzBrV_0oL9LFVhEgSW",
-        "tableId": "3_9V8n4eraYwE5RkJdFhU",
+      "col_inactivity_user_id": {
+        "id": "col_inactivity_user_id",
+        "tableId": "tbl_inactivity_periods",
         "name": "user_id",
         "comment": "",
         "dataType": "text",
-        "default": "snowflake()",
+        "default": "",
         "options": 14,
         "ui": {
-          "keys": 1,
+          "keys": 3,
           "widthName": 60,
           "widthComment": 60,
           "widthDataType": 60,
-          "widthDefault": 62
+          "widthDefault": 60
         },
         "meta": {
-          "updateAt": 1767139024430,
-          "createAt": 1767139015008
+          "updateAt": 1780469686502,
+          "createAt": 1780469686502
         }
       },
-      "43Mi1_wFB75gQNu4ggqWM": {
-        "id": "43Mi1_wFB75gQNu4ggqWM",
-        "tableId": "3_9V8n4eraYwE5RkJdFhU",
+      "col_inactivity_guild_id": {
+        "id": "col_inactivity_guild_id",
+        "tableId": "tbl_inactivity_periods",
+        "name": "guild_id",
+        "comment": "",
+        "dataType": "text",
+        "default": "",
+        "options": 8,
+        "ui": {
+          "keys": 0,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1780469686502,
+          "createAt": 1780469686502
+        }
+      },
+      "col_inactivity_role_snapshot": {
+        "id": "col_inactivity_role_snapshot",
+        "tableId": "tbl_inactivity_periods",
         "name": "role_snapshot",
         "comment": "",
         "dataType": "text",
@@ -1017,16 +672,16 @@
           "widthDefault": 60
         },
         "meta": {
-          "updateAt": 1767139052300,
-          "createAt": 1767139040349
+          "updateAt": 1780469686502,
+          "createAt": 1780469686502
         }
       },
-      "oXWLYZltldatqiV5rpqNs": {
-        "id": "oXWLYZltldatqiV5rpqNs",
-        "tableId": "3_9V8n4eraYwE5RkJdFhU",
+      "col_inactivity_started_at": {
+        "id": "col_inactivity_started_at",
+        "tableId": "tbl_inactivity_periods",
         "name": "started_at",
         "comment": "",
-        "dataType": "date",
+        "dataType": "timestamp",
         "default": "now()",
         "options": 8,
         "ui": {
@@ -1037,17 +692,17 @@
           "widthDefault": 60
         },
         "meta": {
-          "updateAt": 1767139066848,
-          "createAt": 1767139061248
+          "updateAt": 1780469686502,
+          "createAt": 1780469686502
         }
       },
-      "pcnA95P_YKPr0VhlNiAii": {
-        "id": "pcnA95P_YKPr0VhlNiAii",
-        "tableId": "3_9V8n4eraYwE5RkJdFhU",
+      "col_inactivity_ends_at": {
+        "id": "col_inactivity_ends_at",
+        "tableId": "tbl_inactivity_periods",
         "name": "ends_at",
         "comment": "",
-        "dataType": "date",
-        "default": "now()",
+        "dataType": "timestamp",
+        "default": "",
         "options": 8,
         "ui": {
           "keys": 0,
@@ -1057,13 +712,13 @@
           "widthDefault": 60
         },
         "meta": {
-          "updateAt": 1767139079695,
-          "createAt": 1767139073185
+          "updateAt": 1780469686502,
+          "createAt": 1780469686502
         }
       },
-      "fiz6bECWrOAi9ydcvcnEu": {
-        "id": "fiz6bECWrOAi9ydcvcnEu",
-        "tableId": "3_9V8n4eraYwE5RkJdFhU",
+      "col_inactivity_source": {
+        "id": "col_inactivity_source",
+        "tableId": "tbl_inactivity_periods",
         "name": "source",
         "comment": "",
         "dataType": "text",
@@ -1077,13 +732,13 @@
           "widthDefault": 60
         },
         "meta": {
-          "updateAt": 1767139090878,
-          "createAt": 1767139083764
+          "updateAt": 1780469686502,
+          "createAt": 1780469686502
         }
       },
-      "1tUVmA07rNOyXYrj5owsU": {
-        "id": "1tUVmA07rNOyXYrj5owsU",
-        "tableId": "3_9V8n4eraYwE5RkJdFhU",
+      "col_inactivity_notified": {
+        "id": "col_inactivity_notified",
+        "tableId": "tbl_inactivity_periods",
         "name": "notified",
         "comment": "",
         "dataType": "boolean",
@@ -1097,37 +752,57 @@
           "widthDefault": 60
         },
         "meta": {
-          "updateAt": 1767139145221,
-          "createAt": 1767139093758
+          "updateAt": 1780469686502,
+          "createAt": 1780469686502
         }
       },
-      "NiLZV0OKzNna4sM1hXXmL": {
-        "id": "NiLZV0OKzNna4sM1hXXmL",
-        "tableId": "3_9V8n4eraYwE5RkJdFhU",
-        "name": "discord_user_id",
+      "col_tracked_roles_guild_id": {
+        "id": "col_tracked_roles_guild_id",
+        "tableId": "tbl_tracked_roles",
+        "name": "guild_id",
         "comment": "",
         "dataType": "text",
         "default": "",
         "options": 10,
         "ui": {
-          "keys": 3,
-          "widthName": 83,
+          "keys": 1,
+          "widthName": 60,
           "widthComment": 60,
           "widthDataType": 60,
           "widthDefault": 60
         },
         "meta": {
-          "updateAt": 1767139210681,
-          "createAt": 1767139196253
+          "updateAt": 1780469686502,
+          "createAt": 1780469686502
         }
       },
-      "rM3je-3Wc5X89te384cj1": {
-        "id": "rM3je-3Wc5X89te384cj1",
-        "tableId": "n9NjBRzd61itcrapIFLdG",
-        "name": "rank",
+      "col_tracked_roles_role_id": {
+        "id": "col_tracked_roles_role_id",
+        "tableId": "tbl_tracked_roles",
+        "name": "role_id",
         "comment": "",
         "dataType": "text",
-        "default": "Miembro",
+        "default": "",
+        "options": 10,
+        "ui": {
+          "keys": 1,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1780469686502,
+          "createAt": 1780469686502
+        }
+      },
+      "col_tracked_roles_created_at": {
+        "id": "col_tracked_roles_created_at",
+        "tableId": "tbl_tracked_roles",
+        "name": "created_at",
+        "comment": "",
+        "dataType": "timestamp",
+        "default": "now()",
         "options": 8,
         "ui": {
           "keys": 0,
@@ -1137,178 +812,2126 @@
           "widthDefault": 60
         },
         "meta": {
-          "updateAt": 1768957732790,
-          "createAt": 1768957711215
+          "updateAt": 1780469686502,
+          "createAt": 1780469686502
+        }
+      },
+      "col_role_statistics_id": {
+        "id": "col_role_statistics_id",
+        "tableId": "tbl_role_statistics",
+        "name": "id",
+        "comment": "",
+        "dataType": "text",
+        "default": "snowflake()",
+        "options": 14,
+        "ui": {
+          "keys": 1,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 62
+        },
+        "meta": {
+          "updateAt": 1780469686502,
+          "createAt": 1780469686502
+        }
+      },
+      "col_role_statistics_guild_id": {
+        "id": "col_role_statistics_guild_id",
+        "tableId": "tbl_role_statistics",
+        "name": "guild_id",
+        "comment": "",
+        "dataType": "text",
+        "default": "",
+        "options": 8,
+        "ui": {
+          "keys": 0,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1780469686502,
+          "createAt": 1780469686502
+        }
+      },
+      "col_role_statistics_role_id": {
+        "id": "col_role_statistics_role_id",
+        "tableId": "tbl_role_statistics",
+        "name": "role_id",
+        "comment": "",
+        "dataType": "text",
+        "default": "",
+        "options": 8,
+        "ui": {
+          "keys": 0,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1780469686502,
+          "createAt": 1780469686502
+        }
+      },
+      "col_role_statistics_inactive_count": {
+        "id": "col_role_statistics_inactive_count",
+        "tableId": "tbl_role_statistics",
+        "name": "inactive_count",
+        "comment": "",
+        "dataType": "int",
+        "default": "0",
+        "options": 8,
+        "ui": {
+          "keys": 0,
+          "widthName": 78,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1780469686502,
+          "createAt": 1780469686502
+        }
+      },
+      "col_role_statistics_active_count": {
+        "id": "col_role_statistics_active_count",
+        "tableId": "tbl_role_statistics",
+        "name": "active_count",
+        "comment": "",
+        "dataType": "int",
+        "default": "0",
+        "options": 8,
+        "ui": {
+          "keys": 0,
+          "widthName": 68,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1780469686502,
+          "createAt": 1780469686502
+        }
+      },
+      "col_role_statistics_captured_at": {
+        "id": "col_role_statistics_captured_at",
+        "tableId": "tbl_role_statistics",
+        "name": "captured_at",
+        "comment": "",
+        "dataType": "timestamp",
+        "default": "now()",
+        "options": 8,
+        "ui": {
+          "keys": 0,
+          "widthName": 64,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1780469686502,
+          "createAt": 1780469686502
+        }
+      },
+      "col_link_codes_id": {
+        "id": "col_link_codes_id",
+        "tableId": "tbl_link_codes",
+        "name": "id",
+        "comment": "",
+        "dataType": "text",
+        "default": "snowflake()",
+        "options": 14,
+        "ui": {
+          "keys": 1,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 62
+        },
+        "meta": {
+          "updateAt": 1780469686502,
+          "createAt": 1780469686502
+        }
+      },
+      "col_link_codes_discord_id": {
+        "id": "col_link_codes_discord_id",
+        "tableId": "tbl_link_codes",
+        "name": "discord_id",
+        "comment": "",
+        "dataType": "text",
+        "default": "",
+        "options": 10,
+        "ui": {
+          "keys": 2,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1780469686502,
+          "createAt": 1780469686502
+        }
+      },
+      "col_link_codes_discord_nickname": {
+        "id": "col_link_codes_discord_nickname",
+        "tableId": "tbl_link_codes",
+        "name": "discord_nickname",
+        "comment": "",
+        "dataType": "text",
+        "default": "",
+        "options": 8,
+        "ui": {
+          "keys": 0,
+          "widthName": 97,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1780469686502,
+          "createAt": 1780469686502
+        }
+      },
+      "col_link_codes_code": {
+        "id": "col_link_codes_code",
+        "tableId": "tbl_link_codes",
+        "name": "code",
+        "comment": "",
+        "dataType": "text",
+        "default": "",
+        "options": 12,
+        "ui": {
+          "keys": 0,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1780469686502,
+          "createAt": 1780469686502
+        }
+      },
+      "col_roles_id": {
+        "id": "col_roles_id",
+        "tableId": "tbl_roles",
+        "name": "id",
+        "comment": "",
+        "dataType": "text",
+        "default": "snowflake()",
+        "options": 14,
+        "ui": {
+          "keys": 1,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 62
+        },
+        "meta": {
+          "updateAt": 1780469686502,
+          "createAt": 1780469686502
+        }
+      },
+      "col_roles_name": {
+        "id": "col_roles_name",
+        "tableId": "tbl_roles",
+        "name": "name",
+        "comment": "",
+        "dataType": "text",
+        "default": "",
+        "options": 12,
+        "ui": {
+          "keys": 0,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1780469686502,
+          "createAt": 1780469686502
+        }
+      },
+      "col_linked_roles_mc_user_uuid": {
+        "id": "col_linked_roles_mc_user_uuid",
+        "tableId": "tbl_linked_roles",
+        "name": "mc_user_uuid",
+        "comment": "",
+        "dataType": "text",
+        "default": "",
+        "options": 10,
+        "ui": {
+          "keys": 3,
+          "widthName": 74,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1780469686502,
+          "createAt": 1780469686502
+        }
+      },
+      "col_linked_roles_role_id": {
+        "id": "col_linked_roles_role_id",
+        "tableId": "tbl_linked_roles",
+        "name": "role_id",
+        "comment": "",
+        "dataType": "text",
+        "default": "",
+        "options": 10,
+        "ui": {
+          "keys": 3,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1780469686502,
+          "createAt": 1780469686502
+        }
+      },
+      "col_medias_id": {
+        "id": "col_medias_id",
+        "tableId": "tbl_medias",
+        "name": "id",
+        "comment": "",
+        "dataType": "text",
+        "default": "snowflake()",
+        "options": 14,
+        "ui": {
+          "keys": 1,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 62
+        },
+        "meta": {
+          "updateAt": 1780469686502,
+          "createAt": 1780469686502
+        }
+      },
+      "col_medias_mc_user_uuid": {
+        "id": "col_medias_mc_user_uuid",
+        "tableId": "tbl_medias",
+        "name": "mc_user_uuid",
+        "comment": "",
+        "dataType": "text",
+        "default": "",
+        "options": 10,
+        "ui": {
+          "keys": 2,
+          "widthName": 74,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1780469686502,
+          "createAt": 1780469686502
+        }
+      },
+      "col_medias_type": {
+        "id": "col_medias_type",
+        "tableId": "tbl_medias",
+        "name": "type",
+        "comment": "",
+        "dataType": "text",
+        "default": "",
+        "options": 8,
+        "ui": {
+          "keys": 0,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1780469686502,
+          "createAt": 1780469686502
+        }
+      },
+      "col_medias_url": {
+        "id": "col_medias_url",
+        "tableId": "tbl_medias",
+        "name": "url",
+        "comment": "",
+        "dataType": "text",
+        "default": "",
+        "options": 8,
+        "ui": {
+          "keys": 0,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1780469686502,
+          "createAt": 1780469686502
+        }
+      },
+      "col_minecraft_users_uuid": {
+        "id": "col_minecraft_users_uuid",
+        "tableId": "tbl_minecraft_users",
+        "name": "uuid",
+        "comment": "",
+        "dataType": "text",
+        "default": "",
+        "options": 14,
+        "ui": {
+          "keys": 1,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1780469686502,
+          "createAt": 1780469686502
+        }
+      },
+      "col_minecraft_users_nickname": {
+        "id": "col_minecraft_users_nickname",
+        "tableId": "tbl_minecraft_users",
+        "name": "nickname",
+        "comment": "",
+        "dataType": "text",
+        "default": "",
+        "options": 12,
+        "ui": {
+          "keys": 0,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1780469686502,
+          "createAt": 1780469686502
+        }
+      },
+      "col_minecraft_users_digs": {
+        "id": "col_minecraft_users_digs",
+        "tableId": "tbl_minecraft_users",
+        "name": "digs",
+        "comment": "",
+        "dataType": "int",
+        "default": "0",
+        "options": 8,
+        "ui": {
+          "keys": 0,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1780469686502,
+          "createAt": 1780469686502
+        }
+      },
+      "col_minecraft_users_description": {
+        "id": "col_minecraft_users_description",
+        "tableId": "tbl_minecraft_users",
+        "name": "description",
+        "comment": "",
+        "dataType": "text",
+        "default": "''",
+        "options": 8,
+        "ui": {
+          "keys": 0,
+          "widthName": 61,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1780469686502,
+          "createAt": 1780469686502
+        }
+      },
+      "col_minecraft_users_discord_user_id": {
+        "id": "col_minecraft_users_discord_user_id",
+        "tableId": "tbl_minecraft_users",
+        "name": "discord_user_id",
+        "comment": "",
+        "dataType": "text",
+        "default": "",
+        "options": 10,
+        "ui": {
+          "keys": 2,
+          "widthName": 83,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1780469686502,
+          "createAt": 1780469686502
+        }
+      },
+      "col_minecraft_users_rank": {
+        "id": "col_minecraft_users_rank",
+        "tableId": "tbl_minecraft_users",
+        "name": "rank",
+        "comment": "",
+        "dataType": "text",
+        "default": "'Miembro'",
+        "options": 8,
+        "ui": {
+          "keys": 0,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1780469686502,
+          "createAt": 1780469686502
+        }
+      },
+      "col_minecraft_users_status": {
+        "id": "col_minecraft_users_status",
+        "tableId": "tbl_minecraft_users",
+        "name": "status",
+        "comment": "",
+        "dataType": "PLAYER_STATUS",
+        "default": "ACTIVE",
+        "options": 8,
+        "ui": {
+          "keys": 0,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 86,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1780469686502,
+          "createAt": 1780469686502
+        }
+      },
+      "col_minecraft_users_last_seen": {
+        "id": "col_minecraft_users_last_seen",
+        "tableId": "tbl_minecraft_users",
+        "name": "last_seen",
+        "comment": "",
+        "dataType": "timestamp?",
+        "default": "",
+        "options": 0,
+        "ui": {
+          "keys": 0,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 64,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1780469686502,
+          "createAt": 1780469686502
+        }
+      },
+      "col_discord_users_id": {
+        "id": "col_discord_users_id",
+        "tableId": "tbl_discord_users",
+        "name": "id",
+        "comment": "",
+        "dataType": "text",
+        "default": "",
+        "options": 14,
+        "ui": {
+          "keys": 1,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1780469686502,
+          "createAt": 1780469686502
+        }
+      },
+      "col_discord_users_username": {
+        "id": "col_discord_users_username",
+        "tableId": "tbl_discord_users",
+        "name": "username",
+        "comment": "",
+        "dataType": "text",
+        "default": "",
+        "options": 12,
+        "ui": {
+          "keys": 0,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1780469686502,
+          "createAt": 1780469686502
+        }
+      },
+      "col_webhook_tokens_id": {
+        "id": "col_webhook_tokens_id",
+        "tableId": "tbl_webhook_tokens",
+        "name": "id",
+        "comment": "",
+        "dataType": "text",
+        "default": "snowflake()",
+        "options": 14,
+        "ui": {
+          "keys": 1,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 62
+        },
+        "meta": {
+          "updateAt": 1780469686502,
+          "createAt": 1780469686502
+        }
+      },
+      "col_webhook_tokens_name": {
+        "id": "col_webhook_tokens_name",
+        "tableId": "tbl_webhook_tokens",
+        "name": "name",
+        "comment": "",
+        "dataType": "text",
+        "default": "",
+        "options": 12,
+        "ui": {
+          "keys": 0,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1780469686502,
+          "createAt": 1780469686502
+        }
+      },
+      "col_webhook_tokens_discord_user_id": {
+        "id": "col_webhook_tokens_discord_user_id",
+        "tableId": "tbl_webhook_tokens",
+        "name": "discord_user_id",
+        "comment": "",
+        "dataType": "text",
+        "default": "",
+        "options": 10,
+        "ui": {
+          "keys": 2,
+          "widthName": 83,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1780469686502,
+          "createAt": 1780469686502
+        }
+      },
+      "col_webhook_tokens_secret": {
+        "id": "col_webhook_tokens_secret",
+        "tableId": "tbl_webhook_tokens",
+        "name": "secret",
+        "comment": "",
+        "dataType": "text",
+        "default": "",
+        "options": 8,
+        "ui": {
+          "keys": 0,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1780469686502,
+          "createAt": 1780469686502
+        }
+      },
+      "col_webhook_tokens_permissions": {
+        "id": "col_webhook_tokens_permissions",
+        "tableId": "tbl_webhook_tokens",
+        "name": "permissions",
+        "comment": "",
+        "dataType": "text[]",
+        "default": "",
+        "options": 8,
+        "ui": {
+          "keys": 0,
+          "widthName": 65,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1780469686502,
+          "createAt": 1780469686502
+        }
+      },
+      "col_webhook_tokens_created_at": {
+        "id": "col_webhook_tokens_created_at",
+        "tableId": "tbl_webhook_tokens",
+        "name": "created_at",
+        "comment": "",
+        "dataType": "timestamp",
+        "default": "now()",
+        "options": 8,
+        "ui": {
+          "keys": 0,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1780469686502,
+          "createAt": 1780469686502
+        }
+      },
+      "col_states_id": {
+        "id": "col_states_id",
+        "tableId": "tbl_states",
+        "name": "id",
+        "comment": "",
+        "dataType": "text",
+        "default": "snowflake()",
+        "options": 14,
+        "ui": {
+          "keys": 1,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 62
+        },
+        "meta": {
+          "updateAt": 1780469686502,
+          "createAt": 1780469686502
+        }
+      },
+      "col_states_key": {
+        "id": "col_states_key",
+        "tableId": "tbl_states",
+        "name": "key",
+        "comment": "",
+        "dataType": "text",
+        "default": "",
+        "options": 12,
+        "ui": {
+          "keys": 0,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1780469686502,
+          "createAt": 1780469686502
+        }
+      },
+      "col_states_value": {
+        "id": "col_states_value",
+        "tableId": "tbl_states",
+        "name": "value",
+        "comment": "",
+        "dataType": "text",
+        "default": "",
+        "options": 8,
+        "ui": {
+          "keys": 0,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1780469686502,
+          "createAt": 1780469686502
+        }
+      },
+      "col_states_updated_at": {
+        "id": "col_states_updated_at",
+        "tableId": "tbl_states",
+        "name": "updated_at",
+        "comment": "",
+        "dataType": "timestamp",
+        "default": "",
+        "options": 8,
+        "ui": {
+          "keys": 0,
+          "widthName": 62,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1780469686502,
+          "createAt": 1780469686502
+        }
+      },
+      "col_posts_id": {
+        "id": "col_posts_id",
+        "tableId": "tbl_posts",
+        "name": "id",
+        "comment": "",
+        "dataType": "text",
+        "default": "snowflake()",
+        "options": 14,
+        "ui": {
+          "keys": 1,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 62
+        },
+        "meta": {
+          "updateAt": 1780469686502,
+          "createAt": 1780469686502
+        }
+      },
+      "col_posts_title": {
+        "id": "col_posts_title",
+        "tableId": "tbl_posts",
+        "name": "title",
+        "comment": "",
+        "dataType": "text",
+        "default": "",
+        "options": 12,
+        "ui": {
+          "keys": 0,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1780469686502,
+          "createAt": 1780469686502
+        }
+      },
+      "col_posts_discord_user_id": {
+        "id": "col_posts_discord_user_id",
+        "tableId": "tbl_posts",
+        "name": "discord_user_id",
+        "comment": "",
+        "dataType": "text",
+        "default": "",
+        "options": 10,
+        "ui": {
+          "keys": 2,
+          "widthName": 83,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1780469686502,
+          "createAt": 1780469686502
+        }
+      },
+      "col_posts_minecraft_player_uuid": {
+        "id": "col_posts_minecraft_player_uuid",
+        "tableId": "tbl_posts",
+        "name": "minecraft_player_uuid",
+        "comment": "",
+        "dataType": "text?",
+        "default": "",
+        "options": 2,
+        "ui": {
+          "keys": 2,
+          "widthName": 118,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1780469686502,
+          "createAt": 1780469686502
+        }
+      },
+      "col_posts_thread_id": {
+        "id": "col_posts_thread_id",
+        "tableId": "tbl_posts",
+        "name": "thread_id",
+        "comment": "",
+        "dataType": "text",
+        "default": "",
+        "options": 8,
+        "ui": {
+          "keys": 0,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1780469686502,
+          "createAt": 1780469686502
+        }
+      },
+      "col_posts_status": {
+        "id": "col_posts_status",
+        "tableId": "tbl_posts",
+        "name": "status",
+        "comment": "",
+        "dataType": "POST_STATUS",
+        "default": "DRAFT",
+        "options": 8,
+        "ui": {
+          "keys": 0,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 75,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1780469686502,
+          "createAt": 1780469686502
+        }
+      },
+      "col_posts_created_at": {
+        "id": "col_posts_created_at",
+        "tableId": "tbl_posts",
+        "name": "created_at",
+        "comment": "",
+        "dataType": "timestamp",
+        "default": "now()",
+        "options": 8,
+        "ui": {
+          "keys": 0,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1780469686502,
+          "createAt": 1780469686502
+        }
+      },
+      "col_posts_updated_at": {
+        "id": "col_posts_updated_at",
+        "tableId": "tbl_posts",
+        "name": "updated_at",
+        "comment": "",
+        "dataType": "timestamp",
+        "default": "",
+        "options": 8,
+        "ui": {
+          "keys": 0,
+          "widthName": 62,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1780469686502,
+          "createAt": 1780469686502
+        }
+      },
+      "col_post_blocks_message_id": {
+        "id": "col_post_blocks_message_id",
+        "tableId": "tbl_post_blocks",
+        "name": "message_id",
+        "comment": "",
+        "dataType": "text",
+        "default": "",
+        "options": 14,
+        "ui": {
+          "keys": 1,
+          "widthName": 63,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1780469686502,
+          "createAt": 1780469686502
+        }
+      },
+      "col_post_blocks_post_id": {
+        "id": "col_post_blocks_post_id",
+        "tableId": "tbl_post_blocks",
+        "name": "post_id",
+        "comment": "",
+        "dataType": "text",
+        "default": "",
+        "options": 10,
+        "ui": {
+          "keys": 2,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1780469686502,
+          "createAt": 1780469686502
+        }
+      },
+      "col_post_blocks_timestamp": {
+        "id": "col_post_blocks_timestamp",
+        "tableId": "tbl_post_blocks",
+        "name": "timestamp",
+        "comment": "",
+        "dataType": "timestamp",
+        "default": "",
+        "options": 8,
+        "ui": {
+          "keys": 0,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1780469686502,
+          "createAt": 1780469686502
+        }
+      },
+      "col_post_blocks_content": {
+        "id": "col_post_blocks_content",
+        "tableId": "tbl_post_blocks",
+        "name": "content",
+        "comment": "",
+        "dataType": "text?",
+        "default": "",
+        "options": 0,
+        "ui": {
+          "keys": 0,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1780469686502,
+          "createAt": 1780469686502
+        }
+      },
+      "col_post_blocks_components": {
+        "id": "col_post_blocks_components",
+        "tableId": "tbl_post_blocks",
+        "name": "components",
+        "comment": "",
+        "dataType": "json[]",
+        "default": "[]",
+        "options": 8,
+        "ui": {
+          "keys": 0,
+          "widthName": 68,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1780469686502,
+          "createAt": 1780469686502
+        }
+      },
+      "col_post_blocks_embeds": {
+        "id": "col_post_blocks_embeds",
+        "tableId": "tbl_post_blocks",
+        "name": "embeds",
+        "comment": "",
+        "dataType": "json[]",
+        "default": "[]",
+        "options": 8,
+        "ui": {
+          "keys": 0,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1780469686502,
+          "createAt": 1780469686502
+        }
+      },
+      "col_post_blocks_attachments": {
+        "id": "col_post_blocks_attachments",
+        "tableId": "tbl_post_blocks",
+        "name": "attachments",
+        "comment": "",
+        "dataType": "json[]",
+        "default": "[]",
+        "options": 8,
+        "ui": {
+          "keys": 0,
+          "widthName": 67,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1780469686502,
+          "createAt": 1780469686502
+        }
+      },
+      "col_post_blocks_author_id": {
+        "id": "col_post_blocks_author_id",
+        "tableId": "tbl_post_blocks",
+        "name": "author_id",
+        "comment": "",
+        "dataType": "text",
+        "default": "",
+        "options": 10,
+        "ui": {
+          "keys": 2,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1780469686502,
+          "createAt": 1780469686502
+        }
+      },
+      "col_users_id": {
+        "id": "col_users_id",
+        "tableId": "tbl_users",
+        "name": "id",
+        "comment": "",
+        "dataType": "text",
+        "default": "snowflake()",
+        "options": 14,
+        "ui": {
+          "keys": 1,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 62
+        },
+        "meta": {
+          "updateAt": 1780469686502,
+          "createAt": 1780469686502
+        }
+      },
+      "col_users_rank": {
+        "id": "col_users_rank",
+        "tableId": "tbl_users",
+        "name": "rank",
+        "comment": "",
+        "dataType": "text",
+        "default": "'User'",
+        "options": 8,
+        "ui": {
+          "keys": 0,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1780469686502,
+          "createAt": 1780469686502
+        }
+      },
+      "col_users_mc_player_uuid": {
+        "id": "col_users_mc_player_uuid",
+        "tableId": "tbl_users",
+        "name": "mc_player_uuid",
+        "comment": "",
+        "dataType": "text?",
+        "default": "",
+        "options": 2,
+        "ui": {
+          "keys": 2,
+          "widthName": 84,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1780469686502,
+          "createAt": 1780469686502
+        }
+      },
+      "col_users_discord_user_id": {
+        "id": "col_users_discord_user_id",
+        "tableId": "tbl_users",
+        "name": "discord_user_id",
+        "comment": "",
+        "dataType": "text",
+        "default": "",
+        "options": 10,
+        "ui": {
+          "keys": 2,
+          "widthName": 83,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1780469686502,
+          "createAt": 1780469686502
+        }
+      },
+      "col_users_created_at": {
+        "id": "col_users_created_at",
+        "tableId": "tbl_users",
+        "name": "created_at",
+        "comment": "",
+        "dataType": "timestamp",
+        "default": "now()",
+        "options": 8,
+        "ui": {
+          "keys": 0,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1780469686502,
+          "createAt": 1780469686502
+        }
+      },
+      "col_users_updated_at": {
+        "id": "col_users_updated_at",
+        "tableId": "tbl_users",
+        "name": "updated_at",
+        "comment": "",
+        "dataType": "timestamp",
+        "default": "",
+        "options": 8,
+        "ui": {
+          "keys": 0,
+          "widthName": 62,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1780469686502,
+          "createAt": 1780469686502
+        }
+      },
+      "col_clients_id": {
+        "id": "col_clients_id",
+        "tableId": "tbl_clients",
+        "name": "id",
+        "comment": "",
+        "dataType": "text",
+        "default": "",
+        "options": 14,
+        "ui": {
+          "keys": 1,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1780469686502,
+          "createAt": 1780469686502
+        }
+      },
+      "col_clients_client_secret": {
+        "id": "col_clients_client_secret",
+        "tableId": "tbl_clients",
+        "name": "client_secret",
+        "comment": "",
+        "dataType": "text?",
+        "default": "",
+        "options": 0,
+        "ui": {
+          "keys": 0,
+          "widthName": 67,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1780469686502,
+          "createAt": 1780469686502
+        }
+      },
+      "col_clients_redirect_uris": {
+        "id": "col_clients_redirect_uris",
+        "tableId": "tbl_clients",
+        "name": "redirect_uris",
+        "comment": "",
+        "dataType": "text[]",
+        "default": "",
+        "options": 8,
+        "ui": {
+          "keys": 0,
+          "widthName": 66,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1780469686502,
+          "createAt": 1780469686502
+        }
+      },
+      "col_clients_created_at": {
+        "id": "col_clients_created_at",
+        "tableId": "tbl_clients",
+        "name": "created_at",
+        "comment": "",
+        "dataType": "timestamp",
+        "default": "now()",
+        "options": 8,
+        "ui": {
+          "keys": 0,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1780469686502,
+          "createAt": 1780469686502
+        }
+      },
+      "col_clients_updated_at": {
+        "id": "col_clients_updated_at",
+        "tableId": "tbl_clients",
+        "name": "updated_at",
+        "comment": "",
+        "dataType": "timestamp",
+        "default": "",
+        "options": 8,
+        "ui": {
+          "keys": 0,
+          "widthName": 62,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1780469686502,
+          "createAt": 1780469686502
+        }
+      },
+      "col_clients_scopes": {
+        "id": "col_clients_scopes",
+        "tableId": "tbl_clients",
+        "name": "scopes",
+        "comment": "",
+        "dataType": "text[]",
+        "default": "",
+        "options": 8,
+        "ui": {
+          "keys": 0,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1780469686502,
+          "createAt": 1780469686502
+        }
+      },
+      "col_authorization_codes_id": {
+        "id": "col_authorization_codes_id",
+        "tableId": "tbl_authorization_codes",
+        "name": "id",
+        "comment": "",
+        "dataType": "text",
+        "default": "snowflake()",
+        "options": 14,
+        "ui": {
+          "keys": 1,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 62
+        },
+        "meta": {
+          "updateAt": 1780469686502,
+          "createAt": 1780469686502
+        }
+      },
+      "col_authorization_codes_code": {
+        "id": "col_authorization_codes_code",
+        "tableId": "tbl_authorization_codes",
+        "name": "code",
+        "comment": "",
+        "dataType": "text",
+        "default": "",
+        "options": 12,
+        "ui": {
+          "keys": 0,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1780469686502,
+          "createAt": 1780469686502
+        }
+      },
+      "col_authorization_codes_user_id": {
+        "id": "col_authorization_codes_user_id",
+        "tableId": "tbl_authorization_codes",
+        "name": "user_id",
+        "comment": "",
+        "dataType": "text",
+        "default": "",
+        "options": 10,
+        "ui": {
+          "keys": 2,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1780469686502,
+          "createAt": 1780469686502
+        }
+      },
+      "col_authorization_codes_client_id": {
+        "id": "col_authorization_codes_client_id",
+        "tableId": "tbl_authorization_codes",
+        "name": "client_id",
+        "comment": "",
+        "dataType": "text",
+        "default": "",
+        "options": 10,
+        "ui": {
+          "keys": 2,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1780469686502,
+          "createAt": 1780469686502
+        }
+      },
+      "col_authorization_codes_redirect_uri": {
+        "id": "col_authorization_codes_redirect_uri",
+        "tableId": "tbl_authorization_codes",
+        "name": "redirect_uri",
+        "comment": "",
+        "dataType": "text",
+        "default": "",
+        "options": 8,
+        "ui": {
+          "keys": 0,
+          "widthName": 61,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1780469686502,
+          "createAt": 1780469686502
+        }
+      },
+      "col_authorization_codes_code_challenge": {
+        "id": "col_authorization_codes_code_challenge",
+        "tableId": "tbl_authorization_codes",
+        "name": "code_challenge",
+        "comment": "",
+        "dataType": "text",
+        "default": "",
+        "options": 8,
+        "ui": {
+          "keys": 0,
+          "widthName": 84,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1780469686502,
+          "createAt": 1780469686502
+        }
+      },
+      "col_authorization_codes_expires_at": {
+        "id": "col_authorization_codes_expires_at",
+        "tableId": "tbl_authorization_codes",
+        "name": "expires_at",
+        "comment": "",
+        "dataType": "timestamp",
+        "default": "",
+        "options": 8,
+        "ui": {
+          "keys": 0,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1780469686502,
+          "createAt": 1780469686502
+        }
+      },
+      "col_authorization_codes_created_at": {
+        "id": "col_authorization_codes_created_at",
+        "tableId": "tbl_authorization_codes",
+        "name": "created_at",
+        "comment": "",
+        "dataType": "timestamp",
+        "default": "now()",
+        "options": 8,
+        "ui": {
+          "keys": 0,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1780469686502,
+          "createAt": 1780469686502
+        }
+      },
+      "col_authorization_codes_scope": {
+        "id": "col_authorization_codes_scope",
+        "tableId": "tbl_authorization_codes",
+        "name": "scope",
+        "comment": "",
+        "dataType": "text",
+        "default": "",
+        "options": 8,
+        "ui": {
+          "keys": 0,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1780469686502,
+          "createAt": 1780469686502
+        }
+      },
+      "col_sessions_id": {
+        "id": "col_sessions_id",
+        "tableId": "tbl_sessions",
+        "name": "id",
+        "comment": "",
+        "dataType": "text",
+        "default": "snowflake()",
+        "options": 14,
+        "ui": {
+          "keys": 1,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 62
+        },
+        "meta": {
+          "updateAt": 1780469686502,
+          "createAt": 1780469686502
+        }
+      },
+      "col_sessions_user_id": {
+        "id": "col_sessions_user_id",
+        "tableId": "tbl_sessions",
+        "name": "user_id",
+        "comment": "",
+        "dataType": "text",
+        "default": "",
+        "options": 10,
+        "ui": {
+          "keys": 2,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1780469686502,
+          "createAt": 1780469686502
+        }
+      },
+      "col_sessions_refresh_token": {
+        "id": "col_sessions_refresh_token",
+        "tableId": "tbl_sessions",
+        "name": "refresh_token",
+        "comment": "",
+        "dataType": "text",
+        "default": "",
+        "options": 12,
+        "ui": {
+          "keys": 0,
+          "widthName": 74,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1780469686502,
+          "createAt": 1780469686502
+        }
+      },
+      "col_sessions_client_id": {
+        "id": "col_sessions_client_id",
+        "tableId": "tbl_sessions",
+        "name": "client_id",
+        "comment": "",
+        "dataType": "text",
+        "default": "",
+        "options": 10,
+        "ui": {
+          "keys": 2,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1780469686502,
+          "createAt": 1780469686502
+        }
+      },
+      "col_sessions_scope": {
+        "id": "col_sessions_scope",
+        "tableId": "tbl_sessions",
+        "name": "scope",
+        "comment": "",
+        "dataType": "text",
+        "default": "''",
+        "options": 8,
+        "ui": {
+          "keys": 0,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1780469686502,
+          "createAt": 1780469686502
+        }
+      },
+      "col_sessions_expires_at": {
+        "id": "col_sessions_expires_at",
+        "tableId": "tbl_sessions",
+        "name": "expires_at",
+        "comment": "",
+        "dataType": "timestamp",
+        "default": "",
+        "options": 8,
+        "ui": {
+          "keys": 0,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1780469686502,
+          "createAt": 1780469686502
+        }
+      },
+      "col_sessions_created_at": {
+        "id": "col_sessions_created_at",
+        "tableId": "tbl_sessions",
+        "name": "created_at",
+        "comment": "",
+        "dataType": "timestamp",
+        "default": "now()",
+        "options": 8,
+        "ui": {
+          "keys": 0,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1780469686502,
+          "createAt": 1780469686502
         }
       }
     },
     "relationshipEntities": {
-      "eiQBxShrsROfyvboYNA7r": {
-        "id": "eiQBxShrsROfyvboYNA7r",
-        "identification": false,
-        "relationshipType": 16,
-        "startRelationshipType": 2,
-        "start": {
-          "tableId": "b8nl1d9q1L_OVrVyFu5Ep",
-          "columnIds": [
-            "-BJV0uOld_8HZt9w8zPOd"
-          ],
-          "x": 672,
-          "y": 562,
-          "direction": 1
-        },
-        "end": {
-          "tableId": "pECNhZMNZeVe28wxGPj1Q",
-          "columnIds": [
-            "FOllJdUixUCosKvDYWEdV"
-          ],
-          "x": 457,
-          "y": 413,
-          "direction": 2
-        },
-        "meta": {
-          "updateAt": 1767137606121,
-          "createAt": 1767137606121
-        }
-      },
-      "D4HikRXg9FXHU_phCLZIl": {
-        "id": "D4HikRXg9FXHU_phCLZIl",
+      "rel_inactivity_discord_user": {
+        "id": "rel_inactivity_discord_user",
         "identification": true,
         "relationshipType": 16,
         "startRelationshipType": 2,
         "start": {
-          "tableId": "UGhWVLlojdQeC5QLHkbwZ",
+          "tableId": "tbl_discord_users",
           "columnIds": [
-            "m8JV99-cnhEqf4sUQyB5s"
+            "col_discord_users_id"
           ],
-          "x": 274.7691,
-          "y": 920.7896,
+          "x": 590.1255,
+          "y": 1041.0483666666667,
+          "direction": 1
+        },
+        "end": {
+          "tableId": "tbl_inactivity_periods",
+          "columnIds": [
+            "col_inactivity_user_id"
+          ],
+          "x": 430.79359999999997,
+          "y": 1159.7889,
           "direction": 4
         },
-        "end": {
-          "tableId": "zqLzFlMfEfTSYFAHoKV-p",
-          "columnIds": [
-            "IvrQCRfUxfhGb-aVJjXS-"
-          ],
-          "x": 269.7691,
-          "y": 767.7896,
-          "direction": 8
-        },
         "meta": {
-          "updateAt": 1767137745009,
-          "createAt": 1767137745009
+          "updateAt": 1780469686502,
+          "createAt": 1780469686502
         }
       },
-      "cK9echvGHTWDTgzHuV-cd": {
-        "id": "cK9echvGHTWDTgzHuV-cd",
+      "rel_link_codes_discord_user": {
+        "id": "rel_link_codes_discord_user",
         "identification": true,
-        "relationshipType": 16,
-        "startRelationshipType": 2,
-        "start": {
-          "tableId": "b8nl1d9q1L_OVrVyFu5Ep",
-          "columnIds": [
-            "-BJV0uOld_8HZt9w8zPOd"
-          ],
-          "x": 672,
-          "y": 650,
-          "direction": 1
-        },
-        "end": {
-          "tableId": "zqLzFlMfEfTSYFAHoKV-p",
-          "columnIds": [
-            "_GXQZrFym0YOUBp52caKp"
-          ],
-          "x": 468.2691,
-          "y": 715.7896,
-          "direction": 2
-        },
-        "meta": {
-          "updateAt": 1767137749926,
-          "createAt": 1767137749926
-        }
-      },
-      "V6E_kuyiRyjza_LPaXapf": {
-        "id": "V6E_kuyiRyjza_LPaXapf",
-        "identification": false,
-        "relationshipType": 16,
-        "startRelationshipType": 2,
-        "start": {
-          "tableId": "n9NjBRzd61itcrapIFLdG",
-          "columnIds": [
-            "bAdyL9_ezfWdFJLmp8jCO"
-          ],
-          "x": 571,
-          "y": 392,
-          "direction": 1
-        },
-        "end": {
-          "tableId": "hosHFkkJm_RzAUmJnWa0R",
-          "columnIds": [
-            "FxUNIZ0c9zT4IAP77Eh50"
-          ],
-          "x": 503.2691,
-          "y": 121.78960000000001,
-          "direction": 2
-        },
-        "meta": {
-          "updateAt": 1767137840933,
-          "createAt": 1767137840933
-        }
-      },
-      "of1cZ1Ty6LzXmoibaVcus": {
-        "id": "of1cZ1Ty6LzXmoibaVcus",
-        "identification": false,
         "relationshipType": 8,
         "startRelationshipType": 2,
         "start": {
-          "tableId": "n9NjBRzd61itcrapIFLdG",
+          "tableId": "tbl_discord_users",
           "columnIds": [
-            "bAdyL9_ezfWdFJLmp8jCO"
+            "col_discord_users_id"
           ],
-          "x": 768.5,
-          "y": 444,
+          "x": 787.6255,
+          "y": 1058.3817,
           "direction": 8
         },
         "end": {
-          "tableId": "b8nl1d9q1L_OVrVyFu5Ep",
+          "tableId": "tbl_link_codes",
           "columnIds": [
-            "bgUkrLbKPT5dymHDOaLSv"
+            "col_link_codes_discord_id"
           ],
-          "x": 881,
-          "y": 518,
+          "x": 922.7057,
+          "y": 1210.5703,
           "direction": 4
         },
         "meta": {
-          "updateAt": 1767138660060,
-          "createAt": 1767138660060
+          "updateAt": 1780469686502,
+          "createAt": 1780469686502
         }
       },
-      "pE3Hxm8mdUNxWXjICby8x": {
-        "id": "pE3Hxm8mdUNxWXjICby8x",
+      "rel_linked_roles_role": {
+        "id": "rel_linked_roles_role",
         "identification": true,
         "relationshipType": 16,
         "startRelationshipType": 2,
         "start": {
-          "tableId": "n9NjBRzd61itcrapIFLdG",
+          "tableId": "tbl_roles",
           "columnIds": [
-            "bAdyL9_ezfWdFJLmp8jCO"
+            "col_roles_id"
           ],
-          "x": 768.5,
-          "y": 340,
+          "x": 1272.5811,
+          "y": 116.726,
+          "direction": 1
+        },
+        "end": {
+          "tableId": "tbl_linked_roles",
+          "columnIds": [
+            "col_linked_roles_role_id"
+          ],
+          "x": 1140.6354999999999,
+          "y": 123.0749,
+          "direction": 2
+        },
+        "meta": {
+          "updateAt": 1780469686502,
+          "createAt": 1780469686502
+        }
+      },
+      "rel_linked_roles_player": {
+        "id": "rel_linked_roles_player",
+        "identification": true,
+        "relationshipType": 16,
+        "startRelationshipType": 2,
+        "start": {
+          "tableId": "tbl_minecraft_users",
+          "columnIds": [
+            "col_minecraft_users_uuid"
+          ],
+          "x": 907.4367,
+          "y": 429.3502,
           "direction": 4
         },
         "end": {
-          "tableId": "3_9V8n4eraYwE5RkJdFhU",
+          "tableId": "tbl_linked_roles",
           "columnIds": [
-            "NiLZV0OKzNna4sM1hXXmL"
+            "col_linked_roles_mc_user_uuid"
           ],
-          "x": 815.2691,
-          "y": 259.7896,
+          "x": 936.1355,
+          "y": 175.0749,
           "direction": 8
         },
         "meta": {
-          "updateAt": 1767139196253,
-          "createAt": 1767139196253
+          "updateAt": 1780469686502,
+          "createAt": 1780469686502
+        }
+      },
+      "rel_medias_player": {
+        "id": "rel_medias_player",
+        "identification": true,
+        "relationshipType": 16,
+        "startRelationshipType": 2,
+        "start": {
+          "tableId": "tbl_minecraft_users",
+          "columnIds": [
+            "col_minecraft_users_uuid"
+          ],
+          "x": 685.4367,
+          "y": 491.3502,
+          "direction": 1
+        },
+        "end": {
+          "tableId": "tbl_medias",
+          "columnIds": [
+            "col_medias_mc_user_uuid"
+          ],
+          "x": 628.2881,
+          "y": 361.1608,
+          "direction": 2
+        },
+        "meta": {
+          "updateAt": 1780469686502,
+          "createAt": 1780469686502
+        }
+      },
+      "rel_player_discord_user": {
+        "id": "rel_player_discord_user",
+        "identification": true,
+        "relationshipType": 8,
+        "startRelationshipType": 2,
+        "start": {
+          "tableId": "tbl_discord_users",
+          "columnIds": [
+            "col_discord_users_id"
+          ],
+          "x": 787.6255,
+          "y": 954.3817,
+          "direction": 4
+        },
+        "end": {
+          "tableId": "tbl_minecraft_users",
+          "columnIds": [
+            "col_minecraft_users_discord_user_id"
+          ],
+          "x": 907.4367,
+          "y": 677.3502,
+          "direction": 8
+        },
+        "meta": {
+          "updateAt": 1780469686502,
+          "createAt": 1780469686502
+        }
+      },
+      "rel_webhook_tokens_discord_user": {
+        "id": "rel_webhook_tokens_discord_user",
+        "identification": true,
+        "relationshipType": 16,
+        "startRelationshipType": 2,
+        "start": {
+          "tableId": "tbl_discord_users",
+          "columnIds": [
+            "col_discord_users_id"
+          ],
+          "x": 985.1255,
+          "y": 1032.3817,
+          "direction": 2
+        },
+        "end": {
+          "tableId": "tbl_webhook_tokens",
+          "columnIds": [
+            "col_webhook_tokens_discord_user_id"
+          ],
+          "x": 1206.6065,
+          "y": 1248.1812,
+          "direction": 1
+        },
+        "meta": {
+          "updateAt": 1780469686502,
+          "createAt": 1780469686502
+        }
+      },
+      "rel_posts_discord_user": {
+        "id": "rel_posts_discord_user",
+        "identification": true,
+        "relationshipType": 16,
+        "startRelationshipType": 2,
+        "start": {
+          "tableId": "tbl_discord_users",
+          "columnIds": [
+            "col_discord_users_id"
+          ],
+          "x": 590.1255,
+          "y": 971.7150333333333,
+          "direction": 1
+        },
+        "end": {
+          "tableId": "tbl_posts",
+          "columnIds": [
+            "col_posts_discord_user_id"
+          ],
+          "x": 499.253,
+          "y": 762.3631,
+          "direction": 8
+        },
+        "meta": {
+          "updateAt": 1780469686502,
+          "createAt": 1780469686502
+        }
+      },
+      "rel_posts_player": {
+        "id": "rel_posts_player",
+        "identification": true,
+        "relationshipType": 16,
+        "startRelationshipType": 1,
+        "start": {
+          "tableId": "tbl_minecraft_users",
+          "columnIds": [
+            "col_minecraft_users_uuid"
+          ],
+          "x": 685.4367,
+          "y": 615.3502,
+          "direction": 1
+        },
+        "end": {
+          "tableId": "tbl_posts",
+          "columnIds": [
+            "col_posts_minecraft_player_uuid"
+          ],
+          "x": 616.7529999999999,
+          "y": 638.3631,
+          "direction": 2
+        },
+        "meta": {
+          "updateAt": 1780469686502,
+          "createAt": 1780469686502
+        }
+      },
+      "rel_post_blocks_author": {
+        "id": "rel_post_blocks_author",
+        "identification": true,
+        "relationshipType": 16,
+        "startRelationshipType": 2,
+        "start": {
+          "tableId": "tbl_discord_users",
+          "columnIds": [
+            "col_discord_users_id"
+          ],
+          "x": 590.1255,
+          "y": 1006.3816999999999,
+          "direction": 1
+        },
+        "end": {
+          "tableId": "tbl_post_blocks",
+          "columnIds": [
+            "col_post_blocks_author_id"
+          ],
+          "x": 465.7683,
+          "y": 958.6504,
+          "direction": 2
+        },
+        "meta": {
+          "updateAt": 1780469686502,
+          "createAt": 1780469686502
+        }
+      },
+      "rel_post_blocks_post": {
+        "id": "rel_post_blocks_post",
+        "identification": true,
+        "relationshipType": 16,
+        "startRelationshipType": 2,
+        "start": {
+          "tableId": "tbl_posts",
+          "columnIds": [
+            "col_posts_id"
+          ],
+          "x": 264.253,
+          "y": 762.3631,
+          "direction": 8
+        },
+        "end": {
+          "tableId": "tbl_post_blocks",
+          "columnIds": [
+            "col_post_blocks_post_id"
+          ],
+          "x": 264.2683,
+          "y": 834.6504,
+          "direction": 4
+        },
+        "meta": {
+          "updateAt": 1780469686502,
+          "createAt": 1780469686502
+        }
+      },
+      "rel_users_player": {
+        "id": "rel_users_player",
+        "identification": true,
+        "relationshipType": 8,
+        "startRelationshipType": 1,
+        "start": {
+          "tableId": "tbl_minecraft_users",
+          "columnIds": [
+            "col_minecraft_users_uuid"
+          ],
+          "x": 1129.4367,
+          "y": 553.3502,
+          "direction": 2
+        },
+        "end": {
+          "tableId": "tbl_users",
+          "columnIds": [
+            "col_users_mc_player_uuid"
+          ],
+          "x": 1201.8646,
+          "y": 612.1676,
+          "direction": 1
+        },
+        "meta": {
+          "updateAt": 1780469686502,
+          "createAt": 1780469686502
+        }
+      },
+      "rel_users_discord_user": {
+        "id": "rel_users_discord_user",
+        "identification": true,
+        "relationshipType": 8,
+        "startRelationshipType": 2,
+        "start": {
+          "tableId": "tbl_discord_users",
+          "columnIds": [
+            "col_discord_users_id"
+          ],
+          "x": 985.1255,
+          "y": 980.3817,
+          "direction": 2
+        },
+        "end": {
+          "tableId": "tbl_users",
+          "columnIds": [
+            "col_users_discord_user_id"
+          ],
+          "x": 1201.8646,
+          "y": 712.1676,
+          "direction": 1
+        },
+        "meta": {
+          "updateAt": 1780469686502,
+          "createAt": 1780469686502
+        }
+      },
+      "rel_authorization_codes_user": {
+        "id": "rel_authorization_codes_user",
+        "identification": true,
+        "relationshipType": 16,
+        "startRelationshipType": 2,
+        "start": {
+          "tableId": "tbl_users",
+          "columnIds": [
+            "col_users_id"
+          ],
+          "x": 1412.3646,
+          "y": 762.1676,
+          "direction": 8
+        },
+        "end": {
+          "tableId": "tbl_authorization_codes",
+          "columnIds": [
+            "col_authorization_codes_user_id"
+          ],
+          "x": 1317.7055,
+          "y": 830.833,
+          "direction": 4
+        },
+        "meta": {
+          "updateAt": 1780469686502,
+          "createAt": 1780469686502
+        }
+      },
+      "rel_authorization_codes_client": {
+        "id": "rel_authorization_codes_client",
+        "identification": true,
+        "relationshipType": 16,
+        "startRelationshipType": 2,
+        "start": {
+          "tableId": "tbl_clients",
+          "columnIds": [
+            "col_clients_id"
+          ],
+          "x": 1638.4039,
+          "y": 403.9996,
+          "direction": 1
+        },
+        "end": {
+          "tableId": "tbl_authorization_codes",
+          "columnIds": [
+            "col_authorization_codes_client_id"
+          ],
+          "x": 1528.2055,
+          "y": 830.833,
+          "direction": 4
+        },
+        "meta": {
+          "updateAt": 1780469686502,
+          "createAt": 1780469686502
+        }
+      },
+      "rel_sessions_user": {
+        "id": "rel_sessions_user",
+        "identification": true,
+        "relationshipType": 16,
+        "startRelationshipType": 2,
+        "start": {
+          "tableId": "tbl_users",
+          "columnIds": [
+            "col_users_id"
+          ],
+          "x": 1412.3646,
+          "y": 562.1676,
+          "direction": 4
+        },
+        "end": {
+          "tableId": "tbl_sessions",
+          "columnIds": [
+            "col_sessions_user_id"
+          ],
+          "x": 1341.3656,
+          "y": 437.64369999999997,
+          "direction": 8
+        },
+        "meta": {
+          "updateAt": 1780469686502,
+          "createAt": 1780469686502
+        }
+      },
+      "rel_sessions_client": {
+        "id": "rel_sessions_client",
+        "identification": true,
+        "relationshipType": 16,
+        "startRelationshipType": 2,
+        "start": {
+          "tableId": "tbl_clients",
+          "columnIds": [
+            "col_clients_id"
+          ],
+          "x": 1638.4039,
+          "y": 303.9996,
+          "direction": 1
+        },
+        "end": {
+          "tableId": "tbl_sessions",
+          "columnIds": [
+            "col_sessions_client_id"
+          ],
+          "x": 1546.8656,
+          "y": 325.64369999999997,
+          "direction": 2
+        },
+        "meta": {
+          "updateAt": 1780469686502,
+          "createAt": 1780469686502
         }
       }
     },

--- a/src/db/schema.prisma
+++ b/src/db/schema.prisma
@@ -257,6 +257,7 @@ model Session {
     /// Hashed
     refresh_token String   @unique
     client_id     String
+    scope         String   @default("")
     expires_at    DateTime
     created_at    DateTime @default(now())
 

--- a/src/db/schema.prisma
+++ b/src/db/schema.prisma
@@ -226,6 +226,7 @@ model Client {
     redirect_uris String[]
     created_at    DateTime @default(now())
     updated_at    DateTime @updatedAt
+    scopes        String[]
 
     authorization_codes AuthorizationCode[]
     sessions            Session[]
@@ -242,6 +243,7 @@ model AuthorizationCode {
     code_challenge String
     expires_at     DateTime
     created_at     DateTime @default(now())
+    scope          String
 
     user   User   @relation(fields: [user_id], references: [id], onDelete: Cascade, onUpdate: Cascade)
     client Client @relation(fields: [client_id], references: [id], onDelete: Cascade, onUpdate: Cascade)

--- a/src/db/schema.prisma
+++ b/src/db/schema.prisma
@@ -65,22 +65,22 @@ model LinkCode {
 }
 
 /// Catálogo de roles disponibles para usuarios de Minecraft.
-model Role {
+model MinecraftRole {
     id   String @id @default(dbgenerated("snowflake()"))
     name String @unique
 
-    linked_roles LinkedRole[]
+    linked_roles LinkedMinecraftRole[]
 
     @@map("roles")
 }
 
 /// Relación N:M entre usuarios de Minecraft y los roles asignados.
-model LinkedRole {
+model LinkedMinecraftRole {
     mc_user_uuid String
     role_id      String
 
-    role   Role   @relation(fields: [role_id], references: [id])
-    player Player @relation(fields: [mc_user_uuid], references: [uuid])
+    role   MinecraftRole @relation(fields: [role_id], references: [id])
+    player Player        @relation(fields: [mc_user_uuid], references: [uuid])
 
     @@id([mc_user_uuid, role_id])
     @@map("linked_roles")
@@ -112,13 +112,12 @@ model Player {
     digs            Int           @default(0)
     description     String        @default("")
     discord_user_id String        @unique
-    rank            String        @default("Miembro")
     status          PLAYER_STATUS @default(ACTIVE)
     /// La ultima vez que entró
     last_seen       DateTime?
 
-    discord_user DiscordUser  @relation(fields: [discord_user_id], references: [id])
-    linked_roles LinkedRole[]
+    discord_user DiscordUser           @relation(fields: [discord_user_id], references: [id])
+    linked_roles LinkedMinecraftRole[]
     medias       Media[]
     posts        Post[]
     user         User?
@@ -205,7 +204,6 @@ model PostBlocks {
 
 model User {
     id              String   @id @default(dbgenerated("snowflake()"))
-    rank            String   @default("User")
     mc_player_uuid  String?  @unique
     discord_user_id String   @unique
     created_at      DateTime @default(now())
@@ -216,6 +214,7 @@ model User {
 
     authorization_codes AuthorizationCode[]
     sessions            Session[]
+    linked_roles        LinkedRole[]
 
     @@map("users")
 }
@@ -265,4 +264,26 @@ model Session {
     client Client @relation(fields: [client_id], references: [id], onDelete: Cascade, onUpdate: Cascade)
 
     @@map("sessions")
+}
+
+model Role {
+    id          String @id @default(dbgenerated("snowflake()"))
+    name        String @unique
+    /// permisos como Bit Flags
+    permissions BigInt @default(0)
+
+    linked_roles LinkedRole[]
+
+    @@map("user_roles")
+}
+
+model LinkedRole {
+    user_id String
+    role_id String
+
+    user User @relation(fields: [user_id], references: [id])
+    role Role @relation(fields: [role_id], references: [id])
+
+    @@id([user_id, role_id])
+    @@map("linked_user_roles")
 }

--- a/src/db/seed.ts
+++ b/src/db/seed.ts
@@ -4,7 +4,7 @@ import { logger } from '#/logger.ts'
 import { PrismaClientKnownRequestError } from '#/db/generated/internal/prismaNamespace.ts'
 
 try {
-    const defaultRole = await db.role.create({
+    const defaultRole = await db.minecraftRole.create({
         data: {
             name: envs.DEFAULT_ROLE_NAME,
         },

--- a/src/db/seed.ts
+++ b/src/db/seed.ts
@@ -34,6 +34,7 @@ if (!clientCount) {
                 'http://localhost:8080/oauth/callback',
                 'https://api.triskcraft.com/oauth/callback',
             ],
+            scopes: ['openid', 'identify', 'minecraft'],
         },
     })
 }

--- a/src/db/seed.ts
+++ b/src/db/seed.ts
@@ -14,7 +14,7 @@ try {
 } catch (error) {
     if (error instanceof PrismaClientKnownRequestError) {
         if (error.code === 'P2002') {
-            const defaultRole = await db.role.findUnique({
+            const defaultRole = await db.minecraftRole.findUnique({
                 where: {
                     name: envs.DEFAULT_ROLE_NAME,
                 },
@@ -35,6 +35,19 @@ if (!clientCount) {
                 'https://api.triskcraft.com/oauth/callback',
             ],
             scopes: ['openid', 'identify', 'minecraft'],
+        },
+    })
+}
+
+const superRole = await db.role.findUnique({
+    where: { name: 'super' },
+})
+
+if (!superRole) {
+    await db.role.create({
+        data: {
+            name: 'super',
+            permissions: 1,
         },
     })
 }

--- a/src/db/seed.ts
+++ b/src/db/seed.ts
@@ -51,3 +51,16 @@ if (!superRole) {
         },
     })
 }
+
+const userRole = await db.role.findUnique({
+    where: { name: 'user' },
+})
+
+if (!userRole) {
+    await db.role.create({
+        data: {
+            name: 'user',
+            permissions: 0,
+        },
+    })
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -60,7 +60,6 @@ await deployWebhookPanel()
 initializeRankService()
 // Activa los jobs programados que mantienen el sistema actualizado.
 scheduler.start()
-roleService.start()
 blogService.start()
 welcomeService.start()
 if (envs.ROLE_SERVICE) {

--- a/src/interactions/commands/dis-session.command.ts
+++ b/src/interactions/commands/dis-session.command.ts
@@ -7,6 +7,7 @@ import {
 import { db } from '#/db/prisma.ts'
 import { logger } from '#/logger.ts'
 import type { CommandInteractionHandler } from '#/services/interactions.service.ts'
+import { randomInt } from 'node:crypto'
 
 /**
  * Genera un código de vinculación de sesión y lo persiste en la base de datos.
@@ -15,9 +16,7 @@ import type { CommandInteractionHandler } from '#/services/interactions.service.
 export default class implements CommandInteractionHandler {
     name = 'dis-session'
     async run(interaction: ChatInputCommandInteraction<'cached'>) {
-        const code = Math.floor(Math.random() * 1000000)
-            .toString()
-            .padStart(6, '0')
+        const code = randomInt(100000, 999999).toString()
         const discord_id = interaction.user.id
         const username = interaction.user.username
         const discord_nickname = interaction.member?.displayName || username

--- a/src/interactions/modals/inactive.ts
+++ b/src/interactions/modals/inactive.ts
@@ -39,7 +39,7 @@ export default class extends ModalInteractionHandler {
                 })
                 return
             }
-            inactivityService.markInactivity(
+            await inactivityService.markInactivity(
                 interaction.guildId,
                 interaction.member,
                 untilDate.toJSDate(),

--- a/src/interactions/modals/webhook-add.ts
+++ b/src/interactions/modals/webhook-add.ts
@@ -21,7 +21,7 @@ import type { WebhookToken } from '#/db/generated/client.ts'
 import { PrismaClientKnownRequestError } from '#/db/generated/internal/prismaNamespace.ts'
 import { logger } from '#/logger.ts'
 
-const alg = 'HS256'
+const alg = 'RS256'
 
 const Permissions = {
     [WEBHOOK_PERMISSIONS.DIGS]: 'Webhook de digs',

--- a/src/services/rank.service.ts
+++ b/src/services/rank.service.ts
@@ -8,8 +8,8 @@ import { playersService } from './players.service.ts'
 
 async function checkRanks(member: GuildMember, cached: Player) {
     const currentRank = getRank([...member.roles.cache.values()])
-    if (cached.rank !== currentRank) {
-        await cached.setRank(currentRank)
+    if (cached.role !== currentRank) {
+        await cached.setRole(currentRank)
         logger.info(
             `[RANK SERVICE] Updated rank for ${cached.nickname} to ${currentRank}`,
         )

--- a/src/services/roles.service.ts
+++ b/src/services/roles.service.ts
@@ -75,7 +75,7 @@ class RoleService {
         })
         for (const { uuid, nickname } of usersWithoutRoles) {
             try {
-                await db.linkedRole.create({
+                await db.linkedMinecraftRole.create({
                     data: {
                         role: {
                             connect: {
@@ -207,7 +207,8 @@ class RoleService {
                     new Player({
                         discord_user_id: user.discord_user_id,
                         nickname: user.nickname,
-                        rank: user.rank,
+                        role:
+                            user.linked_roles[0]?.role.id ?? envs.DEFAULT_RANK,
                         uuid: user.uuid,
                     }),
                 )

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -31,7 +31,9 @@ export function getOauthCtxCookie(req: Request): OAuthCtx | null {
     }
 }
 
-export function getDiscordAccessCookie(req: Request): DiscordAccessTokenResponse | null {
+export function getDiscordAccessCookie(
+    req: Request,
+): DiscordAccessTokenResponse | null {
     try {
         const raw = JSON.parse(req.cookies['discord_access'])
         return DiscordAccessSchema.safeParse(raw).data ?? null
@@ -41,7 +43,7 @@ export function getDiscordAccessCookie(req: Request): DiscordAccessTokenResponse
 }
 export async function getSessionCookie(req: Request) {
     try {
-        const cookie = req.cookies['session'] ?? '' // TODO: validate this as {DiscordAccessTokenResponse}
+        const cookie = req.cookies['session'] ?? ''
         return await jwtVerify(cookie, PUBLIC_KEY)
     } catch {
         return null

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -4,6 +4,28 @@ import { SignJWT } from 'jose'
 import { jwtVerify, type JWTPayload as JoseJWTPayload } from 'jose'
 import { z } from 'zod'
 
+export const OAUTH_SCOPES = ['openid', 'identify', 'minecraft'] as const
+export type OAuthScope = (typeof OAUTH_SCOPES)[number]
+
+export function parseScopes(scope: unknown): OAuthScope[] {
+    if (typeof scope !== 'string') {
+        return []
+    }
+
+    const requested = new Set(
+        scope
+            .split(/\s+/)
+            .map(s => s.trim())
+            .filter(Boolean),
+    )
+
+    return OAUTH_SCOPES.filter(scope => requested.has(scope))
+}
+
+export function serializeScopes(scopes: readonly OAuthScope[]) {
+    return scopes.join(' ')
+}
+
 const OAuthCtxSchema = z.record(z.string(), z.string())
 export type OAuthCtx = z.infer<typeof OAuthCtxSchema>
 
@@ -77,6 +99,7 @@ export async function refreshToken(refresh_token: string) {
 export interface JWTPayload extends JoseJWTPayload {
     aud: string
     client_id: string
+    scope: string
     sub: string
     session_id: string
 }

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -2,6 +2,19 @@ import { envs, PRIVATE_KEY, PUBLIC_KEY } from '#/config.ts'
 import type { Request } from 'express'
 import { SignJWT } from 'jose'
 import { jwtVerify, type JWTPayload as JoseJWTPayload } from 'jose'
+import { z } from 'zod'
+
+const OAuthCtxSchema = z.record(z.string(), z.string())
+export type OAuthCtx = z.infer<typeof OAuthCtxSchema>
+
+const DiscordAccessSchema = z.object({
+    token_type: z.literal('Bearer'),
+    access_token: z.string().min(1),
+    expires_in: z.number(),
+    refresh_token: z.string().min(1),
+    scope: z.string(),
+})
+export type DiscordAccessTokenResponse = z.infer<typeof DiscordAccessSchema>
 
 export async function getSession(req: Request) {
     const discord = getDiscordAccessCookie(req)
@@ -9,37 +22,23 @@ export async function getSession(req: Request) {
     return { discord, session }
 }
 
-export function getOauthCtxCookie(req: Request) {
+export function getOauthCtxCookie(req: Request): OAuthCtx | null {
     try {
-        return JSON.parse(req.cookies['oauth_ctx']) // TODO: validate this
+        const raw = JSON.parse(req.cookies['oauth_ctx'])
+        return OAuthCtxSchema.safeParse(raw).data ?? null
     } catch {
         return null
     }
 }
 
-export interface DiscordAccessTokenResponse {
-    token_type: 'Bearer'
-    access_token: string
-    expires_in: number
-    refresh_token: string
-    scope: string
-}
-export function getDiscordAccessCookie(req: Request) {
+export function getDiscordAccessCookie(req: Request): DiscordAccessTokenResponse | null {
     try {
-        return JSON.parse(
-            req.cookies['discord_access'],
-        ) as DiscordAccessTokenResponse // TODO: validate this as {DiscordAccessTokenResponse}
+        const raw = JSON.parse(req.cookies['discord_access'])
+        return DiscordAccessSchema.safeParse(raw).data ?? null
     } catch {
         return null
     }
 }
-// interface DiscordAccessTokenResponse {
-//     token_type: 'Bearer'
-//     access_token: string
-//     expires_in: number
-//     refresh_token: string
-//     scope: string
-// }
 export async function getSessionCookie(req: Request) {
     try {
         const cookie = req.cookies['session'] ?? '' // TODO: validate this as {DiscordAccessTokenResponse}

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -57,7 +57,7 @@ export async function refreshToken(refresh_token: string) {
         refresh_token,
     })
 
-    const request = await fetch('https://discord.com', {
+    const request = await fetch('https://discord.com/api/v10/oauth2/token', {
         method: 'POST',
         body: params,
         headers: {


### PR DESCRIPTION
## Resumen

Integra el nuevo flujo OAuth 2.0 con PKCE, scopes y roles de usuario, además de ampliar la API pública y reorganizar la capa de Prisma/DB.

## Cambios principales

- Agrega endpoints OAuth bajo `/auth`:
  - `/auth/authorize`
  - `/auth/discord`
  - `/auth/token`
  - `/auth/refresh`
  - `/auth/me`
- Implementa scopes OAuth `openid`, `identify` y `minecraft`.
- Agrega roles de usuario (`user_roles`, `linked_user_roles`) y asignación inicial de `user`/`super`.
- Añade endpoints v1:
  - `GET /v1/posts`
  - `GET /v1/games/minecraft/players`
- Agrega webhook `POST /webhooks/join`.
- Migra Prisma de `src/prisma` a `src/db`.
- Agrega soporte para JWT con par RSA `private.pem`/`public.pem`.
- Añade documentación en `docs/` y actualiza README/documentación técnica.
- Agrega workflow de deploy a `main`.
- Actualiza dependencias y runtime requerido a Node `>=24.14`.

## Migraciones y datos

Este PR agrega migraciones para:

- Preparar OAuth (`users`, `clients`, `authorization_codes`, `sessions`).
- Persistir scopes en authorization codes y sesiones.
- Agregar roles de usuario.
- Agregar estado/soft-delete de jugadores y `last_seen`.

Nota: la migración de roles elimina las columnas `rank` de `users` y `minecraft_users`; el rango pasa a resolverse desde roles enlazados.

## Variables/archivos requeridos

Se agregan nuevas variables obligatorias:

- `DISCORD_CLIENT_SECRET`
- `DISCORD_REDIRECT_URI`
- `API_URL`
- `SUPER_USER_DISCORD_ID`
- `S3_URL`
- `S3_ACCESS_KEY_ID`
- `S3_SECRET_ACCESS_KEY`

También se requiere generar:

- `private.pem`
- `public.pem`

## Verificación

- [x] `npm run build`
- [x] `npm run lint`

## Notas de revisión

- Revisar cuidadosamente las migraciones antes de aplicar en producción, especialmente la eliminación de columnas `rank`.
- Verificar que los clients OAuth existentes tengan `redirect_uris` y `scopes` configurados.
- Confirmar que los secretos de GitHub para deploy (`VPS_HOST`, `VPS_SSH_KEY`) existan antes de mergear a `main`.