### PR TITLE
Agregar endpoint para obtener un post por ID

### DIFF
--- a/src/api/v1/posts/get.ts
+++ b/src/api/v1/posts/get.ts
@@ -2,6 +2,7 @@ import type { Request, Response } from 'express'
 import { db } from '#/db/prisma.ts'
 import { POST_BLOCK_MEDIA_TYPE, POST_STATUS } from '#/db/generated/enums.ts'
 import type { BlogPost } from '@triskcraft/api-types'
+import { NotFoundError } from '#/api/errors.ts'
 /**
  * Endpoint que entrega el listado de post disponibles para el blog
  * Se aplica caching HTTP para evitar recalcular resultados en llamadas
@@ -116,6 +117,126 @@ export async function getPosts(req: Request, res: Response<BlogPost[]>) {
             })),
         }),
     )
+    res.set('Cache-Control', 'public, max-age=86400')
+    res.json(post_mapped)
+}
+
+export async function getPostsById(
+    req: Request<{ id: string }>,
+    res: Response<BlogPost>,
+) {
+    const id = req.params.id
+    const posts = await db.post.findFirst({
+        where: {
+            status: {
+                not: POST_STATUS.DRAFT,
+            },
+            id,
+        },
+        omit: {
+            thread_id: true,
+            discord_user_id: true,
+            player_uuid: true,
+            status: true,
+            cover_media_id: true,
+        },
+        include: {
+            cover_media: true,
+            post_blocks: {
+                orderBy: {
+                    timestamp: 'asc',
+                },
+                include: {
+                    media: {
+                        orderBy: {
+                            position: 'asc',
+                        },
+                        include: {
+                            media: true,
+                        },
+                    },
+                },
+                omit: {
+                    post_id: true,
+                    message_id: true,
+                    author_id: true,
+                },
+            },
+            discord_user: true,
+            player: {
+                select: {
+                    digs: true,
+                    uuid: true,
+                    nickname: true,
+                    user: {
+                        select: {
+                            linked_roles: {
+                                select: {
+                                    role: {
+                                        select: {
+                                            name: true,
+                                        },
+                                    },
+                                },
+                            },
+                        },
+                    },
+                    linked_roles: {
+                        select: {
+                            role: {
+                                omit: {
+                                    id: true,
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+        },
+    })
+    if (!posts) {
+        throw new NotFoundError()
+    }
+    const post_mapped: BlogPost = [posts].map(
+        ({
+            created_at,
+            cover_media,
+            discord_user,
+            id,
+            title,
+            player,
+            post_blocks,
+            updated_at,
+        }) => ({
+            id,
+            title,
+            cover_image:
+                cover_media?.media_type === POST_BLOCK_MEDIA_TYPE.IMAGE ?
+                    cover_media
+                :   null,
+            user: discord_user,
+            created_at: created_at.getTime(),
+            updated_at: updated_at.getTime(),
+            player:
+                player ?
+                    {
+                        ...player,
+                        uuid: player.uuid,
+                        nickname: player.nickname,
+                        digs: player.digs,
+                        rank:
+                            player.user?.linked_roles[0]?.role.name ??
+                            'Miembro',
+                        roles: player.linked_roles.map(l => l.role.name),
+                    }
+                :   null,
+            post_blocks: post_blocks.map(p => ({
+                ...p,
+                media: p.media.map(({ media }) => media),
+                timestamp: p.timestamp.getTime(),
+            })),
+        }),
+    )[0]!
     res.set('Cache-Control', 'public, max-age=86400')
     res.json(post_mapped)
 }

--- a/src/api/v1/posts/route.ts
+++ b/src/api/v1/posts/route.ts
@@ -1,8 +1,9 @@
 import { Router } from 'express'
-import { getPosts } from '#/api/v1/posts/get.ts'
+import { getPosts, getPostsById } from '#/api/v1/posts/get.ts'
 
 const router = Router()
 
 router.get('/', getPosts)
+router.get('/:id', getPostsById)
 
 export default router


### PR DESCRIPTION
## Resumen
- Agrega el endpoint `GET /v1/posts/:id` para consultar una publicación específica.
- Reutiliza la lógica de armado de posts del endpoint existente.
- Actualiza el router de posts para aceptar el parámetro `:id`.

## Verificación
- Cambio ya commiteado en `dev`: `6a91420 add /v1/posts/:id`
