### PR TITLE
Corregir vinculación de roles de Minecraft

### DIFF
--- a/src/classes/minecraft-roles-manager.ts
+++ b/src/classes/minecraft-roles-manager.ts
@@ -60,7 +60,7 @@ export class MinecraftRolesManager {
 
     async create(name: string) {
         const role = new MinecraftRole(
-            await db.role.create({
+            await db.minecraftRole.create({
                 data: { name },
             }),
         )
@@ -69,7 +69,7 @@ export class MinecraftRolesManager {
     }
 
     async delete(id: string) {
-        await db.role.delete({
+        await db.minecraftRole.delete({
             where: { id },
         })
         this.#cache.delete(id)

--- a/src/classes/player.ts
+++ b/src/classes/player.ts
@@ -57,7 +57,17 @@ export class Player {
         return this.toJSON()
     }
 
-    async setRole(role: string) {
+    async setRole(roleName: string) {
+        const role = await db.minecraftRole.upsert({
+            where: {
+                name: roleName,
+            },
+            update: {},
+            create: {
+                name: roleName,
+            },
+        })
+
         await db.linkedMinecraftRole.deleteMany({
             where: {
                 mc_user_uuid: this.#uuid,
@@ -66,10 +76,10 @@ export class Player {
         await db.linkedMinecraftRole.create({
             data: {
                 mc_user_uuid: this.#uuid,
-                role_id: role,
+                role_id: role.id,
             },
         })
-        this.#role = role
+        this.#role = role.id
         return this
     }
 }


### PR DESCRIPTION
## Resumen
- Corrige la vinculación de rangos para que linked_roles.role_id use el ID real de MinecraftRole.
- Crea o actualiza el rol de Minecraft por nombre antes de asociarlo al jugador.
- Corrige MinecraftRolesManager para usar minecraftRole en vez de la tabla de roles de usuarios.

## Contexto
Esto evita el error de producción P2003 por la FK linked_roles_role_id_fkey cuando llega un rango de Discord por nombre.

## Verificación
- npm run lint
- npm run build