### PR TITLE
Migra el bot a pnpm y agrega validación de PR

### DIFF
--- a/.agents/skills/nodejs-backend-patterns/SKILL.md
+++ b/.agents/skills/nodejs-backend-patterns/SKILL.md
@@ -1,0 +1,639 @@
+---
+name: nodejs-backend-patterns
+description: Build production-ready Node.js backend services with Express/Fastify, implementing middleware patterns, error handling, authentication, database integration, and API design best practices. Use when creating Node.js servers, REST APIs, GraphQL backends, or microservices architectures.
+---
+
+# Node.js Backend Patterns
+
+Comprehensive guidance for building scalable, maintainable, and production-ready Node.js backend applications with modern frameworks, architectural patterns, and best practices.
+
+## When to Use This Skill
+
+- Building REST APIs or GraphQL servers
+- Creating microservices with Node.js
+- Implementing authentication and authorization
+- Designing scalable backend architectures
+- Setting up middleware and error handling
+- Integrating databases (SQL and NoSQL)
+- Building real-time applications with WebSockets
+- Implementing background job processing
+
+## Core Frameworks
+
+### Express.js - Minimalist Framework
+
+**Basic Setup:**
+
+```typescript
+import express, { Request, Response, NextFunction } from "express";
+import helmet from "helmet";
+import cors from "cors";
+import compression from "compression";
+
+const app = express();
+
+// Security middleware
+app.use(helmet());
+app.use(cors({ origin: process.env.ALLOWED_ORIGINS?.split(",") }));
+app.use(compression());
+
+// Body parsing
+app.use(express.json({ limit: "10mb" }));
+app.use(express.urlencoded({ extended: true, limit: "10mb" }));
+
+// Request logging
+app.use((req: Request, res: Response, next: NextFunction) => {
+  console.log(`${req.method} ${req.path}`);
+  next();
+});
+
+const PORT = process.env.PORT || 3000;
+app.listen(PORT, () => {
+  console.log(`Server running on port ${PORT}`);
+});
+```
+
+### Fastify - High Performance Framework
+
+**Basic Setup:**
+
+```typescript
+import Fastify from "fastify";
+import helmet from "@fastify/helmet";
+import cors from "@fastify/cors";
+import compress from "@fastify/compress";
+
+const fastify = Fastify({
+  logger: {
+    level: process.env.LOG_LEVEL || "info",
+    transport: {
+      target: "pino-pretty",
+      options: { colorize: true },
+    },
+  },
+});
+
+// Plugins
+await fastify.register(helmet);
+await fastify.register(cors, { origin: true });
+await fastify.register(compress);
+
+// Type-safe routes with schema validation
+fastify.post<{
+  Body: { name: string; email: string };
+  Reply: { id: string; name: string };
+}>(
+  "/users",
+  {
+    schema: {
+      body: {
+        type: "object",
+        required: ["name", "email"],
+        properties: {
+          name: { type: "string", minLength: 1 },
+          email: { type: "string", format: "email" },
+        },
+      },
+    },
+  },
+  async (request, reply) => {
+    const { name, email } = request.body;
+    return { id: "123", name };
+  },
+);
+
+await fastify.listen({ port: 3000, host: "0.0.0.0" });
+```
+
+## Architectural Patterns
+
+### Pattern 1: Layered Architecture
+
+**Structure:**
+
+```
+src/
+├── controllers/     # Handle HTTP requests/responses
+├── services/        # Business logic
+├── repositories/    # Data access layer
+├── models/          # Data models
+├── middleware/      # Express/Fastify middleware
+├── routes/          # Route definitions
+├── utils/           # Helper functions
+├── config/          # Configuration
+└── types/           # TypeScript types
+```
+
+**Controller Layer:**
+
+```typescript
+// controllers/user.controller.ts
+import { Request, Response, NextFunction } from "express";
+import { UserService } from "../services/user.service";
+import { CreateUserDTO, UpdateUserDTO } from "../types/user.types";
+
+export class UserController {
+  constructor(private userService: UserService) {}
+
+  async createUser(req: Request, res: Response, next: NextFunction) {
+    try {
+      const userData: CreateUserDTO = req.body;
+      const user = await this.userService.createUser(userData);
+      res.status(201).json(user);
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  async getUser(req: Request, res: Response, next: NextFunction) {
+    try {
+      const { id } = req.params;
+      const user = await this.userService.getUserById(id);
+      res.json(user);
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  async updateUser(req: Request, res: Response, next: NextFunction) {
+    try {
+      const { id } = req.params;
+      const updates: UpdateUserDTO = req.body;
+      const user = await this.userService.updateUser(id, updates);
+      res.json(user);
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  async deleteUser(req: Request, res: Response, next: NextFunction) {
+    try {
+      const { id } = req.params;
+      await this.userService.deleteUser(id);
+      res.status(204).send();
+    } catch (error) {
+      next(error);
+    }
+  }
+}
+```
+
+**Service Layer:**
+
+```typescript
+// services/user.service.ts
+import { UserRepository } from "../repositories/user.repository";
+import { CreateUserDTO, UpdateUserDTO, User } from "../types/user.types";
+import { NotFoundError, ValidationError } from "../utils/errors";
+import bcrypt from "bcrypt";
+
+export class UserService {
+  constructor(private userRepository: UserRepository) {}
+
+  async createUser(userData: CreateUserDTO): Promise<User> {
+    // Validation
+    const existingUser = await this.userRepository.findByEmail(userData.email);
+    if (existingUser) {
+      throw new ValidationError("Email already exists");
+    }
+
+    // Hash password
+    const hashedPassword = await bcrypt.hash(userData.password, 10);
+
+    // Create user
+    const user = await this.userRepository.create({
+      ...userData,
+      password: hashedPassword,
+    });
+
+    // Remove password from response
+    const { password, ...userWithoutPassword } = user;
+    return userWithoutPassword as User;
+  }
+
+  async getUserById(id: string): Promise<User> {
+    const user = await this.userRepository.findById(id);
+    if (!user) {
+      throw new NotFoundError("User not found");
+    }
+    const { password, ...userWithoutPassword } = user;
+    return userWithoutPassword as User;
+  }
+
+  async updateUser(id: string, updates: UpdateUserDTO): Promise<User> {
+    const user = await this.userRepository.update(id, updates);
+    if (!user) {
+      throw new NotFoundError("User not found");
+    }
+    const { password, ...userWithoutPassword } = user;
+    return userWithoutPassword as User;
+  }
+
+  async deleteUser(id: string): Promise<void> {
+    const deleted = await this.userRepository.delete(id);
+    if (!deleted) {
+      throw new NotFoundError("User not found");
+    }
+  }
+}
+```
+
+**Repository Layer:**
+
+```typescript
+// repositories/user.repository.ts
+import { Pool } from "pg";
+import { CreateUserDTO, UpdateUserDTO, UserEntity } from "../types/user.types";
+
+export class UserRepository {
+  constructor(private db: Pool) {}
+
+  async create(
+    userData: CreateUserDTO & { password: string },
+  ): Promise<UserEntity> {
+    const query = `
+      INSERT INTO users (name, email, password)
+      VALUES ($1, $2, $3)
+      RETURNING id, name, email, password, created_at, updated_at
+    `;
+    const { rows } = await this.db.query(query, [
+      userData.name,
+      userData.email,
+      userData.password,
+    ]);
+    return rows[0];
+  }
+
+  async findById(id: string): Promise<UserEntity | null> {
+    const query = "SELECT * FROM users WHERE id = $1";
+    const { rows } = await this.db.query(query, [id]);
+    return rows[0] || null;
+  }
+
+  async findByEmail(email: string): Promise<UserEntity | null> {
+    const query = "SELECT * FROM users WHERE email = $1";
+    const { rows } = await this.db.query(query, [email]);
+    return rows[0] || null;
+  }
+
+  async update(id: string, updates: UpdateUserDTO): Promise<UserEntity | null> {
+    const fields = Object.keys(updates);
+    const values = Object.values(updates);
+
+    const setClause = fields
+      .map((field, idx) => `${field} = $${idx + 2}`)
+      .join(", ");
+
+    const query = `
+      UPDATE users
+      SET ${setClause}, updated_at = CURRENT_TIMESTAMP
+      WHERE id = $1
+      RETURNING *
+    `;
+
+    const { rows } = await this.db.query(query, [id, ...values]);
+    return rows[0] || null;
+  }
+
+  async delete(id: string): Promise<boolean> {
+    const query = "DELETE FROM users WHERE id = $1";
+    const { rowCount } = await this.db.query(query, [id]);
+    return rowCount > 0;
+  }
+}
+```
+
+### Pattern 2: Dependency Injection
+
+Use a DI container to wire up repositories, services, and controllers. For a full container implementation, see [references/advanced-patterns.md](references/advanced-patterns.md).
+
+## Middleware Patterns
+
+### Authentication Middleware
+
+```typescript
+// middleware/auth.middleware.ts
+import { Request, Response, NextFunction } from "express";
+import jwt from "jsonwebtoken";
+import { UnauthorizedError } from "../utils/errors";
+
+interface JWTPayload {
+  userId: string;
+  email: string;
+}
+
+declare global {
+  namespace Express {
+    interface Request {
+      user?: JWTPayload;
+    }
+  }
+}
+
+export const authenticate = async (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+) => {
+  try {
+    const token = req.headers.authorization?.replace("Bearer ", "");
+
+    if (!token) {
+      throw new UnauthorizedError("No token provided");
+    }
+
+    const payload = jwt.verify(token, process.env.JWT_SECRET!) as JWTPayload;
+
+    req.user = payload;
+    next();
+  } catch (error) {
+    next(new UnauthorizedError("Invalid token"));
+  }
+};
+
+export const authorize = (...roles: string[]) => {
+  return async (req: Request, res: Response, next: NextFunction) => {
+    if (!req.user) {
+      return next(new UnauthorizedError("Not authenticated"));
+    }
+
+    // Check if user has required role
+    const hasRole = roles.some((role) => req.user?.roles?.includes(role));
+
+    if (!hasRole) {
+      return next(new UnauthorizedError("Insufficient permissions"));
+    }
+
+    next();
+  };
+};
+```
+
+### Validation Middleware
+
+```typescript
+// middleware/validation.middleware.ts
+import { Request, Response, NextFunction } from "express";
+import { AnyZodObject, ZodError } from "zod";
+import { ValidationError } from "../utils/errors";
+
+export const validate = (schema: AnyZodObject) => {
+  return async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      await schema.parseAsync({
+        body: req.body,
+        query: req.query,
+        params: req.params,
+      });
+      next();
+    } catch (error) {
+      if (error instanceof ZodError) {
+        const errors = error.errors.map((err) => ({
+          field: err.path.join("."),
+          message: err.message,
+        }));
+        next(new ValidationError("Validation failed", errors));
+      } else {
+        next(error);
+      }
+    }
+  };
+};
+
+// Usage with Zod
+import { z } from "zod";
+
+const createUserSchema = z.object({
+  body: z.object({
+    name: z.string().min(1),
+    email: z.string().email(),
+    password: z.string().min(8),
+  }),
+});
+
+router.post("/users", validate(createUserSchema), userController.createUser);
+```
+
+### Rate Limiting Middleware
+
+```typescript
+// middleware/rate-limit.middleware.ts
+import rateLimit from "express-rate-limit";
+import RedisStore from "rate-limit-redis";
+import Redis from "ioredis";
+
+const redis = new Redis({
+  host: process.env.REDIS_HOST,
+  port: parseInt(process.env.REDIS_PORT || "6379"),
+});
+
+export const apiLimiter = rateLimit({
+  store: new RedisStore({
+    client: redis,
+    prefix: "rl:",
+  }),
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // Limit each IP to 100 requests per windowMs
+  message: "Too many requests from this IP, please try again later",
+  standardHeaders: true,
+  legacyHeaders: false,
+});
+
+export const authLimiter = rateLimit({
+  store: new RedisStore({
+    client: redis,
+    prefix: "rl:auth:",
+  }),
+  windowMs: 15 * 60 * 1000,
+  max: 5, // Stricter limit for auth endpoints
+  skipSuccessfulRequests: true,
+});
+```
+
+### Request Logging Middleware
+
+```typescript
+// middleware/logger.middleware.ts
+import { Request, Response, NextFunction } from "express";
+import pino from "pino";
+
+const logger = pino({
+  level: process.env.LOG_LEVEL || "info",
+  transport: {
+    target: "pino-pretty",
+    options: { colorize: true },
+  },
+});
+
+export const requestLogger = (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+) => {
+  const start = Date.now();
+
+  // Log response when finished
+  res.on("finish", () => {
+    const duration = Date.now() - start;
+    logger.info({
+      method: req.method,
+      url: req.url,
+      status: res.statusCode,
+      duration: `${duration}ms`,
+      userAgent: req.headers["user-agent"],
+      ip: req.ip,
+    });
+  });
+
+  next();
+};
+
+export { logger };
+```
+
+## Error Handling
+
+### Custom Error Classes
+
+```typescript
+// utils/errors.ts
+export class AppError extends Error {
+  constructor(
+    public message: string,
+    public statusCode: number = 500,
+    public isOperational: boolean = true,
+  ) {
+    super(message);
+    Object.setPrototypeOf(this, AppError.prototype);
+    Error.captureStackTrace(this, this.constructor);
+  }
+}
+
+export class ValidationError extends AppError {
+  constructor(
+    message: string,
+    public errors?: any[],
+  ) {
+    super(message, 400);
+  }
+}
+
+export class NotFoundError extends AppError {
+  constructor(message: string = "Resource not found") {
+    super(message, 404);
+  }
+}
+
+export class UnauthorizedError extends AppError {
+  constructor(message: string = "Unauthorized") {
+    super(message, 401);
+  }
+}
+
+export class ForbiddenError extends AppError {
+  constructor(message: string = "Forbidden") {
+    super(message, 403);
+  }
+}
+
+export class ConflictError extends AppError {
+  constructor(message: string) {
+    super(message, 409);
+  }
+}
+```
+
+### Global Error Handler
+
+```typescript
+// middleware/error-handler.ts
+import { Request, Response, NextFunction } from "express";
+import { AppError } from "../utils/errors";
+import { logger } from "./logger.middleware";
+
+export const errorHandler = (
+  err: Error,
+  req: Request,
+  res: Response,
+  next: NextFunction,
+) => {
+  if (err instanceof AppError) {
+    return res.status(err.statusCode).json({
+      status: "error",
+      message: err.message,
+      ...(err instanceof ValidationError && { errors: err.errors }),
+    });
+  }
+
+  // Log unexpected errors
+  logger.error({
+    error: err.message,
+    stack: err.stack,
+    url: req.url,
+    method: req.method,
+  });
+
+  // Don't leak error details in production
+  const message =
+    process.env.NODE_ENV === "production"
+      ? "Internal server error"
+      : err.message;
+
+  res.status(500).json({
+    status: "error",
+    message,
+  });
+};
+
+// Async error wrapper
+export const asyncHandler = (
+  fn: (req: Request, res: Response, next: NextFunction) => Promise<any>,
+) => {
+  return (req: Request, res: Response, next: NextFunction) => {
+    Promise.resolve(fn(req, res, next)).catch(next);
+  };
+};
+```
+
+## Database Patterns
+
+Node.js supports both SQL and NoSQL databases. Use connection pooling for all production databases.
+
+Key patterns covered in [references/advanced-patterns.md](references/advanced-patterns.md):
+- **PostgreSQL with connection pool** — `pg` Pool configuration and graceful shutdown
+- **MongoDB with Mongoose** — connection management and schema definition
+- **Transaction pattern** — `BEGIN`/`COMMIT`/`ROLLBACK` with `pg` client
+
+## Authentication & Authorization
+
+JWT-based auth with access tokens (short-lived, 15m) and refresh tokens (7d). Full `AuthService` implementation with `bcrypt` password comparison in [references/advanced-patterns.md](references/advanced-patterns.md).
+
+## Caching Strategies
+
+Redis-backed `CacheService` with get/set/delete/invalidatePattern, plus a `@Cacheable` decorator for method-level caching. See [references/advanced-patterns.md](references/advanced-patterns.md).
+
+## API Response Format
+
+Standardized `ApiResponse` helper with `success`, `error`, and `paginated` static methods. See [references/advanced-patterns.md](references/advanced-patterns.md).
+
+## Best Practices
+
+1. **Use TypeScript**: Type safety prevents runtime errors
+2. **Implement proper error handling**: Use custom error classes
+3. **Validate input**: Use libraries like Zod or Joi
+4. **Use environment variables**: Never hardcode secrets
+5. **Implement logging**: Use structured logging (Pino, Winston)
+6. **Add rate limiting**: Prevent abuse
+7. **Use HTTPS**: Always in production
+8. **Implement CORS properly**: Don't use `*` in production
+9. **Use dependency injection**: Easier testing and maintenance
+10. **Write tests**: Unit, integration, and E2E tests
+11. **Handle graceful shutdown**: Clean up resources
+12. **Use connection pooling**: For databases
+13. **Implement health checks**: For monitoring
+14. **Use compression**: Reduce response size
+15. **Monitor performance**: Use APM tools
+
+## Testing Patterns
+
+See `javascript-testing-patterns` skill for comprehensive testing guidance.

--- a/.agents/skills/nodejs-backend-patterns/SKILL.md
+++ b/.agents/skills/nodejs-backend-patterns/SKILL.md
@@ -25,32 +25,32 @@ Comprehensive guidance for building scalable, maintainable, and production-ready
 **Basic Setup:**
 
 ```typescript
-import express, { Request, Response, NextFunction } from "express";
-import helmet from "helmet";
-import cors from "cors";
-import compression from "compression";
+import express, { Request, Response, NextFunction } from 'express'
+import helmet from 'helmet'
+import cors from 'cors'
+import compression from 'compression'
 
-const app = express();
+const app = express()
 
 // Security middleware
-app.use(helmet());
-app.use(cors({ origin: process.env.ALLOWED_ORIGINS?.split(",") }));
-app.use(compression());
+app.use(helmet())
+app.use(cors({ origin: process.env.ALLOWED_ORIGINS?.split(',') }))
+app.use(compression())
 
 // Body parsing
-app.use(express.json({ limit: "10mb" }));
-app.use(express.urlencoded({ extended: true, limit: "10mb" }));
+app.use(express.json({ limit: '10mb' }))
+app.use(express.urlencoded({ extended: true, limit: '10mb' }))
 
 // Request logging
 app.use((req: Request, res: Response, next: NextFunction) => {
-  console.log(`${req.method} ${req.path}`);
-  next();
-});
+    console.log(`${req.method} ${req.path}`)
+    next()
+})
 
-const PORT = process.env.PORT || 3000;
+const PORT = process.env.PORT || 3000
 app.listen(PORT, () => {
-  console.log(`Server running on port ${PORT}`);
-});
+    console.log(`Server running on port ${PORT}`)
+})
 ```
 
 ### Fastify - High Performance Framework
@@ -58,51 +58,51 @@ app.listen(PORT, () => {
 **Basic Setup:**
 
 ```typescript
-import Fastify from "fastify";
-import helmet from "@fastify/helmet";
-import cors from "@fastify/cors";
-import compress from "@fastify/compress";
+import Fastify from 'fastify'
+import helmet from '@fastify/helmet'
+import cors from '@fastify/cors'
+import compress from '@fastify/compress'
 
 const fastify = Fastify({
-  logger: {
-    level: process.env.LOG_LEVEL || "info",
-    transport: {
-      target: "pino-pretty",
-      options: { colorize: true },
+    logger: {
+        level: process.env.LOG_LEVEL || 'info',
+        transport: {
+            target: 'pino-pretty',
+            options: { colorize: true },
+        },
     },
-  },
-});
+})
 
 // Plugins
-await fastify.register(helmet);
-await fastify.register(cors, { origin: true });
-await fastify.register(compress);
+await fastify.register(helmet)
+await fastify.register(cors, { origin: true })
+await fastify.register(compress)
 
 // Type-safe routes with schema validation
 fastify.post<{
-  Body: { name: string; email: string };
-  Reply: { id: string; name: string };
+    Body: { name: string; email: string }
+    Reply: { id: string; name: string }
 }>(
-  "/users",
-  {
-    schema: {
-      body: {
-        type: "object",
-        required: ["name", "email"],
-        properties: {
-          name: { type: "string", minLength: 1 },
-          email: { type: "string", format: "email" },
+    '/users',
+    {
+        schema: {
+            body: {
+                type: 'object',
+                required: ['name', 'email'],
+                properties: {
+                    name: { type: 'string', minLength: 1 },
+                    email: { type: 'string', format: 'email' },
+                },
+            },
         },
-      },
     },
-  },
-  async (request, reply) => {
-    const { name, email } = request.body;
-    return { id: "123", name };
-  },
-);
+    async (request, reply) => {
+        const { name, email } = request.body
+        return { id: '123', name }
+    },
+)
 
-await fastify.listen({ port: 3000, host: "0.0.0.0" });
+await fastify.listen({ port: 3000, host: '0.0.0.0' })
 ```
 
 ## Architectural Patterns
@@ -128,53 +128,53 @@ src/
 
 ```typescript
 // controllers/user.controller.ts
-import { Request, Response, NextFunction } from "express";
-import { UserService } from "../services/user.service";
-import { CreateUserDTO, UpdateUserDTO } from "../types/user.types";
+import { Request, Response, NextFunction } from 'express'
+import { UserService } from '../services/user.service'
+import { CreateUserDTO, UpdateUserDTO } from '../types/user.types'
 
 export class UserController {
-  constructor(private userService: UserService) {}
+    constructor(private userService: UserService) {}
 
-  async createUser(req: Request, res: Response, next: NextFunction) {
-    try {
-      const userData: CreateUserDTO = req.body;
-      const user = await this.userService.createUser(userData);
-      res.status(201).json(user);
-    } catch (error) {
-      next(error);
+    async createUser(req: Request, res: Response, next: NextFunction) {
+        try {
+            const userData: CreateUserDTO = req.body
+            const user = await this.userService.createUser(userData)
+            res.status(201).json(user)
+        } catch (error) {
+            next(error)
+        }
     }
-  }
 
-  async getUser(req: Request, res: Response, next: NextFunction) {
-    try {
-      const { id } = req.params;
-      const user = await this.userService.getUserById(id);
-      res.json(user);
-    } catch (error) {
-      next(error);
+    async getUser(req: Request, res: Response, next: NextFunction) {
+        try {
+            const { id } = req.params
+            const user = await this.userService.getUserById(id)
+            res.json(user)
+        } catch (error) {
+            next(error)
+        }
     }
-  }
 
-  async updateUser(req: Request, res: Response, next: NextFunction) {
-    try {
-      const { id } = req.params;
-      const updates: UpdateUserDTO = req.body;
-      const user = await this.userService.updateUser(id, updates);
-      res.json(user);
-    } catch (error) {
-      next(error);
+    async updateUser(req: Request, res: Response, next: NextFunction) {
+        try {
+            const { id } = req.params
+            const updates: UpdateUserDTO = req.body
+            const user = await this.userService.updateUser(id, updates)
+            res.json(user)
+        } catch (error) {
+            next(error)
+        }
     }
-  }
 
-  async deleteUser(req: Request, res: Response, next: NextFunction) {
-    try {
-      const { id } = req.params;
-      await this.userService.deleteUser(id);
-      res.status(204).send();
-    } catch (error) {
-      next(error);
+    async deleteUser(req: Request, res: Response, next: NextFunction) {
+        try {
+            const { id } = req.params
+            await this.userService.deleteUser(id)
+            res.status(204).send()
+        } catch (error) {
+            next(error)
+        }
     }
-  }
 }
 ```
 
@@ -182,59 +182,61 @@ export class UserController {
 
 ```typescript
 // services/user.service.ts
-import { UserRepository } from "../repositories/user.repository";
-import { CreateUserDTO, UpdateUserDTO, User } from "../types/user.types";
-import { NotFoundError, ValidationError } from "../utils/errors";
-import bcrypt from "bcrypt";
+import { UserRepository } from '../repositories/user.repository'
+import { CreateUserDTO, UpdateUserDTO, User } from '../types/user.types'
+import { NotFoundError, ValidationError } from '../utils/errors'
+import bcrypt from 'bcrypt'
 
 export class UserService {
-  constructor(private userRepository: UserRepository) {}
+    constructor(private userRepository: UserRepository) {}
 
-  async createUser(userData: CreateUserDTO): Promise<User> {
-    // Validation
-    const existingUser = await this.userRepository.findByEmail(userData.email);
-    if (existingUser) {
-      throw new ValidationError("Email already exists");
+    async createUser(userData: CreateUserDTO): Promise<User> {
+        // Validation
+        const existingUser = await this.userRepository.findByEmail(
+            userData.email,
+        )
+        if (existingUser) {
+            throw new ValidationError('Email already exists')
+        }
+
+        // Hash password
+        const hashedPassword = await bcrypt.hash(userData.password, 10)
+
+        // Create user
+        const user = await this.userRepository.create({
+            ...userData,
+            password: hashedPassword,
+        })
+
+        // Remove password from response
+        const { password, ...userWithoutPassword } = user
+        return userWithoutPassword as User
     }
 
-    // Hash password
-    const hashedPassword = await bcrypt.hash(userData.password, 10);
-
-    // Create user
-    const user = await this.userRepository.create({
-      ...userData,
-      password: hashedPassword,
-    });
-
-    // Remove password from response
-    const { password, ...userWithoutPassword } = user;
-    return userWithoutPassword as User;
-  }
-
-  async getUserById(id: string): Promise<User> {
-    const user = await this.userRepository.findById(id);
-    if (!user) {
-      throw new NotFoundError("User not found");
+    async getUserById(id: string): Promise<User> {
+        const user = await this.userRepository.findById(id)
+        if (!user) {
+            throw new NotFoundError('User not found')
+        }
+        const { password, ...userWithoutPassword } = user
+        return userWithoutPassword as User
     }
-    const { password, ...userWithoutPassword } = user;
-    return userWithoutPassword as User;
-  }
 
-  async updateUser(id: string, updates: UpdateUserDTO): Promise<User> {
-    const user = await this.userRepository.update(id, updates);
-    if (!user) {
-      throw new NotFoundError("User not found");
+    async updateUser(id: string, updates: UpdateUserDTO): Promise<User> {
+        const user = await this.userRepository.update(id, updates)
+        if (!user) {
+            throw new NotFoundError('User not found')
+        }
+        const { password, ...userWithoutPassword } = user
+        return userWithoutPassword as User
     }
-    const { password, ...userWithoutPassword } = user;
-    return userWithoutPassword as User;
-  }
 
-  async deleteUser(id: string): Promise<void> {
-    const deleted = await this.userRepository.delete(id);
-    if (!deleted) {
-      throw new NotFoundError("User not found");
+    async deleteUser(id: string): Promise<void> {
+        const deleted = await this.userRepository.delete(id)
+        if (!deleted) {
+            throw new NotFoundError('User not found')
+        }
     }
-  }
 }
 ```
 
@@ -242,64 +244,67 @@ export class UserService {
 
 ```typescript
 // repositories/user.repository.ts
-import { Pool } from "pg";
-import { CreateUserDTO, UpdateUserDTO, UserEntity } from "../types/user.types";
+import { Pool } from 'pg'
+import { CreateUserDTO, UpdateUserDTO, UserEntity } from '../types/user.types'
 
 export class UserRepository {
-  constructor(private db: Pool) {}
+    constructor(private db: Pool) {}
 
-  async create(
-    userData: CreateUserDTO & { password: string },
-  ): Promise<UserEntity> {
-    const query = `
+    async create(
+        userData: CreateUserDTO & { password: string },
+    ): Promise<UserEntity> {
+        const query = `
       INSERT INTO users (name, email, password)
       VALUES ($1, $2, $3)
       RETURNING id, name, email, password, created_at, updated_at
-    `;
-    const { rows } = await this.db.query(query, [
-      userData.name,
-      userData.email,
-      userData.password,
-    ]);
-    return rows[0];
-  }
+    `
+        const { rows } = await this.db.query(query, [
+            userData.name,
+            userData.email,
+            userData.password,
+        ])
+        return rows[0]
+    }
 
-  async findById(id: string): Promise<UserEntity | null> {
-    const query = "SELECT * FROM users WHERE id = $1";
-    const { rows } = await this.db.query(query, [id]);
-    return rows[0] || null;
-  }
+    async findById(id: string): Promise<UserEntity | null> {
+        const query = 'SELECT * FROM users WHERE id = $1'
+        const { rows } = await this.db.query(query, [id])
+        return rows[0] || null
+    }
 
-  async findByEmail(email: string): Promise<UserEntity | null> {
-    const query = "SELECT * FROM users WHERE email = $1";
-    const { rows } = await this.db.query(query, [email]);
-    return rows[0] || null;
-  }
+    async findByEmail(email: string): Promise<UserEntity | null> {
+        const query = 'SELECT * FROM users WHERE email = $1'
+        const { rows } = await this.db.query(query, [email])
+        return rows[0] || null
+    }
 
-  async update(id: string, updates: UpdateUserDTO): Promise<UserEntity | null> {
-    const fields = Object.keys(updates);
-    const values = Object.values(updates);
+    async update(
+        id: string,
+        updates: UpdateUserDTO,
+    ): Promise<UserEntity | null> {
+        const fields = Object.keys(updates)
+        const values = Object.values(updates)
 
-    const setClause = fields
-      .map((field, idx) => `${field} = $${idx + 2}`)
-      .join(", ");
+        const setClause = fields
+            .map((field, idx) => `${field} = $${idx + 2}`)
+            .join(', ')
 
-    const query = `
+        const query = `
       UPDATE users
       SET ${setClause}, updated_at = CURRENT_TIMESTAMP
       WHERE id = $1
       RETURNING *
-    `;
+    `
 
-    const { rows } = await this.db.query(query, [id, ...values]);
-    return rows[0] || null;
-  }
+        const { rows } = await this.db.query(query, [id, ...values])
+        return rows[0] || null
+    }
 
-  async delete(id: string): Promise<boolean> {
-    const query = "DELETE FROM users WHERE id = $1";
-    const { rowCount } = await this.db.query(query, [id]);
-    return rowCount > 0;
-  }
+    async delete(id: string): Promise<boolean> {
+        const query = 'DELETE FROM users WHERE id = $1'
+        const { rowCount } = await this.db.query(query, [id])
+        return rowCount > 0
+    }
 }
 ```
 
@@ -313,182 +318,182 @@ Use a DI container to wire up repositories, services, and controllers. For a ful
 
 ```typescript
 // middleware/auth.middleware.ts
-import { Request, Response, NextFunction } from "express";
-import jwt from "jsonwebtoken";
-import { UnauthorizedError } from "../utils/errors";
+import { Request, Response, NextFunction } from 'express'
+import jwt from 'jsonwebtoken'
+import { UnauthorizedError } from '../utils/errors'
 
 interface JWTPayload {
-  userId: string;
-  email: string;
+    userId: string
+    email: string
 }
 
 declare global {
-  namespace Express {
-    interface Request {
-      user?: JWTPayload;
+    namespace Express {
+        interface Request {
+            user?: JWTPayload
+        }
     }
-  }
 }
 
 export const authenticate = async (
-  req: Request,
-  res: Response,
-  next: NextFunction,
+    req: Request,
+    res: Response,
+    next: NextFunction,
 ) => {
-  try {
-    const token = req.headers.authorization?.replace("Bearer ", "");
+    try {
+        const token = req.headers.authorization?.replace('Bearer ', '')
 
-    if (!token) {
-      throw new UnauthorizedError("No token provided");
+        if (!token) {
+            throw new UnauthorizedError('No token provided')
+        }
+
+        const payload = jwt.verify(token, process.env.JWT_SECRET!) as JWTPayload
+
+        req.user = payload
+        next()
+    } catch (error) {
+        next(new UnauthorizedError('Invalid token'))
     }
-
-    const payload = jwt.verify(token, process.env.JWT_SECRET!) as JWTPayload;
-
-    req.user = payload;
-    next();
-  } catch (error) {
-    next(new UnauthorizedError("Invalid token"));
-  }
-};
+}
 
 export const authorize = (...roles: string[]) => {
-  return async (req: Request, res: Response, next: NextFunction) => {
-    if (!req.user) {
-      return next(new UnauthorizedError("Not authenticated"));
+    return async (req: Request, res: Response, next: NextFunction) => {
+        if (!req.user) {
+            return next(new UnauthorizedError('Not authenticated'))
+        }
+
+        // Check if user has required role
+        const hasRole = roles.some(role => req.user?.roles?.includes(role))
+
+        if (!hasRole) {
+            return next(new UnauthorizedError('Insufficient permissions'))
+        }
+
+        next()
     }
-
-    // Check if user has required role
-    const hasRole = roles.some((role) => req.user?.roles?.includes(role));
-
-    if (!hasRole) {
-      return next(new UnauthorizedError("Insufficient permissions"));
-    }
-
-    next();
-  };
-};
+}
 ```
 
 ### Validation Middleware
 
 ```typescript
 // middleware/validation.middleware.ts
-import { Request, Response, NextFunction } from "express";
-import { AnyZodObject, ZodError } from "zod";
-import { ValidationError } from "../utils/errors";
+import { Request, Response, NextFunction } from 'express'
+import { AnyZodObject, ZodError } from 'zod'
+import { ValidationError } from '../utils/errors'
 
 export const validate = (schema: AnyZodObject) => {
-  return async (req: Request, res: Response, next: NextFunction) => {
-    try {
-      await schema.parseAsync({
-        body: req.body,
-        query: req.query,
-        params: req.params,
-      });
-      next();
-    } catch (error) {
-      if (error instanceof ZodError) {
-        const errors = error.errors.map((err) => ({
-          field: err.path.join("."),
-          message: err.message,
-        }));
-        next(new ValidationError("Validation failed", errors));
-      } else {
-        next(error);
-      }
+    return async (req: Request, res: Response, next: NextFunction) => {
+        try {
+            await schema.parseAsync({
+                body: req.body,
+                query: req.query,
+                params: req.params,
+            })
+            next()
+        } catch (error) {
+            if (error instanceof ZodError) {
+                const errors = error.errors.map(err => ({
+                    field: err.path.join('.'),
+                    message: err.message,
+                }))
+                next(new ValidationError('Validation failed', errors))
+            } else {
+                next(error)
+            }
+        }
     }
-  };
-};
+}
 
 // Usage with Zod
-import { z } from "zod";
+import { z } from 'zod'
 
 const createUserSchema = z.object({
-  body: z.object({
-    name: z.string().min(1),
-    email: z.string().email(),
-    password: z.string().min(8),
-  }),
-});
+    body: z.object({
+        name: z.string().min(1),
+        email: z.string().email(),
+        password: z.string().min(8),
+    }),
+})
 
-router.post("/users", validate(createUserSchema), userController.createUser);
+router.post('/users', validate(createUserSchema), userController.createUser)
 ```
 
 ### Rate Limiting Middleware
 
 ```typescript
 // middleware/rate-limit.middleware.ts
-import rateLimit from "express-rate-limit";
-import RedisStore from "rate-limit-redis";
-import Redis from "ioredis";
+import rateLimit from 'express-rate-limit'
+import RedisStore from 'rate-limit-redis'
+import Redis from 'ioredis'
 
 const redis = new Redis({
-  host: process.env.REDIS_HOST,
-  port: parseInt(process.env.REDIS_PORT || "6379"),
-});
+    host: process.env.REDIS_HOST,
+    port: parseInt(process.env.REDIS_PORT || '6379'),
+})
 
 export const apiLimiter = rateLimit({
-  store: new RedisStore({
-    client: redis,
-    prefix: "rl:",
-  }),
-  windowMs: 15 * 60 * 1000, // 15 minutes
-  max: 100, // Limit each IP to 100 requests per windowMs
-  message: "Too many requests from this IP, please try again later",
-  standardHeaders: true,
-  legacyHeaders: false,
-});
+    store: new RedisStore({
+        client: redis,
+        prefix: 'rl:',
+    }),
+    windowMs: 15 * 60 * 1000, // 15 minutes
+    max: 100, // Limit each IP to 100 requests per windowMs
+    message: 'Too many requests from this IP, please try again later',
+    standardHeaders: true,
+    legacyHeaders: false,
+})
 
 export const authLimiter = rateLimit({
-  store: new RedisStore({
-    client: redis,
-    prefix: "rl:auth:",
-  }),
-  windowMs: 15 * 60 * 1000,
-  max: 5, // Stricter limit for auth endpoints
-  skipSuccessfulRequests: true,
-});
+    store: new RedisStore({
+        client: redis,
+        prefix: 'rl:auth:',
+    }),
+    windowMs: 15 * 60 * 1000,
+    max: 5, // Stricter limit for auth endpoints
+    skipSuccessfulRequests: true,
+})
 ```
 
 ### Request Logging Middleware
 
 ```typescript
 // middleware/logger.middleware.ts
-import { Request, Response, NextFunction } from "express";
-import pino from "pino";
+import { Request, Response, NextFunction } from 'express'
+import pino from 'pino'
 
 const logger = pino({
-  level: process.env.LOG_LEVEL || "info",
-  transport: {
-    target: "pino-pretty",
-    options: { colorize: true },
-  },
-});
+    level: process.env.LOG_LEVEL || 'info',
+    transport: {
+        target: 'pino-pretty',
+        options: { colorize: true },
+    },
+})
 
 export const requestLogger = (
-  req: Request,
-  res: Response,
-  next: NextFunction,
+    req: Request,
+    res: Response,
+    next: NextFunction,
 ) => {
-  const start = Date.now();
+    const start = Date.now()
 
-  // Log response when finished
-  res.on("finish", () => {
-    const duration = Date.now() - start;
-    logger.info({
-      method: req.method,
-      url: req.url,
-      status: res.statusCode,
-      duration: `${duration}ms`,
-      userAgent: req.headers["user-agent"],
-      ip: req.ip,
-    });
-  });
+    // Log response when finished
+    res.on('finish', () => {
+        const duration = Date.now() - start
+        logger.info({
+            method: req.method,
+            url: req.url,
+            status: res.statusCode,
+            duration: `${duration}ms`,
+            userAgent: req.headers['user-agent'],
+            ip: req.ip,
+        })
+    })
 
-  next();
-};
+    next()
+}
 
-export { logger };
+export { logger }
 ```
 
 ## Error Handling
@@ -498,48 +503,48 @@ export { logger };
 ```typescript
 // utils/errors.ts
 export class AppError extends Error {
-  constructor(
-    public message: string,
-    public statusCode: number = 500,
-    public isOperational: boolean = true,
-  ) {
-    super(message);
-    Object.setPrototypeOf(this, AppError.prototype);
-    Error.captureStackTrace(this, this.constructor);
-  }
+    constructor(
+        public message: string,
+        public statusCode: number = 500,
+        public isOperational: boolean = true,
+    ) {
+        super(message)
+        Object.setPrototypeOf(this, AppError.prototype)
+        Error.captureStackTrace(this, this.constructor)
+    }
 }
 
 export class ValidationError extends AppError {
-  constructor(
-    message: string,
-    public errors?: any[],
-  ) {
-    super(message, 400);
-  }
+    constructor(
+        message: string,
+        public errors?: any[],
+    ) {
+        super(message, 400)
+    }
 }
 
 export class NotFoundError extends AppError {
-  constructor(message: string = "Resource not found") {
-    super(message, 404);
-  }
+    constructor(message: string = 'Resource not found') {
+        super(message, 404)
+    }
 }
 
 export class UnauthorizedError extends AppError {
-  constructor(message: string = "Unauthorized") {
-    super(message, 401);
-  }
+    constructor(message: string = 'Unauthorized') {
+        super(message, 401)
+    }
 }
 
 export class ForbiddenError extends AppError {
-  constructor(message: string = "Forbidden") {
-    super(message, 403);
-  }
+    constructor(message: string = 'Forbidden') {
+        super(message, 403)
+    }
 }
 
 export class ConflictError extends AppError {
-  constructor(message: string) {
-    super(message, 409);
-  }
+    constructor(message: string) {
+        super(message, 409)
+    }
 }
 ```
 
@@ -547,52 +552,52 @@ export class ConflictError extends AppError {
 
 ```typescript
 // middleware/error-handler.ts
-import { Request, Response, NextFunction } from "express";
-import { AppError } from "../utils/errors";
-import { logger } from "./logger.middleware";
+import { Request, Response, NextFunction } from 'express'
+import { AppError } from '../utils/errors'
+import { logger } from './logger.middleware'
 
 export const errorHandler = (
-  err: Error,
-  req: Request,
-  res: Response,
-  next: NextFunction,
+    err: Error,
+    req: Request,
+    res: Response,
+    next: NextFunction,
 ) => {
-  if (err instanceof AppError) {
-    return res.status(err.statusCode).json({
-      status: "error",
-      message: err.message,
-      ...(err instanceof ValidationError && { errors: err.errors }),
-    });
-  }
+    if (err instanceof AppError) {
+        return res.status(err.statusCode).json({
+            status: 'error',
+            message: err.message,
+            ...(err instanceof ValidationError && { errors: err.errors }),
+        })
+    }
 
-  // Log unexpected errors
-  logger.error({
-    error: err.message,
-    stack: err.stack,
-    url: req.url,
-    method: req.method,
-  });
+    // Log unexpected errors
+    logger.error({
+        error: err.message,
+        stack: err.stack,
+        url: req.url,
+        method: req.method,
+    })
 
-  // Don't leak error details in production
-  const message =
-    process.env.NODE_ENV === "production"
-      ? "Internal server error"
-      : err.message;
+    // Don't leak error details in production
+    const message =
+        process.env.NODE_ENV === 'production' ?
+            'Internal server error'
+        :   err.message
 
-  res.status(500).json({
-    status: "error",
-    message,
-  });
-};
+    res.status(500).json({
+        status: 'error',
+        message,
+    })
+}
 
 // Async error wrapper
 export const asyncHandler = (
-  fn: (req: Request, res: Response, next: NextFunction) => Promise<any>,
+    fn: (req: Request, res: Response, next: NextFunction) => Promise<any>,
 ) => {
-  return (req: Request, res: Response, next: NextFunction) => {
-    Promise.resolve(fn(req, res, next)).catch(next);
-  };
-};
+    return (req: Request, res: Response, next: NextFunction) => {
+        Promise.resolve(fn(req, res, next)).catch(next)
+    }
+}
 ```
 
 ## Database Patterns
@@ -600,6 +605,7 @@ export const asyncHandler = (
 Node.js supports both SQL and NoSQL databases. Use connection pooling for all production databases.
 
 Key patterns covered in [references/advanced-patterns.md](references/advanced-patterns.md):
+
 - **PostgreSQL with connection pool** — `pg` Pool configuration and graceful shutdown
 - **MongoDB with Mongoose** — connection management and schema definition
 - **Transaction pattern** — `BEGIN`/`COMMIT`/`ROLLBACK` with `pg` client

--- a/.agents/skills/nodejs-backend-patterns/references/advanced-patterns.md
+++ b/.agents/skills/nodejs-backend-patterns/references/advanced-patterns.md
@@ -1,0 +1,430 @@
+# Node.js Advanced Patterns
+
+Advanced patterns for dependency injection, database integration, authentication, caching, and API response formatting.
+
+## Dependency Injection
+
+### DI Container
+
+```typescript
+// di-container.ts
+import { Pool } from "pg";
+import { UserRepository } from "./repositories/user.repository";
+import { UserService } from "./services/user.service";
+import { UserController } from "./controllers/user.controller";
+import { AuthService } from "./services/auth.service";
+
+class Container {
+  private instances = new Map<string, any>();
+
+  register<T>(key: string, factory: () => T): void {
+    this.instances.set(key, factory);
+  }
+
+  resolve<T>(key: string): T {
+    const factory = this.instances.get(key);
+    if (!factory) {
+      throw new Error(`No factory registered for ${key}`);
+    }
+    return factory();
+  }
+
+  singleton<T>(key: string, factory: () => T): void {
+    let instance: T;
+    this.instances.set(key, () => {
+      if (!instance) {
+        instance = factory();
+      }
+      return instance;
+    });
+  }
+}
+
+export const container = new Container();
+
+// Register dependencies
+container.singleton(
+  "db",
+  () =>
+    new Pool({
+      host: process.env.DB_HOST,
+      port: parseInt(process.env.DB_PORT || "5432"),
+      database: process.env.DB_NAME,
+      user: process.env.DB_USER,
+      password: process.env.DB_PASSWORD,
+      max: 20,
+      idleTimeoutMillis: 30000,
+      connectionTimeoutMillis: 2000,
+    }),
+);
+
+container.singleton(
+  "userRepository",
+  () => new UserRepository(container.resolve("db")),
+);
+
+container.singleton(
+  "userService",
+  () => new UserService(container.resolve("userRepository")),
+);
+
+container.register(
+  "userController",
+  () => new UserController(container.resolve("userService")),
+);
+
+container.singleton(
+  "authService",
+  () => new AuthService(container.resolve("userRepository")),
+);
+```
+
+## Database Patterns
+
+### PostgreSQL with Connection Pool
+
+```typescript
+// config/database.ts
+import { Pool, PoolConfig } from "pg";
+
+const poolConfig: PoolConfig = {
+  host: process.env.DB_HOST,
+  port: parseInt(process.env.DB_PORT || "5432"),
+  database: process.env.DB_NAME,
+  user: process.env.DB_USER,
+  password: process.env.DB_PASSWORD,
+  max: 20,
+  idleTimeoutMillis: 30000,
+  connectionTimeoutMillis: 2000,
+};
+
+export const pool = new Pool(poolConfig);
+
+// Test connection
+pool.on("connect", () => {
+  console.log("Database connected");
+});
+
+pool.on("error", (err) => {
+  console.error("Unexpected database error", err);
+  process.exit(-1);
+});
+
+// Graceful shutdown
+export const closeDatabase = async () => {
+  await pool.end();
+  console.log("Database connection closed");
+};
+```
+
+### MongoDB with Mongoose
+
+```typescript
+// config/mongoose.ts
+import mongoose from "mongoose";
+
+const connectDB = async () => {
+  try {
+    await mongoose.connect(process.env.MONGODB_URI!, {
+      maxPoolSize: 10,
+      serverSelectionTimeoutMS: 5000,
+      socketTimeoutMS: 45000,
+    });
+
+    console.log("MongoDB connected");
+  } catch (error) {
+    console.error("MongoDB connection error:", error);
+    process.exit(1);
+  }
+};
+
+mongoose.connection.on("disconnected", () => {
+  console.log("MongoDB disconnected");
+});
+
+mongoose.connection.on("error", (err) => {
+  console.error("MongoDB error:", err);
+});
+
+export { connectDB };
+
+// Model example
+import { Schema, model, Document } from "mongoose";
+
+interface IUser extends Document {
+  name: string;
+  email: string;
+  password: string;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+const userSchema = new Schema<IUser>(
+  {
+    name: { type: String, required: true },
+    email: { type: String, required: true, unique: true },
+    password: { type: String, required: true },
+  },
+  {
+    timestamps: true,
+  },
+);
+
+// Indexes
+userSchema.index({ email: 1 });
+
+export const User = model<IUser>("User", userSchema);
+```
+
+### Transaction Pattern
+
+```typescript
+// services/order.service.ts
+import { Pool } from "pg";
+
+export class OrderService {
+  constructor(private db: Pool) {}
+
+  async createOrder(userId: string, items: any[]) {
+    const client = await this.db.connect();
+
+    try {
+      await client.query("BEGIN");
+
+      // Create order
+      const orderResult = await client.query(
+        "INSERT INTO orders (user_id, total) VALUES ($1, $2) RETURNING id",
+        [userId, calculateTotal(items)],
+      );
+      const orderId = orderResult.rows[0].id;
+
+      // Create order items
+      for (const item of items) {
+        await client.query(
+          "INSERT INTO order_items (order_id, product_id, quantity, price) VALUES ($1, $2, $3, $4)",
+          [orderId, item.productId, item.quantity, item.price],
+        );
+
+        // Update inventory
+        await client.query(
+          "UPDATE products SET stock = stock - $1 WHERE id = $2",
+          [item.quantity, item.productId],
+        );
+      }
+
+      await client.query("COMMIT");
+      return orderId;
+    } catch (error) {
+      await client.query("ROLLBACK");
+      throw error;
+    } finally {
+      client.release();
+    }
+  }
+}
+```
+
+## Authentication & Authorization
+
+### JWT Authentication
+
+```typescript
+// services/auth.service.ts
+import jwt from "jsonwebtoken";
+import bcrypt from "bcrypt";
+import { UserRepository } from "../repositories/user.repository";
+import { UnauthorizedError } from "../utils/errors";
+
+export class AuthService {
+  constructor(private userRepository: UserRepository) {}
+
+  async login(email: string, password: string) {
+    const user = await this.userRepository.findByEmail(email);
+
+    if (!user) {
+      throw new UnauthorizedError("Invalid credentials");
+    }
+
+    const isValid = await bcrypt.compare(password, user.password);
+
+    if (!isValid) {
+      throw new UnauthorizedError("Invalid credentials");
+    }
+
+    const token = this.generateToken({
+      userId: user.id,
+      email: user.email,
+    });
+
+    const refreshToken = this.generateRefreshToken({
+      userId: user.id,
+    });
+
+    return {
+      token,
+      refreshToken,
+      user: {
+        id: user.id,
+        name: user.name,
+        email: user.email,
+      },
+    };
+  }
+
+  async refreshToken(refreshToken: string) {
+    try {
+      const payload = jwt.verify(
+        refreshToken,
+        process.env.REFRESH_TOKEN_SECRET!,
+      ) as { userId: string };
+
+      const user = await this.userRepository.findById(payload.userId);
+
+      if (!user) {
+        throw new UnauthorizedError("User not found");
+      }
+
+      const token = this.generateToken({
+        userId: user.id,
+        email: user.email,
+      });
+
+      return { token };
+    } catch (error) {
+      throw new UnauthorizedError("Invalid refresh token");
+    }
+  }
+
+  private generateToken(payload: any): string {
+    return jwt.sign(payload, process.env.JWT_SECRET!, {
+      expiresIn: "15m",
+    });
+  }
+
+  private generateRefreshToken(payload: any): string {
+    return jwt.sign(payload, process.env.REFRESH_TOKEN_SECRET!, {
+      expiresIn: "7d",
+    });
+  }
+}
+```
+
+## Caching Strategies
+
+```typescript
+// utils/cache.ts
+import Redis from "ioredis";
+
+const redis = new Redis({
+  host: process.env.REDIS_HOST,
+  port: parseInt(process.env.REDIS_PORT || "6379"),
+  retryStrategy: (times) => {
+    const delay = Math.min(times * 50, 2000);
+    return delay;
+  },
+});
+
+export class CacheService {
+  async get<T>(key: string): Promise<T | null> {
+    const data = await redis.get(key);
+    return data ? JSON.parse(data) : null;
+  }
+
+  async set(key: string, value: any, ttl?: number): Promise<void> {
+    const serialized = JSON.stringify(value);
+    if (ttl) {
+      await redis.setex(key, ttl, serialized);
+    } else {
+      await redis.set(key, serialized);
+    }
+  }
+
+  async delete(key: string): Promise<void> {
+    await redis.del(key);
+  }
+
+  async invalidatePattern(pattern: string): Promise<void> {
+    const keys = await redis.keys(pattern);
+    if (keys.length > 0) {
+      await redis.del(...keys);
+    }
+  }
+}
+
+// Cache decorator
+export function Cacheable(ttl: number = 300) {
+  return function (
+    target: any,
+    propertyKey: string,
+    descriptor: PropertyDescriptor,
+  ) {
+    const originalMethod = descriptor.value;
+
+    descriptor.value = async function (...args: any[]) {
+      const cache = new CacheService();
+      const cacheKey = `${propertyKey}:${JSON.stringify(args)}`;
+
+      const cached = await cache.get(cacheKey);
+      if (cached) {
+        return cached;
+      }
+
+      const result = await originalMethod.apply(this, args);
+      await cache.set(cacheKey, result, ttl);
+
+      return result;
+    };
+
+    return descriptor;
+  };
+}
+```
+
+## API Response Format
+
+```typescript
+// utils/response.ts
+import { Response } from "express";
+
+export class ApiResponse {
+  static success<T>(
+    res: Response,
+    data: T,
+    message?: string,
+    statusCode = 200,
+  ) {
+    return res.status(statusCode).json({
+      status: "success",
+      message,
+      data,
+    });
+  }
+
+  static error(res: Response, message: string, statusCode = 500, errors?: any) {
+    return res.status(statusCode).json({
+      status: "error",
+      message,
+      ...(errors && { errors }),
+    });
+  }
+
+  static paginated<T>(
+    res: Response,
+    data: T[],
+    page: number,
+    limit: number,
+    total: number,
+  ) {
+    return res.json({
+      status: "success",
+      data,
+      pagination: {
+        page,
+        limit,
+        total,
+        pages: Math.ceil(total / limit),
+      },
+    });
+  }
+}
+```

--- a/.agents/skills/nodejs-backend-patterns/references/advanced-patterns.md
+++ b/.agents/skills/nodejs-backend-patterns/references/advanced-patterns.md
@@ -8,75 +8,75 @@ Advanced patterns for dependency injection, database integration, authentication
 
 ```typescript
 // di-container.ts
-import { Pool } from "pg";
-import { UserRepository } from "./repositories/user.repository";
-import { UserService } from "./services/user.service";
-import { UserController } from "./controllers/user.controller";
-import { AuthService } from "./services/auth.service";
+import { Pool } from 'pg'
+import { UserRepository } from './repositories/user.repository'
+import { UserService } from './services/user.service'
+import { UserController } from './controllers/user.controller'
+import { AuthService } from './services/auth.service'
 
 class Container {
-  private instances = new Map<string, any>();
+    private instances = new Map<string, any>()
 
-  register<T>(key: string, factory: () => T): void {
-    this.instances.set(key, factory);
-  }
-
-  resolve<T>(key: string): T {
-    const factory = this.instances.get(key);
-    if (!factory) {
-      throw new Error(`No factory registered for ${key}`);
+    register<T>(key: string, factory: () => T): void {
+        this.instances.set(key, factory)
     }
-    return factory();
-  }
 
-  singleton<T>(key: string, factory: () => T): void {
-    let instance: T;
-    this.instances.set(key, () => {
-      if (!instance) {
-        instance = factory();
-      }
-      return instance;
-    });
-  }
+    resolve<T>(key: string): T {
+        const factory = this.instances.get(key)
+        if (!factory) {
+            throw new Error(`No factory registered for ${key}`)
+        }
+        return factory()
+    }
+
+    singleton<T>(key: string, factory: () => T): void {
+        let instance: T
+        this.instances.set(key, () => {
+            if (!instance) {
+                instance = factory()
+            }
+            return instance
+        })
+    }
 }
 
-export const container = new Container();
+export const container = new Container()
 
 // Register dependencies
 container.singleton(
-  "db",
-  () =>
-    new Pool({
-      host: process.env.DB_HOST,
-      port: parseInt(process.env.DB_PORT || "5432"),
-      database: process.env.DB_NAME,
-      user: process.env.DB_USER,
-      password: process.env.DB_PASSWORD,
-      max: 20,
-      idleTimeoutMillis: 30000,
-      connectionTimeoutMillis: 2000,
-    }),
-);
+    'db',
+    () =>
+        new Pool({
+            host: process.env.DB_HOST,
+            port: parseInt(process.env.DB_PORT || '5432'),
+            database: process.env.DB_NAME,
+            user: process.env.DB_USER,
+            password: process.env.DB_PASSWORD,
+            max: 20,
+            idleTimeoutMillis: 30000,
+            connectionTimeoutMillis: 2000,
+        }),
+)
 
 container.singleton(
-  "userRepository",
-  () => new UserRepository(container.resolve("db")),
-);
+    'userRepository',
+    () => new UserRepository(container.resolve('db')),
+)
 
 container.singleton(
-  "userService",
-  () => new UserService(container.resolve("userRepository")),
-);
+    'userService',
+    () => new UserService(container.resolve('userRepository')),
+)
 
 container.register(
-  "userController",
-  () => new UserController(container.resolve("userService")),
-);
+    'userController',
+    () => new UserController(container.resolve('userService')),
+)
 
 container.singleton(
-  "authService",
-  () => new AuthService(container.resolve("userRepository")),
-);
+    'authService',
+    () => new AuthService(container.resolve('userRepository')),
+)
 ```
 
 ## Database Patterns
@@ -85,142 +85,142 @@ container.singleton(
 
 ```typescript
 // config/database.ts
-import { Pool, PoolConfig } from "pg";
+import { Pool, PoolConfig } from 'pg'
 
 const poolConfig: PoolConfig = {
-  host: process.env.DB_HOST,
-  port: parseInt(process.env.DB_PORT || "5432"),
-  database: process.env.DB_NAME,
-  user: process.env.DB_USER,
-  password: process.env.DB_PASSWORD,
-  max: 20,
-  idleTimeoutMillis: 30000,
-  connectionTimeoutMillis: 2000,
-};
+    host: process.env.DB_HOST,
+    port: parseInt(process.env.DB_PORT || '5432'),
+    database: process.env.DB_NAME,
+    user: process.env.DB_USER,
+    password: process.env.DB_PASSWORD,
+    max: 20,
+    idleTimeoutMillis: 30000,
+    connectionTimeoutMillis: 2000,
+}
 
-export const pool = new Pool(poolConfig);
+export const pool = new Pool(poolConfig)
 
 // Test connection
-pool.on("connect", () => {
-  console.log("Database connected");
-});
+pool.on('connect', () => {
+    console.log('Database connected')
+})
 
-pool.on("error", (err) => {
-  console.error("Unexpected database error", err);
-  process.exit(-1);
-});
+pool.on('error', err => {
+    console.error('Unexpected database error', err)
+    process.exit(-1)
+})
 
 // Graceful shutdown
 export const closeDatabase = async () => {
-  await pool.end();
-  console.log("Database connection closed");
-};
+    await pool.end()
+    console.log('Database connection closed')
+}
 ```
 
 ### MongoDB with Mongoose
 
 ```typescript
 // config/mongoose.ts
-import mongoose from "mongoose";
+import mongoose from 'mongoose'
 
 const connectDB = async () => {
-  try {
-    await mongoose.connect(process.env.MONGODB_URI!, {
-      maxPoolSize: 10,
-      serverSelectionTimeoutMS: 5000,
-      socketTimeoutMS: 45000,
-    });
+    try {
+        await mongoose.connect(process.env.MONGODB_URI!, {
+            maxPoolSize: 10,
+            serverSelectionTimeoutMS: 5000,
+            socketTimeoutMS: 45000,
+        })
 
-    console.log("MongoDB connected");
-  } catch (error) {
-    console.error("MongoDB connection error:", error);
-    process.exit(1);
-  }
-};
+        console.log('MongoDB connected')
+    } catch (error) {
+        console.error('MongoDB connection error:', error)
+        process.exit(1)
+    }
+}
 
-mongoose.connection.on("disconnected", () => {
-  console.log("MongoDB disconnected");
-});
+mongoose.connection.on('disconnected', () => {
+    console.log('MongoDB disconnected')
+})
 
-mongoose.connection.on("error", (err) => {
-  console.error("MongoDB error:", err);
-});
+mongoose.connection.on('error', err => {
+    console.error('MongoDB error:', err)
+})
 
-export { connectDB };
+export { connectDB }
 
 // Model example
-import { Schema, model, Document } from "mongoose";
+import { Schema, model, Document } from 'mongoose'
 
 interface IUser extends Document {
-  name: string;
-  email: string;
-  password: string;
-  createdAt: Date;
-  updatedAt: Date;
+    name: string
+    email: string
+    password: string
+    createdAt: Date
+    updatedAt: Date
 }
 
 const userSchema = new Schema<IUser>(
-  {
-    name: { type: String, required: true },
-    email: { type: String, required: true, unique: true },
-    password: { type: String, required: true },
-  },
-  {
-    timestamps: true,
-  },
-);
+    {
+        name: { type: String, required: true },
+        email: { type: String, required: true, unique: true },
+        password: { type: String, required: true },
+    },
+    {
+        timestamps: true,
+    },
+)
 
 // Indexes
-userSchema.index({ email: 1 });
+userSchema.index({ email: 1 })
 
-export const User = model<IUser>("User", userSchema);
+export const User = model<IUser>('User', userSchema)
 ```
 
 ### Transaction Pattern
 
 ```typescript
 // services/order.service.ts
-import { Pool } from "pg";
+import { Pool } from 'pg'
 
 export class OrderService {
-  constructor(private db: Pool) {}
+    constructor(private db: Pool) {}
 
-  async createOrder(userId: string, items: any[]) {
-    const client = await this.db.connect();
+    async createOrder(userId: string, items: any[]) {
+        const client = await this.db.connect()
 
-    try {
-      await client.query("BEGIN");
+        try {
+            await client.query('BEGIN')
 
-      // Create order
-      const orderResult = await client.query(
-        "INSERT INTO orders (user_id, total) VALUES ($1, $2) RETURNING id",
-        [userId, calculateTotal(items)],
-      );
-      const orderId = orderResult.rows[0].id;
+            // Create order
+            const orderResult = await client.query(
+                'INSERT INTO orders (user_id, total) VALUES ($1, $2) RETURNING id',
+                [userId, calculateTotal(items)],
+            )
+            const orderId = orderResult.rows[0].id
 
-      // Create order items
-      for (const item of items) {
-        await client.query(
-          "INSERT INTO order_items (order_id, product_id, quantity, price) VALUES ($1, $2, $3, $4)",
-          [orderId, item.productId, item.quantity, item.price],
-        );
+            // Create order items
+            for (const item of items) {
+                await client.query(
+                    'INSERT INTO order_items (order_id, product_id, quantity, price) VALUES ($1, $2, $3, $4)',
+                    [orderId, item.productId, item.quantity, item.price],
+                )
 
-        // Update inventory
-        await client.query(
-          "UPDATE products SET stock = stock - $1 WHERE id = $2",
-          [item.quantity, item.productId],
-        );
-      }
+                // Update inventory
+                await client.query(
+                    'UPDATE products SET stock = stock - $1 WHERE id = $2',
+                    [item.quantity, item.productId],
+                )
+            }
 
-      await client.query("COMMIT");
-      return orderId;
-    } catch (error) {
-      await client.query("ROLLBACK");
-      throw error;
-    } finally {
-      client.release();
+            await client.query('COMMIT')
+            return orderId
+        } catch (error) {
+            await client.query('ROLLBACK')
+            throw error
+        } finally {
+            client.release()
+        }
     }
-  }
 }
 ```
 
@@ -230,82 +230,82 @@ export class OrderService {
 
 ```typescript
 // services/auth.service.ts
-import jwt from "jsonwebtoken";
-import bcrypt from "bcrypt";
-import { UserRepository } from "../repositories/user.repository";
-import { UnauthorizedError } from "../utils/errors";
+import jwt from 'jsonwebtoken'
+import bcrypt from 'bcrypt'
+import { UserRepository } from '../repositories/user.repository'
+import { UnauthorizedError } from '../utils/errors'
 
 export class AuthService {
-  constructor(private userRepository: UserRepository) {}
+    constructor(private userRepository: UserRepository) {}
 
-  async login(email: string, password: string) {
-    const user = await this.userRepository.findByEmail(email);
+    async login(email: string, password: string) {
+        const user = await this.userRepository.findByEmail(email)
 
-    if (!user) {
-      throw new UnauthorizedError("Invalid credentials");
+        if (!user) {
+            throw new UnauthorizedError('Invalid credentials')
+        }
+
+        const isValid = await bcrypt.compare(password, user.password)
+
+        if (!isValid) {
+            throw new UnauthorizedError('Invalid credentials')
+        }
+
+        const token = this.generateToken({
+            userId: user.id,
+            email: user.email,
+        })
+
+        const refreshToken = this.generateRefreshToken({
+            userId: user.id,
+        })
+
+        return {
+            token,
+            refreshToken,
+            user: {
+                id: user.id,
+                name: user.name,
+                email: user.email,
+            },
+        }
     }
 
-    const isValid = await bcrypt.compare(password, user.password);
+    async refreshToken(refreshToken: string) {
+        try {
+            const payload = jwt.verify(
+                refreshToken,
+                process.env.REFRESH_TOKEN_SECRET!,
+            ) as { userId: string }
 
-    if (!isValid) {
-      throw new UnauthorizedError("Invalid credentials");
+            const user = await this.userRepository.findById(payload.userId)
+
+            if (!user) {
+                throw new UnauthorizedError('User not found')
+            }
+
+            const token = this.generateToken({
+                userId: user.id,
+                email: user.email,
+            })
+
+            return { token }
+        } catch (error) {
+            throw new UnauthorizedError('Invalid refresh token')
+        }
     }
 
-    const token = this.generateToken({
-      userId: user.id,
-      email: user.email,
-    });
-
-    const refreshToken = this.generateRefreshToken({
-      userId: user.id,
-    });
-
-    return {
-      token,
-      refreshToken,
-      user: {
-        id: user.id,
-        name: user.name,
-        email: user.email,
-      },
-    };
-  }
-
-  async refreshToken(refreshToken: string) {
-    try {
-      const payload = jwt.verify(
-        refreshToken,
-        process.env.REFRESH_TOKEN_SECRET!,
-      ) as { userId: string };
-
-      const user = await this.userRepository.findById(payload.userId);
-
-      if (!user) {
-        throw new UnauthorizedError("User not found");
-      }
-
-      const token = this.generateToken({
-        userId: user.id,
-        email: user.email,
-      });
-
-      return { token };
-    } catch (error) {
-      throw new UnauthorizedError("Invalid refresh token");
+    private generateToken(payload: any): string {
+        return jwt.sign(payload, process.env.JWT_SECRET!, {
+            expiresIn: '15m',
+        })
     }
-  }
 
-  private generateToken(payload: any): string {
-    return jwt.sign(payload, process.env.JWT_SECRET!, {
-      expiresIn: "15m",
-    });
-  }
-
-  private generateRefreshToken(payload: any): string {
-    return jwt.sign(payload, process.env.REFRESH_TOKEN_SECRET!, {
-      expiresIn: "7d",
-    });
-  }
+    private generateRefreshToken(payload: any): string {
+        return jwt.sign(payload, process.env.REFRESH_TOKEN_SECRET!, {
+            expiresIn: '7d',
+        })
+    }
 }
 ```
 
@@ -313,70 +313,70 @@ export class AuthService {
 
 ```typescript
 // utils/cache.ts
-import Redis from "ioredis";
+import Redis from 'ioredis'
 
 const redis = new Redis({
-  host: process.env.REDIS_HOST,
-  port: parseInt(process.env.REDIS_PORT || "6379"),
-  retryStrategy: (times) => {
-    const delay = Math.min(times * 50, 2000);
-    return delay;
-  },
-});
+    host: process.env.REDIS_HOST,
+    port: parseInt(process.env.REDIS_PORT || '6379'),
+    retryStrategy: times => {
+        const delay = Math.min(times * 50, 2000)
+        return delay
+    },
+})
 
 export class CacheService {
-  async get<T>(key: string): Promise<T | null> {
-    const data = await redis.get(key);
-    return data ? JSON.parse(data) : null;
-  }
-
-  async set(key: string, value: any, ttl?: number): Promise<void> {
-    const serialized = JSON.stringify(value);
-    if (ttl) {
-      await redis.setex(key, ttl, serialized);
-    } else {
-      await redis.set(key, serialized);
+    async get<T>(key: string): Promise<T | null> {
+        const data = await redis.get(key)
+        return data ? JSON.parse(data) : null
     }
-  }
 
-  async delete(key: string): Promise<void> {
-    await redis.del(key);
-  }
-
-  async invalidatePattern(pattern: string): Promise<void> {
-    const keys = await redis.keys(pattern);
-    if (keys.length > 0) {
-      await redis.del(...keys);
+    async set(key: string, value: any, ttl?: number): Promise<void> {
+        const serialized = JSON.stringify(value)
+        if (ttl) {
+            await redis.setex(key, ttl, serialized)
+        } else {
+            await redis.set(key, serialized)
+        }
     }
-  }
+
+    async delete(key: string): Promise<void> {
+        await redis.del(key)
+    }
+
+    async invalidatePattern(pattern: string): Promise<void> {
+        const keys = await redis.keys(pattern)
+        if (keys.length > 0) {
+            await redis.del(...keys)
+        }
+    }
 }
 
 // Cache decorator
 export function Cacheable(ttl: number = 300) {
-  return function (
-    target: any,
-    propertyKey: string,
-    descriptor: PropertyDescriptor,
-  ) {
-    const originalMethod = descriptor.value;
+    return function (
+        target: any,
+        propertyKey: string,
+        descriptor: PropertyDescriptor,
+    ) {
+        const originalMethod = descriptor.value
 
-    descriptor.value = async function (...args: any[]) {
-      const cache = new CacheService();
-      const cacheKey = `${propertyKey}:${JSON.stringify(args)}`;
+        descriptor.value = async function (...args: any[]) {
+            const cache = new CacheService()
+            const cacheKey = `${propertyKey}:${JSON.stringify(args)}`
 
-      const cached = await cache.get(cacheKey);
-      if (cached) {
-        return cached;
-      }
+            const cached = await cache.get(cacheKey)
+            if (cached) {
+                return cached
+            }
 
-      const result = await originalMethod.apply(this, args);
-      await cache.set(cacheKey, result, ttl);
+            const result = await originalMethod.apply(this, args)
+            await cache.set(cacheKey, result, ttl)
 
-      return result;
-    };
+            return result
+        }
 
-    return descriptor;
-  };
+        return descriptor
+    }
 }
 ```
 
@@ -384,47 +384,52 @@ export function Cacheable(ttl: number = 300) {
 
 ```typescript
 // utils/response.ts
-import { Response } from "express";
+import { Response } from 'express'
 
 export class ApiResponse {
-  static success<T>(
-    res: Response,
-    data: T,
-    message?: string,
-    statusCode = 200,
-  ) {
-    return res.status(statusCode).json({
-      status: "success",
-      message,
-      data,
-    });
-  }
+    static success<T>(
+        res: Response,
+        data: T,
+        message?: string,
+        statusCode = 200,
+    ) {
+        return res.status(statusCode).json({
+            status: 'success',
+            message,
+            data,
+        })
+    }
 
-  static error(res: Response, message: string, statusCode = 500, errors?: any) {
-    return res.status(statusCode).json({
-      status: "error",
-      message,
-      ...(errors && { errors }),
-    });
-  }
+    static error(
+        res: Response,
+        message: string,
+        statusCode = 500,
+        errors?: any,
+    ) {
+        return res.status(statusCode).json({
+            status: 'error',
+            message,
+            ...(errors && { errors }),
+        })
+    }
 
-  static paginated<T>(
-    res: Response,
-    data: T[],
-    page: number,
-    limit: number,
-    total: number,
-  ) {
-    return res.json({
-      status: "success",
-      data,
-      pagination: {
-        page,
-        limit,
-        total,
-        pages: Math.ceil(total / limit),
-      },
-    });
-  }
+    static paginated<T>(
+        res: Response,
+        data: T[],
+        page: number,
+        limit: number,
+        total: number,
+    ) {
+        return res.json({
+            status: 'success',
+            data,
+            pagination: {
+                page,
+                limit,
+                total,
+                pages: Math.ceil(total / limit),
+            },
+        })
+    }
 }
 ```

--- a/.agents/skills/nodejs-best-practices/SKILL.md
+++ b/.agents/skills/nodejs-best-practices/SKILL.md
@@ -1,0 +1,343 @@
+---
+name: nodejs-best-practices
+description: "Node.js development principles and decision-making. Framework selection, async patterns, security, and architecture. Teaches thinking, not copying."
+risk: unknown
+source: community
+date_added: "2026-02-27"
+---
+
+# Node.js Best Practices
+
+> Principles and decision-making for Node.js development in 2025.
+> **Learn to THINK, not memorize code patterns.**
+
+## When to Use
+Use this skill when making Node.js architecture decisions, choosing frameworks, designing async patterns, or applying security and deployment best practices.
+
+---
+
+## ⚠️ How to Use This Skill
+
+This skill teaches **decision-making principles**, not fixed code to copy.
+
+- ASK user for preferences when unclear
+- Choose framework/pattern based on CONTEXT
+- Don't default to same solution every time
+
+---
+
+## 1. Framework Selection (2025)
+
+### Decision Tree
+
+```
+What are you building?
+│
+├── Edge/Serverless (Cloudflare, Vercel)
+│   └── Hono (zero-dependency, ultra-fast cold starts)
+│
+├── High Performance API
+│   └── Fastify (2-3x faster than Express)
+│
+├── Enterprise/Team familiarity
+│   └── NestJS (structured, DI, decorators)
+│
+├── Legacy/Stable/Maximum ecosystem
+│   └── Express (mature, most middleware)
+│
+└── Full-stack with frontend
+    └── Next.js API Routes or tRPC
+```
+
+### Comparison Principles
+
+| Factor | Hono | Fastify | Express |
+|--------|------|---------|---------|
+| **Best for** | Edge, serverless | Performance | Legacy, learning |
+| **Cold start** | Fastest | Fast | Moderate |
+| **Ecosystem** | Growing | Good | Largest |
+| **TypeScript** | Native | Excellent | Good |
+| **Learning curve** | Low | Medium | Low |
+
+### Selection Questions to Ask:
+1. What's the deployment target?
+2. Is cold start time critical?
+3. Does team have existing experience?
+4. Is there legacy code to maintain?
+
+---
+
+## 2. Runtime Considerations (2025)
+
+### Native TypeScript
+
+```
+Node.js 22+: --experimental-strip-types
+├── Run .ts files directly
+├── No build step needed for simple projects
+└── Consider for: scripts, simple APIs
+```
+
+### Module System Decision
+
+```
+ESM (import/export)
+├── Modern standard
+├── Better tree-shaking
+├── Async module loading
+└── Use for: new projects
+
+CommonJS (require)
+├── Legacy compatibility
+├── More npm packages support
+└── Use for: existing codebases, some edge cases
+```
+
+### Runtime Selection
+
+| Runtime | Best For |
+|---------|----------|
+| **Node.js** | General purpose, largest ecosystem |
+| **Bun** | Performance, built-in bundler |
+| **Deno** | Security-first, built-in TypeScript |
+
+---
+
+## 3. Architecture Principles
+
+### Layered Structure Concept
+
+```
+Request Flow:
+│
+├── Controller/Route Layer
+│   ├── Handles HTTP specifics
+│   ├── Input validation at boundary
+│   └── Calls service layer
+│
+├── Service Layer
+│   ├── Business logic
+│   ├── Framework-agnostic
+│   └── Calls repository layer
+│
+└── Repository Layer
+    ├── Data access only
+    ├── Database queries
+    └── ORM interactions
+```
+
+### Why This Matters:
+- **Testability**: Mock layers independently
+- **Flexibility**: Swap database without touching business logic
+- **Clarity**: Each layer has single responsibility
+
+### When to Simplify:
+- Small scripts → Single file OK
+- Prototypes → Less structure acceptable
+- Always ask: "Will this grow?"
+
+---
+
+## 4. Error Handling Principles
+
+### Centralized Error Handling
+
+```
+Pattern:
+├── Create custom error classes
+├── Throw from any layer
+├── Catch at top level (middleware)
+└── Format consistent response
+```
+
+### Error Response Philosophy
+
+```
+Client gets:
+├── Appropriate HTTP status
+├── Error code for programmatic handling
+├── User-friendly message
+└── NO internal details (security!)
+
+Logs get:
+├── Full stack trace
+├── Request context
+├── User ID (if applicable)
+└── Timestamp
+```
+
+### Status Code Selection
+
+| Situation | Status | When |
+|-----------|--------|------|
+| Bad input | 400 | Client sent invalid data |
+| No auth | 401 | Missing or invalid credentials |
+| No permission | 403 | Valid auth, but not allowed |
+| Not found | 404 | Resource doesn't exist |
+| Conflict | 409 | Duplicate or state conflict |
+| Validation | 422 | Schema valid but business rules fail |
+| Server error | 500 | Our fault, log everything |
+
+---
+
+## 5. Async Patterns Principles
+
+### When to Use Each
+
+| Pattern | Use When |
+|---------|----------|
+| `async/await` | Sequential async operations |
+| `Promise.all` | Parallel independent operations |
+| `Promise.allSettled` | Parallel where some can fail |
+| `Promise.race` | Timeout or first response wins |
+
+### Event Loop Awareness
+
+```
+I/O-bound (async helps):
+├── Database queries
+├── HTTP requests
+├── File system
+└── Network operations
+
+CPU-bound (async doesn't help):
+├── Crypto operations
+├── Image processing
+├── Complex calculations
+└── → Use worker threads or offload
+```
+
+### Avoiding Event Loop Blocking
+
+- Never use sync methods in production (fs.readFileSync, etc.)
+- Offload CPU-intensive work
+- Use streaming for large data
+
+---
+
+## 6. Validation Principles
+
+### Validate at Boundaries
+
+```
+Where to validate:
+├── API entry point (request body/params)
+├── Before database operations
+├── External data (API responses, file uploads)
+└── Environment variables (startup)
+```
+
+### Validation Library Selection
+
+| Library | Best For |
+|---------|----------|
+| **Zod** | TypeScript first, inference |
+| **Valibot** | Smaller bundle (tree-shakeable) |
+| **ArkType** | Performance critical |
+| **Yup** | Existing React Form usage |
+
+### Validation Philosophy
+
+- Fail fast: Validate early
+- Be specific: Clear error messages
+- Don't trust: Even "internal" data
+
+---
+
+## 7. Security Principles
+
+### Security Checklist (Not Code)
+
+- [ ] **Input validation**: All inputs validated
+- [ ] **Parameterized queries**: No string concatenation for SQL
+- [ ] **Password hashing**: bcrypt or argon2
+- [ ] **JWT verification**: Always verify signature and expiry
+- [ ] **Rate limiting**: Protect from abuse
+- [ ] **Security headers**: Helmet.js or equivalent
+- [ ] **HTTPS**: Everywhere in production
+- [ ] **CORS**: Properly configured
+- [ ] **Secrets**: Environment variables only
+- [ ] **Dependencies**: Regularly audited
+
+### Security Mindset
+
+```
+Trust nothing:
+├── Query params → validate
+├── Request body → validate
+├── Headers → verify
+├── Cookies → validate
+├── File uploads → scan
+└── External APIs → validate response
+```
+
+---
+
+## 8. Testing Principles
+
+### Test Strategy Selection
+
+| Type | Purpose | Tools |
+|------|---------|-------|
+| **Unit** | Business logic | node:test, Vitest |
+| **Integration** | API endpoints | Supertest |
+| **E2E** | Full flows | Playwright |
+
+### What to Test (Priorities)
+
+1. **Critical paths**: Auth, payments, core business
+2. **Edge cases**: Empty inputs, boundaries
+3. **Error handling**: What happens when things fail?
+4. **Not worth testing**: Framework code, trivial getters
+
+### Built-in Test Runner (Node.js 22+)
+
+```
+node --test src/**/*.test.ts
+├── No external dependency
+├── Good coverage reporting
+└── Watch mode available
+```
+
+---
+
+## 9. Anti-Patterns to Avoid
+
+### ❌ DON'T:
+- Use Express for new edge projects (use Hono)
+- Use sync methods in production code
+- Put business logic in controllers
+- Skip input validation
+- Hardcode secrets
+- Trust external data without validation
+- Block event loop with CPU work
+
+### ✅ DO:
+- Choose framework based on context
+- Ask user for preferences when unclear
+- Use layered architecture for growing projects
+- Validate all inputs
+- Use environment variables for secrets
+- Profile before optimizing
+
+---
+
+## 10. Decision Checklist
+
+Before implementing:
+
+- [ ] **Asked user about stack preference?**
+- [ ] **Chosen framework for THIS context?** (not just default)
+- [ ] **Considered deployment target?**
+- [ ] **Planned error handling strategy?**
+- [ ] **Identified validation points?**
+- [ ] **Considered security requirements?**
+
+---
+
+> **Remember**: Node.js best practices are about decision-making, not memorizing patterns. Every project deserves fresh consideration based on its requirements.
+
+## Limitations
+- Use this skill only when the task clearly matches the scope described above.
+- Do not treat the output as a substitute for environment-specific validation, testing, or expert review.
+- Stop and ask for clarification if required inputs, permissions, safety boundaries, or success criteria are missing.

--- a/.agents/skills/nodejs-best-practices/SKILL.md
+++ b/.agents/skills/nodejs-best-practices/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: nodejs-best-practices
-description: "Node.js development principles and decision-making. Framework selection, async patterns, security, and architecture. Teaches thinking, not copying."
+description: 'Node.js development principles and decision-making. Framework selection, async patterns, security, and architecture. Teaches thinking, not copying.'
 risk: unknown
 source: community
-date_added: "2026-02-27"
+date_added: '2026-02-27'
 ---
 
 # Node.js Best Practices
@@ -12,6 +12,7 @@ date_added: "2026-02-27"
 > **Learn to THINK, not memorize code patterns.**
 
 ## When to Use
+
 Use this skill when making Node.js architecture decisions, choosing frameworks, designing async patterns, or applying security and deployment best practices.
 
 ---
@@ -51,15 +52,16 @@ What are you building?
 
 ### Comparison Principles
 
-| Factor | Hono | Fastify | Express |
-|--------|------|---------|---------|
-| **Best for** | Edge, serverless | Performance | Legacy, learning |
-| **Cold start** | Fastest | Fast | Moderate |
-| **Ecosystem** | Growing | Good | Largest |
-| **TypeScript** | Native | Excellent | Good |
-| **Learning curve** | Low | Medium | Low |
+| Factor             | Hono             | Fastify     | Express          |
+| ------------------ | ---------------- | ----------- | ---------------- |
+| **Best for**       | Edge, serverless | Performance | Legacy, learning |
+| **Cold start**     | Fastest          | Fast        | Moderate         |
+| **Ecosystem**      | Growing          | Good        | Largest          |
+| **TypeScript**     | Native           | Excellent   | Good             |
+| **Learning curve** | Low              | Medium      | Low              |
 
 ### Selection Questions to Ask:
+
 1. What's the deployment target?
 2. Is cold start time critical?
 3. Does team have existing experience?
@@ -95,11 +97,11 @@ CommonJS (require)
 
 ### Runtime Selection
 
-| Runtime | Best For |
-|---------|----------|
-| **Node.js** | General purpose, largest ecosystem |
-| **Bun** | Performance, built-in bundler |
-| **Deno** | Security-first, built-in TypeScript |
+| Runtime     | Best For                            |
+| ----------- | ----------------------------------- |
+| **Node.js** | General purpose, largest ecosystem  |
+| **Bun**     | Performance, built-in bundler       |
+| **Deno**    | Security-first, built-in TypeScript |
 
 ---
 
@@ -127,11 +129,13 @@ Request Flow:
 ```
 
 ### Why This Matters:
+
 - **Testability**: Mock layers independently
 - **Flexibility**: Swap database without touching business logic
 - **Clarity**: Each layer has single responsibility
 
 ### When to Simplify:
+
 - Small scripts → Single file OK
 - Prototypes → Less structure acceptable
 - Always ask: "Will this grow?"
@@ -168,15 +172,15 @@ Logs get:
 
 ### Status Code Selection
 
-| Situation | Status | When |
-|-----------|--------|------|
-| Bad input | 400 | Client sent invalid data |
-| No auth | 401 | Missing or invalid credentials |
-| No permission | 403 | Valid auth, but not allowed |
-| Not found | 404 | Resource doesn't exist |
-| Conflict | 409 | Duplicate or state conflict |
-| Validation | 422 | Schema valid but business rules fail |
-| Server error | 500 | Our fault, log everything |
+| Situation     | Status | When                                 |
+| ------------- | ------ | ------------------------------------ |
+| Bad input     | 400    | Client sent invalid data             |
+| No auth       | 401    | Missing or invalid credentials       |
+| No permission | 403    | Valid auth, but not allowed          |
+| Not found     | 404    | Resource doesn't exist               |
+| Conflict      | 409    | Duplicate or state conflict          |
+| Validation    | 422    | Schema valid but business rules fail |
+| Server error  | 500    | Our fault, log everything            |
 
 ---
 
@@ -184,12 +188,12 @@ Logs get:
 
 ### When to Use Each
 
-| Pattern | Use When |
-|---------|----------|
-| `async/await` | Sequential async operations |
-| `Promise.all` | Parallel independent operations |
-| `Promise.allSettled` | Parallel where some can fail |
-| `Promise.race` | Timeout or first response wins |
+| Pattern              | Use When                        |
+| -------------------- | ------------------------------- |
+| `async/await`        | Sequential async operations     |
+| `Promise.all`        | Parallel independent operations |
+| `Promise.allSettled` | Parallel where some can fail    |
+| `Promise.race`       | Timeout or first response wins  |
 
 ### Event Loop Awareness
 
@@ -229,12 +233,12 @@ Where to validate:
 
 ### Validation Library Selection
 
-| Library | Best For |
-|---------|----------|
-| **Zod** | TypeScript first, inference |
+| Library     | Best For                        |
+| ----------- | ------------------------------- |
+| **Zod**     | TypeScript first, inference     |
 | **Valibot** | Smaller bundle (tree-shakeable) |
-| **ArkType** | Performance critical |
-| **Yup** | Existing React Form usage |
+| **ArkType** | Performance critical            |
+| **Yup**     | Existing React Form usage       |
 
 ### Validation Philosophy
 
@@ -277,11 +281,11 @@ Trust nothing:
 
 ### Test Strategy Selection
 
-| Type | Purpose | Tools |
-|------|---------|-------|
-| **Unit** | Business logic | node:test, Vitest |
-| **Integration** | API endpoints | Supertest |
-| **E2E** | Full flows | Playwright |
+| Type            | Purpose        | Tools             |
+| --------------- | -------------- | ----------------- |
+| **Unit**        | Business logic | node:test, Vitest |
+| **Integration** | API endpoints  | Supertest         |
+| **E2E**         | Full flows     | Playwright        |
 
 ### What to Test (Priorities)
 
@@ -304,6 +308,7 @@ node --test src/**/*.test.ts
 ## 9. Anti-Patterns to Avoid
 
 ### ❌ DON'T:
+
 - Use Express for new edge projects (use Hono)
 - Use sync methods in production code
 - Put business logic in controllers
@@ -313,6 +318,7 @@ node --test src/**/*.test.ts
 - Block event loop with CPU work
 
 ### ✅ DO:
+
 - Choose framework based on context
 - Ask user for preferences when unclear
 - Use layered architecture for growing projects
@@ -338,6 +344,7 @@ Before implementing:
 > **Remember**: Node.js best practices are about decision-making, not memorizing patterns. Every project deserves fresh consideration based on its requirements.
 
 ## Limitations
+
 - Use this skill only when the task clearly matches the scope described above.
 - Do not treat the output as a substitute for environment-specific validation, testing, or expert review.
 - Stop and ask for clarification if required inputs, permissions, safety boundaries, or success criteria are missing.

--- a/.agents/skills/nodejs-express-server/SKILL.md
+++ b/.agents/skills/nodejs-express-server/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: nodejs-express-server
+description: >
+  Build production-ready Express.js servers with middleware, authentication,
+  routing, and database integration. Use when creating REST APIs, managing
+  requests/responses, implementing middleware chains, and handling server logic.
+---
+
+# Node.js Express Server
+
+## Table of Contents
+
+- [Overview](#overview)
+- [When to Use](#when-to-use)
+- [Quick Start](#quick-start)
+- [Reference Guides](#reference-guides)
+- [Best Practices](#best-practices)
+
+## Overview
+
+Create robust Express.js applications with proper routing, middleware chains, authentication mechanisms, and database integration following industry best practices.
+
+## When to Use
+
+- Building REST APIs with Node.js
+- Implementing server-side request handling
+- Creating middleware chains for cross-cutting concerns
+- Managing authentication and authorization
+- Connecting to databases from Node.js
+- Implementing error handling and logging
+
+## Quick Start
+
+Minimal working example:
+
+```javascript
+const express = require("express");
+const app = express();
+const PORT = process.env.PORT || 3000;
+
+// Middleware
+app.use(express.json());
+app.use(express.urlencoded({ extended: true }));
+
+// Routes
+app.get("/health", (req, res) => {
+  res.json({ status: "OK", timestamp: new Date().toISOString() });
+});
+
+// Error handling
+app.use((err, req, res, next) => {
+  console.error(err.stack);
+  res.status(err.status || 500).json({
+    error: err.message,
+    requestId: req.id,
+  });
+});
+
+app.listen(PORT, () => {
+  console.log(`Server running on port ${PORT}`);
+});
+```
+
+## Reference Guides
+
+Detailed implementations in the `references/` directory:
+
+| Guide | Contents |
+|---|---|
+| [Basic Express Setup](references/basic-express-setup.md) | Basic Express Setup |
+| [Middleware Chain Implementation](references/middleware-chain-implementation.md) | Middleware Chain Implementation |
+| [Database Integration (PostgreSQL with Sequelize)](references/database-integration-postgresql-with-sequelize.md) | Database Integration (PostgreSQL with Sequelize) |
+| [Authentication with JWT](references/authentication-with-jwt.md) | Authentication with JWT |
+| [RESTful Routes with CRUD Operations](references/restful-routes-with-crud-operations.md) | RESTful Routes with CRUD Operations |
+| [Error Handling Middleware](references/error-handling-middleware.md) | Error Handling Middleware |
+| [Environment Configuration](references/environment-configuration.md) | Environment Configuration |
+
+## Best Practices
+
+### ✅ DO
+
+- Use middleware for cross-cutting concerns
+- Implement proper error handling
+- Validate input data before processing
+- Use async/await for async operations
+- Implement authentication on protected routes
+- Use environment variables for configuration
+- Add logging and monitoring
+- Use HTTPS in production
+- Implement rate limiting
+- Keep route handlers focused and small
+
+### ❌ DON'T
+
+- Handle errors silently
+- Store sensitive data in code
+- Use synchronous operations in routes
+- Forget to validate user input
+- Implement authentication in route handlers
+- Use callback hell (use promises/async-await)
+- Expose stack traces in production
+- Trust client-side validation only

--- a/.agents/skills/nodejs-express-server/SKILL.md
+++ b/.agents/skills/nodejs-express-server/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: nodejs-express-server
 description: >
-  Build production-ready Express.js servers with middleware, authentication,
-  routing, and database integration. Use when creating REST APIs, managing
-  requests/responses, implementing middleware chains, and handling server logic.
+    Build production-ready Express.js servers with middleware, authentication,
+    routing, and database integration. Use when creating REST APIs, managing
+    requests/responses, implementing middleware chains, and handling server logic.
 ---
 
 # Node.js Express Server
@@ -34,46 +34,46 @@ Create robust Express.js applications with proper routing, middleware chains, au
 Minimal working example:
 
 ```javascript
-const express = require("express");
-const app = express();
-const PORT = process.env.PORT || 3000;
+const express = require('express')
+const app = express()
+const PORT = process.env.PORT || 3000
 
 // Middleware
-app.use(express.json());
-app.use(express.urlencoded({ extended: true }));
+app.use(express.json())
+app.use(express.urlencoded({ extended: true }))
 
 // Routes
-app.get("/health", (req, res) => {
-  res.json({ status: "OK", timestamp: new Date().toISOString() });
-});
+app.get('/health', (req, res) => {
+    res.json({ status: 'OK', timestamp: new Date().toISOString() })
+})
 
 // Error handling
 app.use((err, req, res, next) => {
-  console.error(err.stack);
-  res.status(err.status || 500).json({
-    error: err.message,
-    requestId: req.id,
-  });
-});
+    console.error(err.stack)
+    res.status(err.status || 500).json({
+        error: err.message,
+        requestId: req.id,
+    })
+})
 
 app.listen(PORT, () => {
-  console.log(`Server running on port ${PORT}`);
-});
+    console.log(`Server running on port ${PORT}`)
+})
 ```
 
 ## Reference Guides
 
 Detailed implementations in the `references/` directory:
 
-| Guide | Contents |
-|---|---|
-| [Basic Express Setup](references/basic-express-setup.md) | Basic Express Setup |
-| [Middleware Chain Implementation](references/middleware-chain-implementation.md) | Middleware Chain Implementation |
+| Guide                                                                                                            | Contents                                         |
+| ---------------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
+| [Basic Express Setup](references/basic-express-setup.md)                                                         | Basic Express Setup                              |
+| [Middleware Chain Implementation](references/middleware-chain-implementation.md)                                 | Middleware Chain Implementation                  |
 | [Database Integration (PostgreSQL with Sequelize)](references/database-integration-postgresql-with-sequelize.md) | Database Integration (PostgreSQL with Sequelize) |
-| [Authentication with JWT](references/authentication-with-jwt.md) | Authentication with JWT |
-| [RESTful Routes with CRUD Operations](references/restful-routes-with-crud-operations.md) | RESTful Routes with CRUD Operations |
-| [Error Handling Middleware](references/error-handling-middleware.md) | Error Handling Middleware |
-| [Environment Configuration](references/environment-configuration.md) | Environment Configuration |
+| [Authentication with JWT](references/authentication-with-jwt.md)                                                 | Authentication with JWT                          |
+| [RESTful Routes with CRUD Operations](references/restful-routes-with-crud-operations.md)                         | RESTful Routes with CRUD Operations              |
+| [Error Handling Middleware](references/error-handling-middleware.md)                                             | Error Handling Middleware                        |
+| [Environment Configuration](references/environment-configuration.md)                                             | Environment Configuration                        |
 
 ## Best Practices
 

--- a/.agents/skills/nodejs-express-server/references/authentication-with-jwt.md
+++ b/.agents/skills/nodejs-express-server/references/authentication-with-jwt.md
@@ -1,0 +1,33 @@
+# Authentication with JWT
+
+## Authentication with JWT
+
+```javascript
+const jwt = require("jsonwebtoken");
+const bcrypt = require("bcrypt");
+
+const generateToken = (userId) => {
+  return jwt.sign(
+    { userId, iat: Math.floor(Date.now() / 1000) },
+    process.env.JWT_SECRET,
+    { expiresIn: "24h" },
+  );
+};
+
+app.post(
+  "/login",
+  asyncHandler(async (req, res) => {
+    const { email, password } = req.body;
+    const user = await User.findOne({ where: { email } });
+
+    if (!user) return res.status(404).json({ error: "User not found" });
+
+    const validPassword = await bcrypt.compare(password, user.password);
+    if (!validPassword)
+      return res.status(401).json({ error: "Invalid password" });
+
+    const token = generateToken(user.id);
+    res.json({ token, user: { id: user.id, email: user.email } });
+  }),
+);
+```

--- a/.agents/skills/nodejs-express-server/references/authentication-with-jwt.md
+++ b/.agents/skills/nodejs-express-server/references/authentication-with-jwt.md
@@ -3,31 +3,31 @@
 ## Authentication with JWT
 
 ```javascript
-const jwt = require("jsonwebtoken");
-const bcrypt = require("bcrypt");
+const jwt = require('jsonwebtoken')
+const bcrypt = require('bcrypt')
 
-const generateToken = (userId) => {
-  return jwt.sign(
-    { userId, iat: Math.floor(Date.now() / 1000) },
-    process.env.JWT_SECRET,
-    { expiresIn: "24h" },
-  );
-};
+const generateToken = userId => {
+    return jwt.sign(
+        { userId, iat: Math.floor(Date.now() / 1000) },
+        process.env.JWT_SECRET,
+        { expiresIn: '24h' },
+    )
+}
 
 app.post(
-  "/login",
-  asyncHandler(async (req, res) => {
-    const { email, password } = req.body;
-    const user = await User.findOne({ where: { email } });
+    '/login',
+    asyncHandler(async (req, res) => {
+        const { email, password } = req.body
+        const user = await User.findOne({ where: { email } })
 
-    if (!user) return res.status(404).json({ error: "User not found" });
+        if (!user) return res.status(404).json({ error: 'User not found' })
 
-    const validPassword = await bcrypt.compare(password, user.password);
-    if (!validPassword)
-      return res.status(401).json({ error: "Invalid password" });
+        const validPassword = await bcrypt.compare(password, user.password)
+        if (!validPassword)
+            return res.status(401).json({ error: 'Invalid password' })
 
-    const token = generateToken(user.id);
-    res.json({ token, user: { id: user.id, email: user.email } });
-  }),
-);
+        const token = generateToken(user.id)
+        res.json({ token, user: { id: user.id, email: user.email } })
+    }),
+)
 ```

--- a/.agents/skills/nodejs-express-server/references/basic-express-setup.md
+++ b/.agents/skills/nodejs-express-server/references/basic-express-setup.md
@@ -1,0 +1,31 @@
+# Basic Express Setup
+
+## Basic Express Setup
+
+```javascript
+const express = require("express");
+const app = express();
+const PORT = process.env.PORT || 3000;
+
+// Middleware
+app.use(express.json());
+app.use(express.urlencoded({ extended: true }));
+
+// Routes
+app.get("/health", (req, res) => {
+  res.json({ status: "OK", timestamp: new Date().toISOString() });
+});
+
+// Error handling
+app.use((err, req, res, next) => {
+  console.error(err.stack);
+  res.status(err.status || 500).json({
+    error: err.message,
+    requestId: req.id,
+  });
+});
+
+app.listen(PORT, () => {
+  console.log(`Server running on port ${PORT}`);
+});
+```

--- a/.agents/skills/nodejs-express-server/references/basic-express-setup.md
+++ b/.agents/skills/nodejs-express-server/references/basic-express-setup.md
@@ -3,29 +3,29 @@
 ## Basic Express Setup
 
 ```javascript
-const express = require("express");
-const app = express();
-const PORT = process.env.PORT || 3000;
+const express = require('express')
+const app = express()
+const PORT = process.env.PORT || 3000
 
 // Middleware
-app.use(express.json());
-app.use(express.urlencoded({ extended: true }));
+app.use(express.json())
+app.use(express.urlencoded({ extended: true }))
 
 // Routes
-app.get("/health", (req, res) => {
-  res.json({ status: "OK", timestamp: new Date().toISOString() });
-});
+app.get('/health', (req, res) => {
+    res.json({ status: 'OK', timestamp: new Date().toISOString() })
+})
 
 // Error handling
 app.use((err, req, res, next) => {
-  console.error(err.stack);
-  res.status(err.status || 500).json({
-    error: err.message,
-    requestId: req.id,
-  });
-});
+    console.error(err.stack)
+    res.status(err.status || 500).json({
+        error: err.message,
+        requestId: req.id,
+    })
+})
 
 app.listen(PORT, () => {
-  console.log(`Server running on port ${PORT}`);
-});
+    console.log(`Server running on port ${PORT}`)
+})
 ```

--- a/.agents/skills/nodejs-express-server/references/database-integration-postgresql-with-sequelize.md
+++ b/.agents/skills/nodejs-express-server/references/database-integration-postgresql-with-sequelize.md
@@ -1,0 +1,45 @@
+# Database Integration (PostgreSQL with Sequelize)
+
+## Database Integration (PostgreSQL with Sequelize)
+
+```javascript
+const { Sequelize, DataTypes } = require("sequelize");
+
+const sequelize = new Sequelize(
+  process.env.DB_NAME,
+  process.env.DB_USER,
+  process.env.DB_PASS,
+  {
+    host: process.env.DB_HOST,
+    dialect: "postgres",
+    logging: false,
+  },
+);
+
+const User = sequelize.define(
+  "User",
+  {
+    id: {
+      type: DataTypes.UUID,
+      defaultValue: DataTypes.UUIDV4,
+      primaryKey: true,
+    },
+    email: {
+      type: DataTypes.STRING,
+      unique: true,
+      allowNull: false,
+    },
+    password: DataTypes.STRING,
+    role: {
+      type: DataTypes.ENUM("user", "admin"),
+      defaultValue: "user",
+    },
+  },
+  {
+    timestamps: true,
+  },
+);
+
+// Sync database
+sequelize.sync({ alter: true });
+```

--- a/.agents/skills/nodejs-express-server/references/database-integration-postgresql-with-sequelize.md
+++ b/.agents/skills/nodejs-express-server/references/database-integration-postgresql-with-sequelize.md
@@ -3,43 +3,43 @@
 ## Database Integration (PostgreSQL with Sequelize)
 
 ```javascript
-const { Sequelize, DataTypes } = require("sequelize");
+const { Sequelize, DataTypes } = require('sequelize')
 
 const sequelize = new Sequelize(
-  process.env.DB_NAME,
-  process.env.DB_USER,
-  process.env.DB_PASS,
-  {
-    host: process.env.DB_HOST,
-    dialect: "postgres",
-    logging: false,
-  },
-);
+    process.env.DB_NAME,
+    process.env.DB_USER,
+    process.env.DB_PASS,
+    {
+        host: process.env.DB_HOST,
+        dialect: 'postgres',
+        logging: false,
+    },
+)
 
 const User = sequelize.define(
-  "User",
-  {
-    id: {
-      type: DataTypes.UUID,
-      defaultValue: DataTypes.UUIDV4,
-      primaryKey: true,
+    'User',
+    {
+        id: {
+            type: DataTypes.UUID,
+            defaultValue: DataTypes.UUIDV4,
+            primaryKey: true,
+        },
+        email: {
+            type: DataTypes.STRING,
+            unique: true,
+            allowNull: false,
+        },
+        password: DataTypes.STRING,
+        role: {
+            type: DataTypes.ENUM('user', 'admin'),
+            defaultValue: 'user',
+        },
     },
-    email: {
-      type: DataTypes.STRING,
-      unique: true,
-      allowNull: false,
+    {
+        timestamps: true,
     },
-    password: DataTypes.STRING,
-    role: {
-      type: DataTypes.ENUM("user", "admin"),
-      defaultValue: "user",
-    },
-  },
-  {
-    timestamps: true,
-  },
-);
+)
 
 // Sync database
-sequelize.sync({ alter: true });
+sequelize.sync({ alter: true })
 ```

--- a/.agents/skills/nodejs-express-server/references/environment-configuration.md
+++ b/.agents/skills/nodejs-express-server/references/environment-configuration.md
@@ -1,0 +1,25 @@
+# Environment Configuration
+
+## Environment Configuration
+
+```javascript
+require("dotenv").config();
+
+const config = {
+  port: process.env.PORT || 3000,
+  env: process.env.NODE_ENV || "development",
+  database: {
+    url: process.env.DATABASE_URL,
+    dialect: "postgres",
+  },
+  jwt: {
+    secret: process.env.JWT_SECRET,
+    expiresIn: "24h",
+  },
+  cors: {
+    origin: process.env.CORS_ORIGIN || "http://localhost:3000",
+  },
+};
+
+module.exports = config;
+```

--- a/.agents/skills/nodejs-express-server/references/environment-configuration.md
+++ b/.agents/skills/nodejs-express-server/references/environment-configuration.md
@@ -3,23 +3,23 @@
 ## Environment Configuration
 
 ```javascript
-require("dotenv").config();
+require('dotenv').config()
 
 const config = {
-  port: process.env.PORT || 3000,
-  env: process.env.NODE_ENV || "development",
-  database: {
-    url: process.env.DATABASE_URL,
-    dialect: "postgres",
-  },
-  jwt: {
-    secret: process.env.JWT_SECRET,
-    expiresIn: "24h",
-  },
-  cors: {
-    origin: process.env.CORS_ORIGIN || "http://localhost:3000",
-  },
-};
+    port: process.env.PORT || 3000,
+    env: process.env.NODE_ENV || 'development',
+    database: {
+        url: process.env.DATABASE_URL,
+        dialect: 'postgres',
+    },
+    jwt: {
+        secret: process.env.JWT_SECRET,
+        expiresIn: '24h',
+    },
+    cors: {
+        origin: process.env.CORS_ORIGIN || 'http://localhost:3000',
+    },
+}
 
-module.exports = config;
+module.exports = config
 ```

--- a/.agents/skills/nodejs-express-server/references/error-handling-middleware.md
+++ b/.agents/skills/nodejs-express-server/references/error-handling-middleware.md
@@ -1,0 +1,40 @@
+# Error Handling Middleware
+
+## Error Handling Middleware
+
+```javascript
+class AppError extends Error {
+  constructor(message, statusCode) {
+    super(message);
+    this.statusCode = statusCode;
+    Error.captureStackTrace(this, this.constructor);
+  }
+}
+
+app.use((err, req, res, next) => {
+  err.statusCode = err.statusCode || 500;
+
+  if (err.name === "SequelizeValidationError") {
+    return res.status(400).json({
+      error: "Validation failed",
+      details: err.errors.map((e) => ({ field: e.path, message: e.message })),
+    });
+  }
+
+  if (process.env.NODE_ENV === "production") {
+    return res.status(err.statusCode).json({
+      error: err.message,
+      requestId: req.id,
+    });
+  }
+
+  res.status(err.statusCode).json({
+    error: err.message,
+    stack: err.stack,
+  });
+});
+
+app.use((req, res) => {
+  res.status(404).json({ error: "Route not found" });
+});
+```

--- a/.agents/skills/nodejs-express-server/references/error-handling-middleware.md
+++ b/.agents/skills/nodejs-express-server/references/error-handling-middleware.md
@@ -4,37 +4,40 @@
 
 ```javascript
 class AppError extends Error {
-  constructor(message, statusCode) {
-    super(message);
-    this.statusCode = statusCode;
-    Error.captureStackTrace(this, this.constructor);
-  }
+    constructor(message, statusCode) {
+        super(message)
+        this.statusCode = statusCode
+        Error.captureStackTrace(this, this.constructor)
+    }
 }
 
 app.use((err, req, res, next) => {
-  err.statusCode = err.statusCode || 500;
+    err.statusCode = err.statusCode || 500
 
-  if (err.name === "SequelizeValidationError") {
-    return res.status(400).json({
-      error: "Validation failed",
-      details: err.errors.map((e) => ({ field: e.path, message: e.message })),
-    });
-  }
+    if (err.name === 'SequelizeValidationError') {
+        return res.status(400).json({
+            error: 'Validation failed',
+            details: err.errors.map(e => ({
+                field: e.path,
+                message: e.message,
+            })),
+        })
+    }
 
-  if (process.env.NODE_ENV === "production") {
-    return res.status(err.statusCode).json({
-      error: err.message,
-      requestId: req.id,
-    });
-  }
+    if (process.env.NODE_ENV === 'production') {
+        return res.status(err.statusCode).json({
+            error: err.message,
+            requestId: req.id,
+        })
+    }
 
-  res.status(err.statusCode).json({
-    error: err.message,
-    stack: err.stack,
-  });
-});
+    res.status(err.statusCode).json({
+        error: err.message,
+        stack: err.stack,
+    })
+})
 
 app.use((req, res) => {
-  res.status(404).json({ error: "Route not found" });
-});
+    res.status(404).json({ error: 'Route not found' })
+})
 ```

--- a/.agents/skills/nodejs-express-server/references/middleware-chain-implementation.md
+++ b/.agents/skills/nodejs-express-server/references/middleware-chain-implementation.md
@@ -1,0 +1,38 @@
+# Middleware Chain Implementation
+
+## Middleware Chain Implementation
+
+```javascript
+// Logging middleware
+const logger = (req, res, next) => {
+  const start = Date.now();
+  res.on("finish", () => {
+    const duration = Date.now() - start;
+    console.log(`${req.method} ${req.path} ${res.statusCode} ${duration}ms`);
+  });
+  next();
+};
+
+// Authentication middleware
+const authenticateToken = (req, res, next) => {
+  const token = req.headers["authorization"]?.split(" ")[1];
+  if (!token) return res.status(401).json({ error: "No token" });
+
+  jwt.verify(token, process.env.JWT_SECRET, (err, user) => {
+    if (err) return res.status(403).json({ error: "Invalid token" });
+    req.user = user;
+    next();
+  });
+};
+
+// Error catching middleware wrapper
+const asyncHandler = (fn) => (req, res, next) => {
+  Promise.resolve(fn(req, res, next)).catch(next);
+};
+
+app.use(logger);
+app.use(express.json());
+app.get("/protected", authenticateToken, (req, res) => {
+  res.json({ user: req.user });
+});
+```

--- a/.agents/skills/nodejs-express-server/references/middleware-chain-implementation.md
+++ b/.agents/skills/nodejs-express-server/references/middleware-chain-implementation.md
@@ -5,34 +5,34 @@
 ```javascript
 // Logging middleware
 const logger = (req, res, next) => {
-  const start = Date.now();
-  res.on("finish", () => {
-    const duration = Date.now() - start;
-    console.log(`${req.method} ${req.path} ${res.statusCode} ${duration}ms`);
-  });
-  next();
-};
+    const start = Date.now()
+    res.on('finish', () => {
+        const duration = Date.now() - start
+        console.log(`${req.method} ${req.path} ${res.statusCode} ${duration}ms`)
+    })
+    next()
+}
 
 // Authentication middleware
 const authenticateToken = (req, res, next) => {
-  const token = req.headers["authorization"]?.split(" ")[1];
-  if (!token) return res.status(401).json({ error: "No token" });
+    const token = req.headers['authorization']?.split(' ')[1]
+    if (!token) return res.status(401).json({ error: 'No token' })
 
-  jwt.verify(token, process.env.JWT_SECRET, (err, user) => {
-    if (err) return res.status(403).json({ error: "Invalid token" });
-    req.user = user;
-    next();
-  });
-};
+    jwt.verify(token, process.env.JWT_SECRET, (err, user) => {
+        if (err) return res.status(403).json({ error: 'Invalid token' })
+        req.user = user
+        next()
+    })
+}
 
 // Error catching middleware wrapper
-const asyncHandler = (fn) => (req, res, next) => {
-  Promise.resolve(fn(req, res, next)).catch(next);
-};
+const asyncHandler = fn => (req, res, next) => {
+    Promise.resolve(fn(req, res, next)).catch(next)
+}
 
-app.use(logger);
-app.use(express.json());
-app.get("/protected", authenticateToken, (req, res) => {
-  res.json({ user: req.user });
-});
+app.use(logger)
+app.use(express.json())
+app.get('/protected', authenticateToken, (req, res) => {
+    res.json({ user: req.user })
+})
 ```

--- a/.agents/skills/nodejs-express-server/references/restful-routes-with-crud-operations.md
+++ b/.agents/skills/nodejs-express-server/references/restful-routes-with-crud-operations.md
@@ -1,0 +1,83 @@
+# RESTful Routes with CRUD Operations
+
+## RESTful Routes with CRUD Operations
+
+```javascript
+const userRouter = express.Router();
+
+// GET all users (with pagination)
+userRouter.get(
+  "/",
+  authenticateToken,
+  asyncHandler(async (req, res) => {
+    const { page = 1, limit = 20 } = req.query;
+    const users = await User.findAndCountAll({
+      offset: (page - 1) * limit,
+      limit: parseInt(limit),
+    });
+
+    res.json({
+      data: users.rows,
+      pagination: { page, limit, total: users.count },
+    });
+  }),
+);
+
+// GET single user
+userRouter.get(
+  "/:id",
+  authenticateToken,
+  asyncHandler(async (req, res) => {
+    const user = await User.findByPk(req.params.id);
+    if (!user) return res.status(404).json({ error: "Not found" });
+    res.json({ data: user });
+  }),
+);
+
+// POST create user
+userRouter.post(
+  "/",
+  asyncHandler(async (req, res) => {
+    const { email, password } = req.body;
+    const hashedPassword = await bcrypt.hash(password, 10);
+
+    const user = await User.create({
+      email,
+      password: hashedPassword,
+    });
+
+    res.status(201).json({ data: user });
+  }),
+);
+
+// PATCH update user
+userRouter.patch(
+  "/:id",
+  authenticateToken,
+  asyncHandler(async (req, res) => {
+    const user = await User.findByPk(req.params.id);
+    if (!user) return res.status(404).json({ error: "Not found" });
+
+    await user.update(req.body, {
+      fields: ["email", "role"],
+    });
+
+    res.json({ data: user });
+  }),
+);
+
+// DELETE user
+userRouter.delete(
+  "/:id",
+  authenticateToken,
+  asyncHandler(async (req, res) => {
+    const user = await User.findByPk(req.params.id);
+    if (!user) return res.status(404).json({ error: "Not found" });
+
+    await user.destroy();
+    res.status(204).send();
+  }),
+);
+
+app.use("/api/users", userRouter);
+```

--- a/.agents/skills/nodejs-express-server/references/restful-routes-with-crud-operations.md
+++ b/.agents/skills/nodejs-express-server/references/restful-routes-with-crud-operations.md
@@ -3,81 +3,81 @@
 ## RESTful Routes with CRUD Operations
 
 ```javascript
-const userRouter = express.Router();
+const userRouter = express.Router()
 
 // GET all users (with pagination)
 userRouter.get(
-  "/",
-  authenticateToken,
-  asyncHandler(async (req, res) => {
-    const { page = 1, limit = 20 } = req.query;
-    const users = await User.findAndCountAll({
-      offset: (page - 1) * limit,
-      limit: parseInt(limit),
-    });
+    '/',
+    authenticateToken,
+    asyncHandler(async (req, res) => {
+        const { page = 1, limit = 20 } = req.query
+        const users = await User.findAndCountAll({
+            offset: (page - 1) * limit,
+            limit: parseInt(limit),
+        })
 
-    res.json({
-      data: users.rows,
-      pagination: { page, limit, total: users.count },
-    });
-  }),
-);
+        res.json({
+            data: users.rows,
+            pagination: { page, limit, total: users.count },
+        })
+    }),
+)
 
 // GET single user
 userRouter.get(
-  "/:id",
-  authenticateToken,
-  asyncHandler(async (req, res) => {
-    const user = await User.findByPk(req.params.id);
-    if (!user) return res.status(404).json({ error: "Not found" });
-    res.json({ data: user });
-  }),
-);
+    '/:id',
+    authenticateToken,
+    asyncHandler(async (req, res) => {
+        const user = await User.findByPk(req.params.id)
+        if (!user) return res.status(404).json({ error: 'Not found' })
+        res.json({ data: user })
+    }),
+)
 
 // POST create user
 userRouter.post(
-  "/",
-  asyncHandler(async (req, res) => {
-    const { email, password } = req.body;
-    const hashedPassword = await bcrypt.hash(password, 10);
+    '/',
+    asyncHandler(async (req, res) => {
+        const { email, password } = req.body
+        const hashedPassword = await bcrypt.hash(password, 10)
 
-    const user = await User.create({
-      email,
-      password: hashedPassword,
-    });
+        const user = await User.create({
+            email,
+            password: hashedPassword,
+        })
 
-    res.status(201).json({ data: user });
-  }),
-);
+        res.status(201).json({ data: user })
+    }),
+)
 
 // PATCH update user
 userRouter.patch(
-  "/:id",
-  authenticateToken,
-  asyncHandler(async (req, res) => {
-    const user = await User.findByPk(req.params.id);
-    if (!user) return res.status(404).json({ error: "Not found" });
+    '/:id',
+    authenticateToken,
+    asyncHandler(async (req, res) => {
+        const user = await User.findByPk(req.params.id)
+        if (!user) return res.status(404).json({ error: 'Not found' })
 
-    await user.update(req.body, {
-      fields: ["email", "role"],
-    });
+        await user.update(req.body, {
+            fields: ['email', 'role'],
+        })
 
-    res.json({ data: user });
-  }),
-);
+        res.json({ data: user })
+    }),
+)
 
 // DELETE user
 userRouter.delete(
-  "/:id",
-  authenticateToken,
-  asyncHandler(async (req, res) => {
-    const user = await User.findByPk(req.params.id);
-    if (!user) return res.status(404).json({ error: "Not found" });
+    '/:id',
+    authenticateToken,
+    asyncHandler(async (req, res) => {
+        const user = await User.findByPk(req.params.id)
+        if (!user) return res.status(404).json({ error: 'Not found' })
 
-    await user.destroy();
-    res.status(204).send();
-  }),
-);
+        await user.destroy()
+        res.status(204).send()
+    }),
+)
 
-app.use("/api/users", userRouter);
+app.use('/api/users', userRouter)
 ```

--- a/.agents/skills/nodejs-express-server/scripts/security-checklist.sh
+++ b/.agents/skills/nodejs-express-server/scripts/security-checklist.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# security-checklist.sh - Generate a security review checklist
+# Usage: ./security-checklist.sh [--output checklist.md]
+
+set -euo pipefail
+
+OUTPUT="${{1:-/dev/stdout}}"
+
+cat > "$OUTPUT" << 'CHECKLIST'
+# Security Review Checklist
+
+## Authentication & Authorization
+- [ ] All endpoints require authentication
+- [ ] Role-based access control implemented
+- [ ] Session management is secure
+
+## Input Validation
+- [ ] All user inputs are validated
+- [ ] SQL injection prevention
+- [ ] XSS prevention
+
+## Data Protection
+- [ ] Sensitive data encrypted at rest
+- [ ] Sensitive data encrypted in transit
+- [ ] PII handling compliant
+
+## TODO: Add domain-specific security checks
+CHECKLIST
+
+echo "Checklist generated: $OUTPUT" >&2

--- a/.agents/skills/prisma-cli/SKILL.md
+++ b/.agents/skills/prisma-cli/SKILL.md
@@ -1,0 +1,243 @@
+---
+name: prisma-cli
+description: Prisma CLI commands reference covering all available commands, options, and usage patterns. Use when running Prisma CLI commands, setting up projects, generating client, running migrations, managing databases, or starting Prisma's MCP server. Triggers on "prisma init", "prisma generate", "prisma migrate", "prisma db", "prisma studio", "prisma mcp".
+license: MIT
+metadata:
+  author: prisma
+  version: "7.6.0"
+---
+
+# Prisma CLI Reference
+
+Complete reference for all Prisma CLI commands. This skill provides guidance on command usage, options, and best practices for current Prisma releases.
+
+## When to Apply
+
+Reference this skill when:
+- Setting up a new Prisma project (`prisma init`)
+- Generating Prisma Client (`prisma generate`)
+- Running database migrations (`prisma migrate`)
+- Managing database state (`prisma db push/pull`)
+- Using local development database (`prisma dev`)
+- Debugging Prisma issues (`prisma debug`)
+
+## Rule Categories by Priority
+
+| Priority | Category | Impact | Prefix |
+|----------|----------|--------|--------|
+| 1 | Setup | HIGH | `init` |
+| 2 | Generation | HIGH | `generate` |
+| 3 | Development | HIGH | `dev` |
+| 4 | Database | HIGH | `db-` |
+| 5 | Migrations | CRITICAL | `migrate-` |
+| 6 | Utility | MEDIUM | `studio`, `validate`, `format`, `debug`, `mcp` |
+
+## Command Categories
+
+| Category | Commands | Purpose |
+|----------|----------|---------|
+| Setup | `init` | Bootstrap new Prisma project |
+| Generation | `generate` | Generate Prisma Client |
+| Validation | `validate`, `format` | Schema validation and formatting |
+| Development | `dev` | Local Prisma Postgres for development |
+| Database | `db pull`, `db push`, `db seed`, `db execute` | Direct database operations |
+| Migrations | `migrate dev`, `migrate deploy`, `migrate reset`, `migrate status`, `migrate diff`, `migrate resolve` | Schema migrations |
+| Utility | `studio`, `mcp`, `version`, `debug` | Development and AI tooling |
+
+## Quick Reference
+
+### Project Setup
+
+```bash
+# Initialize new project (creates prisma/ folder and prisma.config.ts)
+prisma init
+
+# Initialize with specific database
+prisma init --datasource-provider postgresql
+prisma init --datasource-provider mysql
+prisma init --datasource-provider sqlite
+
+# Initialize with Prisma Postgres (cloud)
+prisma init --db
+
+# Initialize with an example model
+prisma init --with-model
+```
+
+### Client Generation
+
+```bash
+# Generate Prisma Client
+prisma generate
+
+# Watch mode for development
+prisma generate --watch
+
+# Generate specific generator only
+prisma generate --generator client
+```
+
+### Bun Runtime
+
+When using Bun, always add the `--bun` flag so Prisma runs with the Bun runtime (otherwise it falls back to Node.js because of the CLI shebang):
+
+```bash
+bunx --bun prisma init
+bunx --bun prisma generate
+```
+
+### Local Development Database
+
+```bash
+# Start local Prisma Postgres
+prisma dev
+
+# Start with specific name
+prisma dev --name myproject
+
+# Start in background (detached)
+prisma dev --detach
+
+# List all local instances
+prisma dev ls
+
+# Stop instance
+prisma dev stop myproject
+
+# Remove instance data
+prisma dev rm myproject
+```
+
+### Database Operations
+
+```bash
+# Pull schema from existing database
+prisma db pull
+
+# Push schema to database (no migrations)
+prisma db push
+
+# Seed database
+prisma db seed
+
+# Execute raw SQL
+prisma db execute --file ./script.sql
+```
+
+### Migrations (Development)
+
+```bash
+# Create and apply migration
+prisma migrate dev
+
+# Create migration with name
+prisma migrate dev --name add_users_table
+
+# Create migration without applying
+prisma migrate dev --create-only
+
+# Reset database and apply all migrations
+prisma migrate reset
+```
+
+### Migrations (Production)
+
+```bash
+# Apply pending migrations (CI/CD)
+prisma migrate deploy
+
+# Check migration status
+prisma migrate status
+
+# Compare schemas and generate diff
+prisma migrate diff --from-config-datasource --to-schema schema.prisma --script
+```
+
+### Utility Commands
+
+```bash
+# Open Prisma Studio (database GUI)
+prisma studio
+
+# Start Prisma's MCP server for AI tools
+prisma mcp
+
+# Show version info
+prisma version
+prisma -v
+
+# Debug information
+prisma debug
+
+# Validate schema
+prisma validate
+
+# Format schema
+prisma format
+```
+
+## Current Prisma CLI Setup
+
+### New Configuration File
+
+Use `prisma.config.ts` for CLI configuration:
+
+```typescript
+import 'dotenv/config'
+import { defineConfig, env } from 'prisma/config'
+
+export default defineConfig({
+  schema: 'prisma/schema.prisma',
+  migrations: {
+    path: 'prisma/migrations',
+    seed: 'tsx prisma/seed.ts',
+  },
+  datasource: {
+    url: env('DATABASE_URL'),
+  },
+})
+```
+
+### Current Command Behavior
+
+- Run `prisma generate` explicitly after `migrate dev`, `db push`, or other schema syncs when you need fresh client output
+- Run `prisma db seed` explicitly after `migrate dev` or `migrate reset` when you need seed data
+- Use `prisma db execute --file ...` for raw SQL scripts
+
+### Environment Variables
+
+Load environment variables explicitly in `prisma.config.ts`, commonly with `dotenv`:
+
+```typescript
+// prisma.config.ts
+import 'dotenv/config'
+```
+
+## Rule Files
+
+See individual rule files for detailed command documentation:
+
+```
+references/init.md           - Project initialization
+references/generate.md       - Client generation
+references/dev.md            - Local development database
+references/db-pull.md        - Database introspection
+references/db-push.md        - Schema push
+references/db-seed.md        - Database seeding
+references/db-execute.md     - Raw SQL execution
+references/migrate-dev.md    - Development migrations
+references/migrate-deploy.md - Production migrations
+references/migrate-reset.md  - Database reset
+references/migrate-status.md - Migration status
+references/migrate-resolve.md - Migration resolution
+references/migrate-diff.md   - Schema diffing
+references/studio.md         - Database GUI
+references/mcp.md            - Prisma MCP server
+references/validate.md       - Schema validation
+references/format.md         - Schema formatting
+references/debug.md          - Debug info
+```
+
+## How to Use
+
+Use the command categories above for navigation, then open the specific command reference file you need.

--- a/.agents/skills/prisma-cli/SKILL.md
+++ b/.agents/skills/prisma-cli/SKILL.md
@@ -3,8 +3,8 @@ name: prisma-cli
 description: Prisma CLI commands reference covering all available commands, options, and usage patterns. Use when running Prisma CLI commands, setting up projects, generating client, running migrations, managing databases, or starting Prisma's MCP server. Triggers on "prisma init", "prisma generate", "prisma migrate", "prisma db", "prisma studio", "prisma mcp".
 license: MIT
 metadata:
-  author: prisma
-  version: "7.6.0"
+    author: prisma
+    version: '7.6.0'
 ---
 
 # Prisma CLI Reference
@@ -14,6 +14,7 @@ Complete reference for all Prisma CLI commands. This skill provides guidance on 
 ## When to Apply
 
 Reference this skill when:
+
 - Setting up a new Prisma project (`prisma init`)
 - Generating Prisma Client (`prisma generate`)
 - Running database migrations (`prisma migrate`)
@@ -23,26 +24,26 @@ Reference this skill when:
 
 ## Rule Categories by Priority
 
-| Priority | Category | Impact | Prefix |
-|----------|----------|--------|--------|
-| 1 | Setup | HIGH | `init` |
-| 2 | Generation | HIGH | `generate` |
-| 3 | Development | HIGH | `dev` |
-| 4 | Database | HIGH | `db-` |
-| 5 | Migrations | CRITICAL | `migrate-` |
-| 6 | Utility | MEDIUM | `studio`, `validate`, `format`, `debug`, `mcp` |
+| Priority | Category    | Impact   | Prefix                                         |
+| -------- | ----------- | -------- | ---------------------------------------------- |
+| 1        | Setup       | HIGH     | `init`                                         |
+| 2        | Generation  | HIGH     | `generate`                                     |
+| 3        | Development | HIGH     | `dev`                                          |
+| 4        | Database    | HIGH     | `db-`                                          |
+| 5        | Migrations  | CRITICAL | `migrate-`                                     |
+| 6        | Utility     | MEDIUM   | `studio`, `validate`, `format`, `debug`, `mcp` |
 
 ## Command Categories
 
-| Category | Commands | Purpose |
-|----------|----------|---------|
-| Setup | `init` | Bootstrap new Prisma project |
-| Generation | `generate` | Generate Prisma Client |
-| Validation | `validate`, `format` | Schema validation and formatting |
-| Development | `dev` | Local Prisma Postgres for development |
-| Database | `db pull`, `db push`, `db seed`, `db execute` | Direct database operations |
-| Migrations | `migrate dev`, `migrate deploy`, `migrate reset`, `migrate status`, `migrate diff`, `migrate resolve` | Schema migrations |
-| Utility | `studio`, `mcp`, `version`, `debug` | Development and AI tooling |
+| Category    | Commands                                                                                              | Purpose                               |
+| ----------- | ----------------------------------------------------------------------------------------------------- | ------------------------------------- |
+| Setup       | `init`                                                                                                | Bootstrap new Prisma project          |
+| Generation  | `generate`                                                                                            | Generate Prisma Client                |
+| Validation  | `validate`, `format`                                                                                  | Schema validation and formatting      |
+| Development | `dev`                                                                                                 | Local Prisma Postgres for development |
+| Database    | `db pull`, `db push`, `db seed`, `db execute`                                                         | Direct database operations            |
+| Migrations  | `migrate dev`, `migrate deploy`, `migrate reset`, `migrate status`, `migrate diff`, `migrate resolve` | Schema migrations                     |
+| Utility     | `studio`, `mcp`, `version`, `debug`                                                                   | Development and AI tooling            |
 
 ## Quick Reference
 
@@ -187,14 +188,14 @@ import 'dotenv/config'
 import { defineConfig, env } from 'prisma/config'
 
 export default defineConfig({
-  schema: 'prisma/schema.prisma',
-  migrations: {
-    path: 'prisma/migrations',
-    seed: 'tsx prisma/seed.ts',
-  },
-  datasource: {
-    url: env('DATABASE_URL'),
-  },
+    schema: 'prisma/schema.prisma',
+    migrations: {
+        path: 'prisma/migrations',
+        seed: 'tsx prisma/seed.ts',
+    },
+    datasource: {
+        url: env('DATABASE_URL'),
+    },
 })
 ```
 

--- a/.agents/skills/prisma-cli/references/db-execute.md
+++ b/.agents/skills/prisma-cli/references/db-execute.md
@@ -1,0 +1,78 @@
+# prisma db execute
+
+Execute native commands (SQL) to your database.
+
+## Command
+
+```bash
+prisma db execute [options]
+```
+
+## What It Does
+
+- Connects to your database using the configured datasource
+- Executes a script provided via file (`--file`) or stdin (`--stdin`)
+- Useful for running raw SQL, maintenance tasks, or applying diffs from `migrate diff`
+- Not supported on MongoDB
+
+## Options
+
+| Option | Description |
+|--------|-------------|
+| `--file` | Path to a file containing the script to execute |
+| `--stdin` | Use terminal standard input as the script |
+| `--config` | Custom path to your Prisma config file |
+
+## Current Option Surface
+
+`prisma db execute` uses the datasource configured in `prisma.config.ts`. Use `--config` if you need a separate config file for another environment.
+
+## Examples
+
+### Execute from file
+
+```bash
+prisma db execute --file ./script.sql
+```
+
+### Execute from stdin
+
+```bash
+echo "TRUNCATE TABLE User;" | prisma db execute --stdin
+```
+
+### Execute `migrate diff` output
+
+Pipe the output of `migrate diff` directly to the database:
+
+```bash
+prisma migrate diff \
+  --from-empty \
+  --to-schema prisma/schema.prisma \
+  --script \
+| prisma db execute --stdin
+```
+
+## Configuration
+
+Uses `datasource` from `prisma.config.ts`:
+
+```typescript
+export default defineConfig({
+  datasource: {
+    url: env('DATABASE_URL'),
+  },
+})
+```
+
+## Use Cases
+
+- **Manual Migrations**: Applying raw SQL changes
+- **Data Maintenance**: Truncating tables, cleaning up data
+- **Schema Synchronization**: Applying `migrate diff` scripts
+- **Debugging**: Running test queries (though typically not for fetching data)
+
+## Limitations
+
+- **No Data Return**: The command reports success/failure, not query results (rows). Use Prisma Client or `prisma studio` to view data.
+- **SQL Only**: Primarily for SQL databases.

--- a/.agents/skills/prisma-cli/references/db-execute.md
+++ b/.agents/skills/prisma-cli/references/db-execute.md
@@ -17,11 +17,11 @@ prisma db execute [options]
 
 ## Options
 
-| Option | Description |
-|--------|-------------|
-| `--file` | Path to a file containing the script to execute |
-| `--stdin` | Use terminal standard input as the script |
-| `--config` | Custom path to your Prisma config file |
+| Option     | Description                                     |
+| ---------- | ----------------------------------------------- |
+| `--file`   | Path to a file containing the script to execute |
+| `--stdin`  | Use terminal standard input as the script       |
+| `--config` | Custom path to your Prisma config file          |
 
 ## Current Option Surface
 
@@ -59,9 +59,9 @@ Uses `datasource` from `prisma.config.ts`:
 
 ```typescript
 export default defineConfig({
-  datasource: {
-    url: env('DATABASE_URL'),
-  },
+    datasource: {
+        url: env('DATABASE_URL'),
+    },
 })
 ```
 

--- a/.agents/skills/prisma-cli/references/db-pull.md
+++ b/.agents/skills/prisma-cli/references/db-pull.md
@@ -1,0 +1,185 @@
+# prisma db pull
+
+Introspects an existing database and updates your Prisma schema to reflect its structure.
+
+## Command
+
+```bash
+prisma db pull [options]
+```
+
+## What It Does
+
+- Connects to your database
+- Reads the database schema (tables, columns, relations, indexes)
+- Updates `schema.prisma` with corresponding Prisma models
+- For MongoDB, samples data to infer schema
+
+## Options
+
+| Option | Description |
+|--------|-------------|
+| `--force` | Ignore current Prisma schema file |
+| `--print` | Print the introspected Prisma schema to stdout |
+| `--schema` | Custom path to your Prisma schema |
+| `--config` | Custom path to your Prisma config file |
+| `--url` | Override the datasource URL from the Prisma config file |
+| `--composite-type-depth` | Specify the depth for introspecting composite types (default: -1 for infinite, 0 = off) |
+| `--schemas` | Specify the database schemas to introspect |
+| `--local-d1` | Generate a Prisma schema from a local Cloudflare D1 database |
+
+## Examples
+
+### Basic introspection
+
+```bash
+prisma db pull
+```
+
+### Preview without writing
+
+```bash
+prisma db pull --print
+```
+
+Outputs schema to terminal for review.
+
+### Force overwrite
+
+```bash
+prisma db pull --force
+```
+
+Replaces schema file, losing any manual customizations.
+
+## Prerequisites
+
+Configure database connection in `prisma.config.ts`:
+
+```typescript
+import 'dotenv/config'
+import { defineConfig, env } from 'prisma/config'
+
+export default defineConfig({
+  schema: 'prisma/schema.prisma',
+  datasource: {
+    url: env('DATABASE_URL'),
+  },
+})
+```
+
+## Workflow
+
+### Starting from existing database
+
+1. Initialize Prisma:
+   ```bash
+   prisma init
+   ```
+
+2. Configure database URL
+
+3. Pull schema:
+   ```bash
+   prisma db pull
+   ```
+
+4. Review and customize generated schema
+
+5. Generate client:
+   ```bash
+   prisma generate
+   ```
+
+### Syncing changes from database
+
+When database changes are made outside Prisma:
+
+```bash
+prisma db pull
+prisma generate
+```
+
+## Generated Schema Example
+
+Database tables become Prisma models:
+
+```sql
+-- Database tables
+CREATE TABLE users (
+  id SERIAL PRIMARY KEY,
+  email VARCHAR(255) UNIQUE NOT NULL,
+  name VARCHAR(100)
+);
+
+CREATE TABLE posts (
+  id SERIAL PRIMARY KEY,
+  title VARCHAR(255) NOT NULL,
+  author_id INTEGER REFERENCES users(id)
+);
+```
+
+Becomes:
+
+```prisma
+model users {
+  id    Int     @id @default(autoincrement())
+  email String  @unique @db.VarChar(255)
+  name  String? @db.VarChar(100)
+  posts posts[]
+}
+
+model posts {
+  id        Int    @id @default(autoincrement())
+  title     String @db.VarChar(255)
+  author_id Int?
+  users     users? @relation(fields: [author_id], references: [id])
+}
+```
+
+## Post-Introspection Cleanup
+
+After `db pull`, consider:
+
+1. **Rename models** to PascalCase:
+   ```prisma
+   model User {  // Was: users
+     @@map("users")
+   }
+   ```
+
+2. **Rename fields** to camelCase:
+   ```prisma
+   authorId Int? @map("author_id")
+   ```
+
+3. **Add relation names** for clarity:
+   ```prisma
+   author User? @relation("PostAuthor", fields: [authorId], references: [id])
+   ```
+
+4. **Add documentation**:
+   ```prisma
+   /// User account information
+   model User {
+     /// Primary email for authentication
+     email String @unique
+   }
+   ```
+
+## MongoDB Introspection
+
+For MongoDB, `db pull` samples documents to infer schema:
+
+```bash
+prisma db pull
+```
+
+May require manual refinement since MongoDB is schemaless.
+
+## Warning
+
+`db pull` overwrites your schema file. Always:
+- Commit current schema before pulling
+- Use `--print` to preview first
+- Backup customizations you want to keep

--- a/.agents/skills/prisma-cli/references/db-pull.md
+++ b/.agents/skills/prisma-cli/references/db-pull.md
@@ -17,16 +17,16 @@ prisma db pull [options]
 
 ## Options
 
-| Option | Description |
-|--------|-------------|
-| `--force` | Ignore current Prisma schema file |
-| `--print` | Print the introspected Prisma schema to stdout |
-| `--schema` | Custom path to your Prisma schema |
-| `--config` | Custom path to your Prisma config file |
-| `--url` | Override the datasource URL from the Prisma config file |
+| Option                   | Description                                                                             |
+| ------------------------ | --------------------------------------------------------------------------------------- |
+| `--force`                | Ignore current Prisma schema file                                                       |
+| `--print`                | Print the introspected Prisma schema to stdout                                          |
+| `--schema`               | Custom path to your Prisma schema                                                       |
+| `--config`               | Custom path to your Prisma config file                                                  |
+| `--url`                  | Override the datasource URL from the Prisma config file                                 |
 | `--composite-type-depth` | Specify the depth for introspecting composite types (default: -1 for infinite, 0 = off) |
-| `--schemas` | Specify the database schemas to introspect |
-| `--local-d1` | Generate a Prisma schema from a local Cloudflare D1 database |
+| `--schemas`              | Specify the database schemas to introspect                                              |
+| `--local-d1`             | Generate a Prisma schema from a local Cloudflare D1 database                            |
 
 ## Examples
 
@@ -61,10 +61,10 @@ import 'dotenv/config'
 import { defineConfig, env } from 'prisma/config'
 
 export default defineConfig({
-  schema: 'prisma/schema.prisma',
-  datasource: {
-    url: env('DATABASE_URL'),
-  },
+    schema: 'prisma/schema.prisma',
+    datasource: {
+        url: env('DATABASE_URL'),
+    },
 })
 ```
 
@@ -73,23 +73,25 @@ export default defineConfig({
 ### Starting from existing database
 
 1. Initialize Prisma:
-   ```bash
-   prisma init
-   ```
+
+    ```bash
+    prisma init
+    ```
 
 2. Configure database URL
 
 3. Pull schema:
-   ```bash
-   prisma db pull
-   ```
+
+    ```bash
+    prisma db pull
+    ```
 
 4. Review and customize generated schema
 
 5. Generate client:
-   ```bash
-   prisma generate
-   ```
+    ```bash
+    prisma generate
+    ```
 
 ### Syncing changes from database
 
@@ -142,30 +144,33 @@ model posts {
 After `db pull`, consider:
 
 1. **Rename models** to PascalCase:
-   ```prisma
-   model User {  // Was: users
-     @@map("users")
-   }
-   ```
+
+    ```prisma
+    model User {  // Was: users
+      @@map("users")
+    }
+    ```
 
 2. **Rename fields** to camelCase:
-   ```prisma
-   authorId Int? @map("author_id")
-   ```
+
+    ```prisma
+    authorId Int? @map("author_id")
+    ```
 
 3. **Add relation names** for clarity:
-   ```prisma
-   author User? @relation("PostAuthor", fields: [authorId], references: [id])
-   ```
+
+    ```prisma
+    author User? @relation("PostAuthor", fields: [authorId], references: [id])
+    ```
 
 4. **Add documentation**:
-   ```prisma
-   /// User account information
-   model User {
-     /// Primary email for authentication
-     email String @unique
-   }
-   ```
+    ```prisma
+    /// User account information
+    model User {
+      /// Primary email for authentication
+      email String @unique
+    }
+    ```
 
 ## MongoDB Introspection
 
@@ -180,6 +185,7 @@ May require manual refinement since MongoDB is schemaless.
 ## Warning
 
 `db pull` overwrites your schema file. Always:
+
 - Commit current schema before pulling
 - Use `--print` to preview first
 - Backup customizations you want to keep

--- a/.agents/skills/prisma-cli/references/db-push.md
+++ b/.agents/skills/prisma-cli/references/db-push.md
@@ -1,0 +1,148 @@
+# prisma db push
+
+Pushes schema changes directly to database without creating migrations. Ideal for prototyping.
+
+## Command
+
+```bash
+prisma db push [options]
+```
+
+## What It Does
+
+- Syncs your Prisma schema to the database
+- Creates database if it doesn't exist
+- Does NOT create migration files
+- Does NOT track migration history
+
+## Options
+
+| Option | Description |
+|--------|-------------|
+| `--force-reset` | Force a reset of the database before push |
+| `--accept-data-loss` | Ignore data loss warnings |
+| `--schema` | Custom path to your Prisma schema |
+| `--config` | Custom path to your Prisma config file |
+| `--url` | Override the datasource URL from the Prisma config file |
+
+### Follow-up Command
+
+- Run `prisma generate` explicitly when you need refreshed client output
+
+## Examples
+
+### Basic push
+
+```bash
+prisma db push
+```
+
+### Accept data loss
+
+```bash
+prisma db push --accept-data-loss
+```
+
+Required when changes would delete data (dropping columns, etc.)
+
+### Force reset
+
+```bash
+prisma db push --force-reset
+```
+
+Completely resets database and applies schema.
+
+### Full workflow
+
+```bash
+prisma db push
+prisma generate
+```
+
+## When to Use
+
+- **Prototyping** - Rapid schema iteration
+- **Local development** - Quick schema changes
+- **MongoDB** - Primary workflow (migrations not supported)
+- **Testing** - Setting up test databases
+
+## When NOT to Use
+
+- **Production** - Use `migrate deploy`
+- **Team collaboration** - Use migrations for trackable changes
+- **When you need rollback** - Migrations provide history
+
+## Comparison with migrate dev
+
+| Feature | db push | migrate dev |
+|---------|---------|-------------|
+| Creates migration files | No | Yes |
+| Tracks history | No | Yes |
+| Requires shadow database | No | Yes |
+| Speed | Faster | Slower |
+| Rollback capability | No | Yes |
+| Best for | Prototyping | Development |
+
+## MongoDB Workflow
+
+MongoDB doesn't support migrations. Use `db push` exclusively:
+
+```bash
+# Schema changes for MongoDB
+prisma db push
+prisma generate
+```
+
+## Common Patterns
+
+### Prototyping workflow
+
+```bash
+# Make schema changes
+# ...
+
+# Push to database
+prisma db push
+
+# Generate client
+prisma generate
+
+# Test your changes
+# Repeat as needed
+```
+
+### Reset and start fresh
+
+```bash
+prisma db push --force-reset
+prisma db seed
+```
+
+### Handling conflicts
+
+If `db push` can't apply changes safely:
+
+```
+Error: The following changes cannot be applied:
+  - Removing field `email` would cause data loss
+  
+Use --accept-data-loss to proceed
+```
+
+Decide whether data loss is acceptable, then:
+
+```bash
+prisma db push --accept-data-loss
+```
+
+## Transition to Migrations
+
+When ready for production, switch to migrations:
+
+```bash
+# Create baseline migration from current schema
+prisma migrate dev --name init
+```
+
+Then use `migrate dev` for future changes.

--- a/.agents/skills/prisma-cli/references/db-push.md
+++ b/.agents/skills/prisma-cli/references/db-push.md
@@ -17,13 +17,13 @@ prisma db push [options]
 
 ## Options
 
-| Option | Description |
-|--------|-------------|
-| `--force-reset` | Force a reset of the database before push |
-| `--accept-data-loss` | Ignore data loss warnings |
-| `--schema` | Custom path to your Prisma schema |
-| `--config` | Custom path to your Prisma config file |
-| `--url` | Override the datasource URL from the Prisma config file |
+| Option               | Description                                             |
+| -------------------- | ------------------------------------------------------- |
+| `--force-reset`      | Force a reset of the database before push               |
+| `--accept-data-loss` | Ignore data loss warnings                               |
+| `--schema`           | Custom path to your Prisma schema                       |
+| `--config`           | Custom path to your Prisma config file                  |
+| `--url`              | Override the datasource URL from the Prisma config file |
 
 ### Follow-up Command
 
@@ -75,14 +75,14 @@ prisma generate
 
 ## Comparison with migrate dev
 
-| Feature | db push | migrate dev |
-|---------|---------|-------------|
-| Creates migration files | No | Yes |
-| Tracks history | No | Yes |
-| Requires shadow database | No | Yes |
-| Speed | Faster | Slower |
-| Rollback capability | No | Yes |
-| Best for | Prototyping | Development |
+| Feature                  | db push     | migrate dev |
+| ------------------------ | ----------- | ----------- |
+| Creates migration files  | No          | Yes         |
+| Tracks history           | No          | Yes         |
+| Requires shadow database | No          | Yes         |
+| Speed                    | Faster      | Slower      |
+| Rollback capability      | No          | Yes         |
+| Best for                 | Prototyping | Development |
 
 ## MongoDB Workflow
 
@@ -126,7 +126,7 @@ If `db push` can't apply changes safely:
 ```
 Error: The following changes cannot be applied:
   - Removing field `email` would cause data loss
-  
+
 Use --accept-data-loss to proceed
 ```
 

--- a/.agents/skills/prisma-cli/references/db-seed.md
+++ b/.agents/skills/prisma-cli/references/db-seed.md
@@ -1,0 +1,188 @@
+# prisma db seed
+
+Runs your database seed script to populate data.
+
+## Command
+
+```bash
+prisma db seed [options]
+```
+
+## What It Does
+
+- Executes your configured seed script
+- Populates database with initial/test data
+- Runs independently (not auto-run by migrations in v7)
+
+## Options
+
+| Option | Description |
+|--------|-------------|
+| `--config` | Custom path to your Prisma config file |
+| `--` | Pass custom arguments to seed script |
+
+## Configuration
+
+Configure seed script in `prisma.config.ts`:
+
+```typescript
+import 'dotenv/config'
+import { defineConfig, env } from 'prisma/config'
+
+export default defineConfig({
+  schema: 'prisma/schema.prisma',
+  migrations: {
+    path: 'prisma/migrations',
+    seed: 'tsx prisma/seed.ts',  // Your seed command
+  },
+  datasource: {
+    url: env('DATABASE_URL'),
+  },
+})
+```
+
+### Common seed commands
+
+```typescript
+// TypeScript with tsx
+seed: 'tsx prisma/seed.ts'
+
+// TypeScript with ts-node
+seed: 'ts-node prisma/seed.ts'
+
+// JavaScript
+seed: 'node prisma/seed.js'
+```
+
+## Seed Script Example
+
+```typescript
+// prisma/seed.ts
+import { PrismaClient } from '../generated/client'
+
+const prisma = new PrismaClient()
+
+async function main() {
+  // Create users
+  const alice = await prisma.user.upsert({
+    where: { email: 'alice@prisma.io' },
+    update: {},
+    create: {
+      email: 'alice@prisma.io',
+      name: 'Alice',
+      posts: {
+        create: {
+          title: 'Hello World',
+          published: true,
+        },
+      },
+    },
+  })
+
+  const bob = await prisma.user.upsert({
+    where: { email: 'bob@prisma.io' },
+    update: {},
+    create: {
+      email: 'bob@prisma.io',
+      name: 'Bob',
+    },
+  })
+
+  console.log({ alice, bob })
+}
+
+main()
+  .then(async () => {
+    await prisma.$disconnect()
+  })
+  .catch(async (e) => {
+    console.error(e)
+    await prisma.$disconnect()
+    process.exit(1)
+  })
+```
+
+## Examples
+
+### Run seed
+
+```bash
+prisma db seed
+```
+
+### With custom arguments
+
+```bash
+prisma db seed -- --environment development
+```
+
+Arguments after `--` are passed to your seed script.
+
+## Current Workflow
+
+Run seeding explicitly after migrations when you need seed data:
+
+```bash
+prisma migrate dev --name init
+prisma generate
+prisma db seed  # Must run explicitly
+```
+
+## Idempotent Seeding
+
+Use `upsert` to make seeds re-runnable:
+
+```typescript
+// Good: Can run multiple times
+await prisma.user.upsert({
+  where: { email: 'alice@prisma.io' },
+  update: {},  // Don't change existing
+  create: { email: 'alice@prisma.io', name: 'Alice' },
+})
+
+// Bad: Fails on second run
+await prisma.user.create({
+  data: { email: 'alice@prisma.io', name: 'Alice' },
+})
+```
+
+## Common Patterns
+
+### Development reset
+
+```bash
+prisma migrate reset --force
+prisma db seed
+```
+
+### Conditional seeding
+
+```typescript
+// prisma/seed.ts
+const count = await prisma.user.count()
+if (count === 0) {
+  // Only seed if empty
+  await seedUsers()
+}
+```
+
+### Environment-specific seeds
+
+```typescript
+// prisma/seed.ts
+const env = process.env.NODE_ENV || 'development'
+
+if (env === 'development') {
+  await seedDevData()
+} else if (env === 'test') {
+  await seedTestData()
+}
+```
+
+## Best Practices
+
+1. Use `upsert` for idempotent seeds
+2. Keep seeds focused and minimal
+3. Use realistic but fake data
+4. Document required seed data
+5. Version control your seed scripts

--- a/.agents/skills/prisma-cli/references/db-seed.md
+++ b/.agents/skills/prisma-cli/references/db-seed.md
@@ -16,10 +16,10 @@ prisma db seed [options]
 
 ## Options
 
-| Option | Description |
-|--------|-------------|
+| Option     | Description                            |
+| ---------- | -------------------------------------- |
 | `--config` | Custom path to your Prisma config file |
-| `--` | Pass custom arguments to seed script |
+| `--`       | Pass custom arguments to seed script   |
 
 ## Configuration
 
@@ -30,14 +30,14 @@ import 'dotenv/config'
 import { defineConfig, env } from 'prisma/config'
 
 export default defineConfig({
-  schema: 'prisma/schema.prisma',
-  migrations: {
-    path: 'prisma/migrations',
-    seed: 'tsx prisma/seed.ts',  // Your seed command
-  },
-  datasource: {
-    url: env('DATABASE_URL'),
-  },
+    schema: 'prisma/schema.prisma',
+    migrations: {
+        path: 'prisma/migrations',
+        seed: 'tsx prisma/seed.ts', // Your seed command
+    },
+    datasource: {
+        url: env('DATABASE_URL'),
+    },
 })
 ```
 
@@ -63,43 +63,43 @@ import { PrismaClient } from '../generated/client'
 const prisma = new PrismaClient()
 
 async function main() {
-  // Create users
-  const alice = await prisma.user.upsert({
-    where: { email: 'alice@prisma.io' },
-    update: {},
-    create: {
-      email: 'alice@prisma.io',
-      name: 'Alice',
-      posts: {
+    // Create users
+    const alice = await prisma.user.upsert({
+        where: { email: 'alice@prisma.io' },
+        update: {},
         create: {
-          title: 'Hello World',
-          published: true,
+            email: 'alice@prisma.io',
+            name: 'Alice',
+            posts: {
+                create: {
+                    title: 'Hello World',
+                    published: true,
+                },
+            },
         },
-      },
-    },
-  })
+    })
 
-  const bob = await prisma.user.upsert({
-    where: { email: 'bob@prisma.io' },
-    update: {},
-    create: {
-      email: 'bob@prisma.io',
-      name: 'Bob',
-    },
-  })
+    const bob = await prisma.user.upsert({
+        where: { email: 'bob@prisma.io' },
+        update: {},
+        create: {
+            email: 'bob@prisma.io',
+            name: 'Bob',
+        },
+    })
 
-  console.log({ alice, bob })
+    console.log({ alice, bob })
 }
 
 main()
-  .then(async () => {
-    await prisma.$disconnect()
-  })
-  .catch(async (e) => {
-    console.error(e)
-    await prisma.$disconnect()
-    process.exit(1)
-  })
+    .then(async () => {
+        await prisma.$disconnect()
+    })
+    .catch(async e => {
+        console.error(e)
+        await prisma.$disconnect()
+        process.exit(1)
+    })
 ```
 
 ## Examples
@@ -135,14 +135,14 @@ Use `upsert` to make seeds re-runnable:
 ```typescript
 // Good: Can run multiple times
 await prisma.user.upsert({
-  where: { email: 'alice@prisma.io' },
-  update: {},  // Don't change existing
-  create: { email: 'alice@prisma.io', name: 'Alice' },
+    where: { email: 'alice@prisma.io' },
+    update: {}, // Don't change existing
+    create: { email: 'alice@prisma.io', name: 'Alice' },
 })
 
 // Bad: Fails on second run
 await prisma.user.create({
-  data: { email: 'alice@prisma.io', name: 'Alice' },
+    data: { email: 'alice@prisma.io', name: 'Alice' },
 })
 ```
 
@@ -161,8 +161,8 @@ prisma db seed
 // prisma/seed.ts
 const count = await prisma.user.count()
 if (count === 0) {
-  // Only seed if empty
-  await seedUsers()
+    // Only seed if empty
+    await seedUsers()
 }
 ```
 
@@ -173,9 +173,9 @@ if (count === 0) {
 const env = process.env.NODE_ENV || 'development'
 
 if (env === 'development') {
-  await seedDevData()
+    await seedDevData()
 } else if (env === 'test') {
-  await seedTestData()
+    await seedTestData()
 }
 ```
 

--- a/.agents/skills/prisma-cli/references/debug.md
+++ b/.agents/skills/prisma-cli/references/debug.md
@@ -1,0 +1,46 @@
+# prisma debug
+
+Prints information helpful for debugging and bug reports.
+
+## Command
+
+```bash
+prisma debug [options]
+```
+
+## What It Does
+
+Outputs details about your Prisma environment, including:
+- Prisma CLI version
+- Prisma Client version (if installed)
+- Engine binaries (Query Engine, Migration Engine, etc.)
+- Platform information (OS, Architecture)
+- Node.js version
+- Configured datasource provider
+
+## Options
+
+| Option | Description |
+|--------|-------------|
+| `--schema` | Path to schema file |
+| `--config` | Custom path to your Prisma config file |
+
+## Example Output
+
+```
+prisma               : 7.3.0
+@prisma/client       : 7.3.0
+Operating System     : darwin
+Architecture         : arm64
+Node.js              : v20.10.0
+TypeScript           : 5.3.3
+Query Compiler       : enabled
+PSL                  : ...
+Schema Engine        : ...
+```
+
+## When to Use
+
+- **Troubleshooting**: Checking version mismatches
+- **Reporting Issues**: Including environment info in GitHub issues
+- **Verifying Installation**: Ensuring correct binaries are downloaded

--- a/.agents/skills/prisma-cli/references/debug.md
+++ b/.agents/skills/prisma-cli/references/debug.md
@@ -11,6 +11,7 @@ prisma debug [options]
 ## What It Does
 
 Outputs details about your Prisma environment, including:
+
 - Prisma CLI version
 - Prisma Client version (if installed)
 - Engine binaries (Query Engine, Migration Engine, etc.)
@@ -20,9 +21,9 @@ Outputs details about your Prisma environment, including:
 
 ## Options
 
-| Option | Description |
-|--------|-------------|
-| `--schema` | Path to schema file |
+| Option     | Description                            |
+| ---------- | -------------------------------------- |
+| `--schema` | Path to schema file                    |
 | `--config` | Custom path to your Prisma config file |
 
 ## Example Output

--- a/.agents/skills/prisma-cli/references/dev.md
+++ b/.agents/skills/prisma-cli/references/dev.md
@@ -1,0 +1,157 @@
+# prisma dev
+
+Starts a local Prisma Postgres database for development. Provides a PostgreSQL-compatible database that runs entirely on your machine.
+
+## Command
+
+```bash
+prisma dev [options]
+```
+
+## What It Does
+
+- Starts a local PostgreSQL-compatible database
+- Runs in your terminal or as a background process
+- Perfect for development and testing
+- Easy migration to Prisma Postgres cloud in production
+
+## Options
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--name` / `-n` | Name for the database instance | `default` |
+| `--port` / `-p` | HTTP server port | `51213` |
+| `--db-port` / `-P` | Database server port | `51214` |
+| `--shadow-db-port` | Shadow database port (for migrations) | `51215` |
+| `--detach` / `-d` | Run in background | `false` |
+| `--debug` | Enable debug logging | `false` |
+
+## Examples
+
+### Start local database
+
+```bash
+prisma dev
+```
+
+Interactive mode with keyboard shortcuts:
+- `q` - Quit
+- `h` - Show HTTP URL  
+- `t` - Show TCP URLs
+
+### Named instance
+
+```bash
+prisma dev --name myproject
+```
+
+Useful for multiple projects.
+
+### Background mode
+
+```bash
+prisma dev --detach
+```
+
+Frees your terminal for other commands.
+
+### Custom ports
+
+```bash
+prisma dev --port 5000 --db-port 5432
+```
+
+## Instance Management
+
+### List all instances
+
+```bash
+prisma dev ls
+```
+
+Shows all local Prisma Postgres instances with status.
+
+### Start existing instance
+
+```bash
+prisma dev start myproject
+```
+
+Starts a previously created instance in background.
+
+### Stop instance
+
+```bash
+prisma dev stop myproject
+```
+
+### Stop with glob pattern
+
+```bash
+prisma dev stop "myproject*"
+```
+
+Stops all instances matching pattern.
+
+### Remove instance
+
+```bash
+prisma dev rm myproject
+```
+
+Removes instance data from filesystem.
+
+### Force remove (stops first)
+
+```bash
+prisma dev rm myproject --force
+```
+
+## Configuration
+
+Configure your `prisma.config.ts` to use local Prisma Postgres:
+
+```typescript
+import 'dotenv/config'
+import { defineConfig, env } from 'prisma/config'
+
+export default defineConfig({
+  schema: 'prisma/schema.prisma',
+  migrations: {
+    path: 'prisma/migrations',
+  },
+  datasource: {
+    // Local Prisma Postgres URL (from prisma dev output)
+    url: env('DATABASE_URL'),
+  },
+})
+```
+
+## Workflow
+
+1. Start local database:
+   ```bash
+   prisma dev
+   ```
+
+2. In another terminal, run migrations:
+   ```bash
+   prisma migrate dev
+   ```
+
+3. Generate client:
+   ```bash
+   prisma generate
+   ```
+
+4. Run your application
+
+## Production Migration
+
+When ready for production, switch to Prisma Postgres cloud:
+
+```bash
+prisma init --db
+```
+
+Update your `DATABASE_URL` to the cloud connection string.

--- a/.agents/skills/prisma-cli/references/dev.md
+++ b/.agents/skills/prisma-cli/references/dev.md
@@ -17,14 +17,14 @@ prisma dev [options]
 
 ## Options
 
-| Option | Description | Default |
-|--------|-------------|---------|
-| `--name` / `-n` | Name for the database instance | `default` |
-| `--port` / `-p` | HTTP server port | `51213` |
-| `--db-port` / `-P` | Database server port | `51214` |
-| `--shadow-db-port` | Shadow database port (for migrations) | `51215` |
-| `--detach` / `-d` | Run in background | `false` |
-| `--debug` | Enable debug logging | `false` |
+| Option             | Description                           | Default   |
+| ------------------ | ------------------------------------- | --------- |
+| `--name` / `-n`    | Name for the database instance        | `default` |
+| `--port` / `-p`    | HTTP server port                      | `51213`   |
+| `--db-port` / `-P` | Database server port                  | `51214`   |
+| `--shadow-db-port` | Shadow database port (for migrations) | `51215`   |
+| `--detach` / `-d`  | Run in background                     | `false`   |
+| `--debug`          | Enable debug logging                  | `false`   |
 
 ## Examples
 
@@ -35,8 +35,9 @@ prisma dev
 ```
 
 Interactive mode with keyboard shortcuts:
+
 - `q` - Quit
-- `h` - Show HTTP URL  
+- `h` - Show HTTP URL
 - `t` - Show TCP URLs
 
 ### Named instance
@@ -116,33 +117,36 @@ import 'dotenv/config'
 import { defineConfig, env } from 'prisma/config'
 
 export default defineConfig({
-  schema: 'prisma/schema.prisma',
-  migrations: {
-    path: 'prisma/migrations',
-  },
-  datasource: {
-    // Local Prisma Postgres URL (from prisma dev output)
-    url: env('DATABASE_URL'),
-  },
+    schema: 'prisma/schema.prisma',
+    migrations: {
+        path: 'prisma/migrations',
+    },
+    datasource: {
+        // Local Prisma Postgres URL (from prisma dev output)
+        url: env('DATABASE_URL'),
+    },
 })
 ```
 
 ## Workflow
 
 1. Start local database:
-   ```bash
-   prisma dev
-   ```
+
+    ```bash
+    prisma dev
+    ```
 
 2. In another terminal, run migrations:
-   ```bash
-   prisma migrate dev
-   ```
+
+    ```bash
+    prisma migrate dev
+    ```
 
 3. Generate client:
-   ```bash
-   prisma generate
-   ```
+
+    ```bash
+    prisma generate
+    ```
 
 4. Run your application
 

--- a/.agents/skills/prisma-cli/references/format.md
+++ b/.agents/skills/prisma-cli/references/format.md
@@ -1,0 +1,48 @@
+# prisma format
+
+Formats your Prisma schema file.
+
+## Command
+
+```bash
+prisma format [options]
+```
+
+## What It Does
+
+- Fixes formatting (indentation, spacing)
+- Adds missing back-relations (e.g., adds the other side of a relation)
+- Adds missing relation arguments (e.g., `fields`, `references`)
+- Sorts fields and attributes (opinionated)
+
+## Options
+
+| Option | Description |
+|--------|-------------|
+| `--schema` | Path to schema file |
+| `--config` | Custom path to your Prisma config file |
+
+## Examples
+
+### Format default schema
+
+```bash
+prisma format
+```
+
+### Format specific schema
+
+```bash
+prisma format --schema=./custom/schema.prisma
+```
+
+## Behavior
+
+`prisma format` modifies the file in place. It is equivalent to "Prettier for Prisma schemas" but also has semantic understanding to fix/add missing schema definitions.
+
+## Use in Editor
+
+Most Prisma editor extensions (VS Code, WebStorm) run `prisma format` automatically on save. This command is useful for:
+- CI pipelines (check formatting)
+- CLI-based workflows
+- Fixing large schema refactors

--- a/.agents/skills/prisma-cli/references/format.md
+++ b/.agents/skills/prisma-cli/references/format.md
@@ -17,9 +17,9 @@ prisma format [options]
 
 ## Options
 
-| Option | Description |
-|--------|-------------|
-| `--schema` | Path to schema file |
+| Option     | Description                            |
+| ---------- | -------------------------------------- |
+| `--schema` | Path to schema file                    |
 | `--config` | Custom path to your Prisma config file |
 
 ## Examples
@@ -43,6 +43,7 @@ prisma format --schema=./custom/schema.prisma
 ## Use in Editor
 
 Most Prisma editor extensions (VS Code, WebStorm) run `prisma format` automatically on save. This command is useful for:
+
 - CI pipelines (check formatting)
 - CLI-based workflows
 - Fixing large schema refactors

--- a/.agents/skills/prisma-cli/references/generate.md
+++ b/.agents/skills/prisma-cli/references/generate.md
@@ -1,0 +1,173 @@
+# prisma generate
+
+Generates assets based on the generator blocks in your Prisma schema, most commonly Prisma Client.
+
+## Command
+
+```bash
+prisma generate [options]
+```
+
+## Bun Runtime
+
+If you're using Bun, run Prisma with `bunx --bun` so it doesn't fall back to Node.js:
+
+```bash
+bunx --bun prisma generate
+```
+
+## What It Does
+
+1. Reads your `schema.prisma` file
+2. Generates a customized Prisma Client based on your models
+3. Outputs to the directory specified in the generator block
+
+## Options
+
+| Option | Description |
+|--------|-------------|
+| `--schema` | Custom path to your Prisma schema |
+| `--config` | Custom path to your Prisma config file |
+| `--sql` | Generate typed sql module |
+| `--watch` | Watch the Prisma schema and rerun after a change |
+| `--generator` | Generator to use (may be provided multiple times) |
+| `--no-hints` | Hides the hint messages but still outputs errors and warnings |
+| `--require-models` | Do not allow generating a client without models |
+
+## Examples
+
+### Basic generation
+
+```bash
+prisma generate
+```
+
+### Watch mode (development)
+
+```bash
+prisma generate --watch
+```
+
+Auto-regenerates when `schema.prisma` changes.
+
+### Specific generator
+
+```bash
+prisma generate --generator client
+```
+
+### Multiple generators
+
+```bash
+prisma generate --generator client --generator zod_schemas
+```
+
+### Typed SQL generation
+
+```bash
+prisma generate --sql
+```
+
+## Schema Configuration
+
+```prisma
+generator client {
+  provider = "prisma-client"
+  output   = "../generated"
+}
+```
+
+### Current Generator Behavior
+
+- `prisma-client` is the standard generator
+- `output` is required when using `prisma-client`
+- `prisma-client` supports both ESM and CommonJS via `moduleFormat`
+- `compilerBuild` supports `fast` and `small` query compiler artifacts
+- Use TypeScript `satisfies` for typed query fragments with `prisma-client`
+- Import Prisma Client from your generated output path, for example:
+
+```typescript
+import { PrismaClient } from '../generated/prisma/client'
+```
+
+### Compiler Build Tuning
+
+Use `compilerBuild` when you need to trade artifact size against the default build:
+
+```prisma
+generator client {
+  provider      = "prisma-client"
+  output        = "../generated"
+  compilerBuild = "small"
+}
+```
+
+- `fast` is the default build for most targets
+- `small` is useful for size-constrained targets
+- Prisma defaults `vercel-edge` targets to `small`
+
+## Common Patterns
+
+### After schema changes
+
+```bash
+prisma migrate dev --name my_migration
+prisma generate
+```
+
+Run `prisma generate` whenever you need refreshed client code after schema-changing commands.
+
+### CI/CD pipeline
+
+```bash
+prisma generate
+```
+
+Run before building your application.
+
+### Multiple generators
+
+```prisma
+generator client {
+  provider = "prisma-client"
+  output   = "../generated"
+}
+
+generator zod {
+  provider = "zod-prisma-types"
+  output   = "../generated/zod"
+}
+```
+
+```bash
+prisma generate  # Runs all generators
+```
+
+## Output Structure
+
+After running `prisma generate`, your output directory contains:
+
+```
+generated/
+├── browser.ts
+├── client.ts
+├── commonInputTypes.ts
+├── models/
+├── enums.ts
+├── models.ts
+└── ...
+```
+
+Import the client:
+
+```typescript
+import { PrismaClient, Prisma } from '../generated/prisma/client'
+```
+
+Import browser-safe types:
+
+```typescript
+import { Prisma } from '../generated/prisma/browser'
+import { Role } from '../generated/prisma/enums'
+import type { UserModel } from '../generated/prisma/models/User'
+```

--- a/.agents/skills/prisma-cli/references/generate.md
+++ b/.agents/skills/prisma-cli/references/generate.md
@@ -24,15 +24,15 @@ bunx --bun prisma generate
 
 ## Options
 
-| Option | Description |
-|--------|-------------|
-| `--schema` | Custom path to your Prisma schema |
-| `--config` | Custom path to your Prisma config file |
-| `--sql` | Generate typed sql module |
-| `--watch` | Watch the Prisma schema and rerun after a change |
-| `--generator` | Generator to use (may be provided multiple times) |
-| `--no-hints` | Hides the hint messages but still outputs errors and warnings |
-| `--require-models` | Do not allow generating a client without models |
+| Option             | Description                                                   |
+| ------------------ | ------------------------------------------------------------- |
+| `--schema`         | Custom path to your Prisma schema                             |
+| `--config`         | Custom path to your Prisma config file                        |
+| `--sql`            | Generate typed sql module                                     |
+| `--watch`          | Watch the Prisma schema and rerun after a change              |
+| `--generator`      | Generator to use (may be provided multiple times)             |
+| `--no-hints`       | Hides the hint messages but still outputs errors and warnings |
+| `--require-models` | Do not allow generating a client without models               |
 
 ## Examples
 

--- a/.agents/skills/prisma-cli/references/init.md
+++ b/.agents/skills/prisma-cli/references/init.md
@@ -1,0 +1,136 @@
+# prisma init
+
+Bootstraps a fresh Prisma ORM project in the current directory.
+
+## Command
+
+```bash
+prisma init [options]
+```
+
+## Bun Runtime
+
+If you're using Bun, run Prisma with `bunx --bun` so it doesn't fall back to Node.js:
+
+```bash
+bunx --bun prisma init
+```
+
+## What It Creates
+
+- `prisma/schema.prisma` - Your Prisma schema file
+- `prisma.config.ts` - TypeScript configuration for Prisma CLI
+- `.env` - Environment variables (DATABASE_URL)
+- `.gitignore` - Ensures `.env` is ignored and appends the generated client path
+
+## Options
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--datasource-provider` | Database provider: `postgresql`, `mysql`, `sqlite`, `sqlserver`, `mongodb`, `cockroachdb` | `postgresql` |
+| `--db` | Provisions a fully managed Prisma Postgres database on the Prisma Data Platform | - |
+| `--url` | Define a custom datasource url | - |
+| `--generator-provider` | Define the generator provider to use | `prisma-client` |
+| `--output` | Define Prisma Client generator output path to use | - |
+| `--preview-feature` | Define a preview feature to use | - |
+| `--with-model` | Add example model to created schema file | - |
+
+## Examples
+
+### Basic initialization
+
+```bash
+prisma init
+```
+
+Creates a PostgreSQL project setup.
+
+### SQLite project
+
+```bash
+prisma init --datasource-provider sqlite
+```
+
+### MySQL with custom URL
+
+```bash
+prisma init --datasource-provider mysql --url "mysql://user:password@localhost:3306/mydb"
+```
+
+### Prisma Postgres (cloud)
+
+```bash
+prisma init --db
+```
+
+Opens browser for authentication, creates cloud database instance.
+
+### Add an example model
+
+```bash
+prisma init --with-model
+```
+
+Adds a starter model to the generated schema.
+
+### With preview features
+
+```bash
+prisma init --preview-feature relationJoins --preview-feature fullTextSearch
+```
+
+## Generated Schema
+
+```prisma
+generator client {
+  provider = "prisma-client"
+  output   = "../generated/prisma"
+}
+
+datasource db {
+  provider = "postgresql"
+}
+```
+
+## Generated Config (Node.js default)
+
+```typescript
+// prisma.config.ts
+import "dotenv/config";
+import { defineConfig } from 'prisma/config'
+
+export default defineConfig({
+  schema: 'prisma/schema.prisma',
+  migrations: {
+    path: 'prisma/migrations',
+  },
+  datasource: {
+    url: process.env['DATABASE_URL'],
+  },
+})
+```
+
+## Generated Config (Bun)
+
+```typescript
+import { defineConfig, env } from 'prisma/config'
+
+export default defineConfig({
+  schema: 'prisma/schema.prisma',
+  migrations: {
+    path: 'prisma/migrations',
+  },
+  datasource: {
+    url: env('DATABASE_URL'),
+  },
+})
+```
+
+## Next Steps After Init
+
+1. Configure `DATABASE_URL` in `.env` (and let `prisma.config.ts` read it)
+2. Define your models in `prisma/schema.prisma`
+3. Run `prisma dev` for local development or connect to remote DB
+4. Run `prisma migrate dev` to create migrations
+5. Run `prisma generate` to generate Prisma Client
+6. Run `prisma db seed` explicitly if you want seed data

--- a/.agents/skills/prisma-cli/references/init.md
+++ b/.agents/skills/prisma-cli/references/init.md
@@ -25,15 +25,15 @@ bunx --bun prisma init
 
 ## Options
 
-| Option | Description | Default |
-|--------|-------------|---------|
-| `--datasource-provider` | Database provider: `postgresql`, `mysql`, `sqlite`, `sqlserver`, `mongodb`, `cockroachdb` | `postgresql` |
-| `--db` | Provisions a fully managed Prisma Postgres database on the Prisma Data Platform | - |
-| `--url` | Define a custom datasource url | - |
-| `--generator-provider` | Define the generator provider to use | `prisma-client` |
-| `--output` | Define Prisma Client generator output path to use | - |
-| `--preview-feature` | Define a preview feature to use | - |
-| `--with-model` | Add example model to created schema file | - |
+| Option                  | Description                                                                               | Default         |
+| ----------------------- | ----------------------------------------------------------------------------------------- | --------------- |
+| `--datasource-provider` | Database provider: `postgresql`, `mysql`, `sqlite`, `sqlserver`, `mongodb`, `cockroachdb` | `postgresql`    |
+| `--db`                  | Provisions a fully managed Prisma Postgres database on the Prisma Data Platform           | -               |
+| `--url`                 | Define a custom datasource url                                                            | -               |
+| `--generator-provider`  | Define the generator provider to use                                                      | `prisma-client` |
+| `--output`              | Define Prisma Client generator output path to use                                         | -               |
+| `--preview-feature`     | Define a preview feature to use                                                           | -               |
+| `--with-model`          | Add example model to created schema file                                                  | -               |
 
 ## Examples
 
@@ -96,17 +96,17 @@ datasource db {
 
 ```typescript
 // prisma.config.ts
-import "dotenv/config";
+import 'dotenv/config'
 import { defineConfig } from 'prisma/config'
 
 export default defineConfig({
-  schema: 'prisma/schema.prisma',
-  migrations: {
-    path: 'prisma/migrations',
-  },
-  datasource: {
-    url: process.env['DATABASE_URL'],
-  },
+    schema: 'prisma/schema.prisma',
+    migrations: {
+        path: 'prisma/migrations',
+    },
+    datasource: {
+        url: process.env['DATABASE_URL'],
+    },
 })
 ```
 
@@ -116,13 +116,13 @@ export default defineConfig({
 import { defineConfig, env } from 'prisma/config'
 
 export default defineConfig({
-  schema: 'prisma/schema.prisma',
-  migrations: {
-    path: 'prisma/migrations',
-  },
-  datasource: {
-    url: env('DATABASE_URL'),
-  },
+    schema: 'prisma/schema.prisma',
+    migrations: {
+        path: 'prisma/migrations',
+    },
+    datasource: {
+        url: env('DATABASE_URL'),
+    },
 })
 ```
 

--- a/.agents/skills/prisma-cli/references/mcp.md
+++ b/.agents/skills/prisma-cli/references/mcp.md
@@ -1,0 +1,38 @@
+# prisma mcp
+
+Starts Prisma's MCP server for AI development tools.
+
+## Command
+
+```bash
+prisma mcp
+```
+
+## What It Does
+
+- Starts a Model Context Protocol (MCP) server for your Prisma project
+- Exposes Prisma schema and database context to compatible AI tools
+- Helps AI assistants understand models, generate queries, and suggest migrations
+
+## Usage
+
+```bash
+prisma mcp
+```
+
+## Typical Use Cases
+
+- Connect Prisma to ChatGPT, Claude, or other MCP-aware tools
+- Give an AI assistant access to your Prisma schema structure
+- Help an agent propose queries, schema updates, and migration steps with project context
+
+## Notes
+
+- Run this from the project that contains your Prisma schema and `prisma.config.ts`
+- The command is separate from Prisma Studio and does not open a browser UI
+- The MCP server wraps Prisma CLI commands. For exact behavior of commands like `migrate dev` or `migrate reset`, follow the underlying CLI command docs rather than relying only on the MCP tool descriptions.
+
+## References
+
+- [Prisma CLI `mcp` command](https://docs.prisma.io/docs/cli/mcp)
+- [Prisma MCP Server](https://www.prisma.io/docs/ai/tools/chatgpt)

--- a/.agents/skills/prisma-cli/references/migrate-deploy.md
+++ b/.agents/skills/prisma-cli/references/migrate-deploy.md
@@ -1,0 +1,127 @@
+# prisma migrate deploy
+
+Applies pending migrations in production/staging environments.
+
+## Command
+
+```bash
+prisma migrate deploy
+```
+
+## What It Does
+
+- Applies all pending migrations from `prisma/migrations/`
+- Updates `_prisma_migrations` table
+- Does NOT generate new migrations
+- Does NOT run seed scripts
+- Safe for CI/CD and production
+
+## Options
+
+| Option | Description |
+|--------|-------------|
+| `--schema` | Custom path to your Prisma schema |
+| `--config` | Custom path to your Prisma config file |
+
+## When to Use
+
+- Production deployments
+- Staging environments  
+- CI/CD pipelines
+- Any non-development environment
+
+## Examples
+
+### Basic deployment
+
+```bash
+prisma migrate deploy
+```
+
+### In CI/CD pipeline
+
+```yaml
+# GitHub Actions example
+- name: Apply migrations
+  run: npx prisma migrate deploy
+  env:
+    DATABASE_URL: ${{ secrets.DATABASE_URL }}
+```
+
+### Docker deployment
+
+```dockerfile
+# Run migrations before starting app
+CMD npx prisma migrate deploy && node dist/index.js
+```
+
+## Comparison with migrate dev
+
+| Feature | migrate dev | migrate deploy |
+|---------|-------------|----------------|
+| Creates migrations | Yes | No |
+| Applies migrations | Yes | Yes |
+| Detects drift | Yes | No |
+| Prompts for input | Yes | No |
+| Uses shadow database | Yes | No |
+| Safe for production | No | Yes |
+| Resets on issues | Prompts | Fails |
+
+## Production Workflow
+
+1. **Development**: Create migrations locally
+   ```bash
+   prisma migrate dev --name add_feature
+   ```
+
+2. **Commit**: Include migration files in version control
+   ```bash
+   git add prisma/migrations
+   git commit -m "Add feature migration"
+   ```
+
+3. **Deploy**: Apply in production
+   ```bash
+   prisma migrate deploy
+   ```
+
+## Error Handling
+
+### Failed migration
+
+If a migration fails, `migrate deploy` exits with error. The failed migration is marked as failed in `_prisma_migrations`.
+
+To fix:
+1. Resolve the issue (fix SQL, database state, etc.)
+2. Mark as resolved: `prisma migrate resolve --applied <migration_name>`
+3. Re-run: `prisma migrate deploy`
+
+### Check status first
+
+```bash
+prisma migrate status
+```
+
+Shows pending and applied migrations before deploying.
+
+## Configuration
+
+Ensure `prisma.config.ts` has the production database URL:
+
+```typescript
+import 'dotenv/config'
+import { defineConfig, env } from 'prisma/config'
+
+export default defineConfig({
+  datasource: {
+    url: env('DATABASE_URL'),
+  },
+})
+```
+
+## Best Practices
+
+1. Always run `migrate status` before `migrate deploy` in CI
+2. Have a rollback plan (backup before migrations)
+3. Test migrations in staging first
+4. Never use `migrate dev` in production

--- a/.agents/skills/prisma-cli/references/migrate-deploy.md
+++ b/.agents/skills/prisma-cli/references/migrate-deploy.md
@@ -18,15 +18,15 @@ prisma migrate deploy
 
 ## Options
 
-| Option | Description |
-|--------|-------------|
-| `--schema` | Custom path to your Prisma schema |
+| Option     | Description                            |
+| ---------- | -------------------------------------- |
+| `--schema` | Custom path to your Prisma schema      |
 | `--config` | Custom path to your Prisma config file |
 
 ## When to Use
 
 - Production deployments
-- Staging environments  
+- Staging environments
 - CI/CD pipelines
 - Any non-development environment
 
@@ -45,7 +45,7 @@ prisma migrate deploy
 - name: Apply migrations
   run: npx prisma migrate deploy
   env:
-    DATABASE_URL: ${{ secrets.DATABASE_URL }}
+      DATABASE_URL: ${{ secrets.DATABASE_URL }}
 ```
 
 ### Docker deployment
@@ -57,33 +57,35 @@ CMD npx prisma migrate deploy && node dist/index.js
 
 ## Comparison with migrate dev
 
-| Feature | migrate dev | migrate deploy |
-|---------|-------------|----------------|
-| Creates migrations | Yes | No |
-| Applies migrations | Yes | Yes |
-| Detects drift | Yes | No |
-| Prompts for input | Yes | No |
-| Uses shadow database | Yes | No |
-| Safe for production | No | Yes |
-| Resets on issues | Prompts | Fails |
+| Feature              | migrate dev | migrate deploy |
+| -------------------- | ----------- | -------------- |
+| Creates migrations   | Yes         | No             |
+| Applies migrations   | Yes         | Yes            |
+| Detects drift        | Yes         | No             |
+| Prompts for input    | Yes         | No             |
+| Uses shadow database | Yes         | No             |
+| Safe for production  | No          | Yes            |
+| Resets on issues     | Prompts     | Fails          |
 
 ## Production Workflow
 
 1. **Development**: Create migrations locally
-   ```bash
-   prisma migrate dev --name add_feature
-   ```
+
+    ```bash
+    prisma migrate dev --name add_feature
+    ```
 
 2. **Commit**: Include migration files in version control
-   ```bash
-   git add prisma/migrations
-   git commit -m "Add feature migration"
-   ```
+
+    ```bash
+    git add prisma/migrations
+    git commit -m "Add feature migration"
+    ```
 
 3. **Deploy**: Apply in production
-   ```bash
-   prisma migrate deploy
-   ```
+    ```bash
+    prisma migrate deploy
+    ```
 
 ## Error Handling
 
@@ -92,6 +94,7 @@ CMD npx prisma migrate deploy && node dist/index.js
 If a migration fails, `migrate deploy` exits with error. The failed migration is marked as failed in `_prisma_migrations`.
 
 To fix:
+
 1. Resolve the issue (fix SQL, database state, etc.)
 2. Mark as resolved: `prisma migrate resolve --applied <migration_name>`
 3. Re-run: `prisma migrate deploy`
@@ -113,9 +116,9 @@ import 'dotenv/config'
 import { defineConfig, env } from 'prisma/config'
 
 export default defineConfig({
-  datasource: {
-    url: env('DATABASE_URL'),
-  },
+    datasource: {
+        url: env('DATABASE_URL'),
+    },
 })
 ```
 

--- a/.agents/skills/prisma-cli/references/migrate-dev.md
+++ b/.agents/skills/prisma-cli/references/migrate-dev.md
@@ -1,0 +1,145 @@
+# prisma migrate dev
+
+Creates and applies migrations during development. Requires a shadow database.
+
+## Command
+
+```bash
+prisma migrate dev [options]
+```
+
+## What It Does
+
+1. Runs existing migrations in shadow database to detect drift
+2. Applies any pending migrations
+3. Generates new migration from schema changes
+4. Applies new migration to development database
+5. Updates `_prisma_migrations` table
+
+## Options
+
+| Option | Description |
+|--------|-------------|
+| `--name` / `-n` | Name the migration |
+| `--create-only` | Create a new migration but do not apply it |
+| `--schema` | Custom path to your Prisma schema |
+| `--config` | Custom path to your Prisma config file |
+| `--url` | Override the datasource URL from the Prisma config file |
+
+### Follow-up Commands
+
+- Run `prisma generate` explicitly when you need refreshed client output
+- Run `prisma db seed` explicitly when you need seed data
+
+Note: Prisma CLI help for `7.6.0` still says `migrate dev` "trigger[s] generators", but local verification in a temp Prisma 7.6.0 project did not emit generated client files. Treat `prisma generate` as an explicit follow-up step when you need generated artifacts on disk.
+
+## Examples
+
+### Create and apply migration
+
+```bash
+prisma migrate dev
+```
+
+Prompts for migration name if schema changed.
+
+### Named migration
+
+```bash
+prisma migrate dev --name add_users_table
+```
+
+### Create without applying
+
+```bash
+prisma migrate dev --create-only
+```
+
+Useful for reviewing migration SQL before applying.
+
+### Full workflow
+
+```bash
+prisma migrate dev --name my_migration
+prisma generate
+prisma db seed
+```
+
+## Migration Files
+
+Created in `prisma/migrations/`:
+
+```
+prisma/migrations/
+├── 20240115120000_add_users_table/
+│   └── migration.sql
+├── 20240116090000_add_posts/
+│   └── migration.sql
+└── migration_lock.toml
+```
+
+## Schema Drift Detection
+
+If `migrate dev` detects drift (manual database changes or edited migrations), it prompts to reset:
+
+```
+Drift detected: Your database schema is not in sync.
+
+Do you want to reset your database? All data will be lost.
+```
+
+## When to Use
+
+- Local development
+- Adding new models/fields
+- Changing relations
+- Creating indexes
+
+## When NOT to Use
+
+- Production deployments (use `migrate deploy`)
+- CI/CD pipelines (use `migrate deploy`)
+- MongoDB (use `db push` instead)
+
+## Common Patterns
+
+### After schema changes
+
+```prisma
+// schema.prisma - Add new field
+model User {
+  id        Int      @id @default(autoincrement())
+  email     String   @unique
+  name      String?
+  createdAt DateTime @default(now())  // New field
+}
+```
+
+```bash
+prisma migrate dev --name add_created_at
+```
+
+### Handling data loss warnings
+
+When a migration would cause data loss:
+
+```bash
+prisma migrate dev --name remove_field
+# Warning: You are about to delete data...
+# Accept with: --accept-data-loss
+```
+
+## Shadow Database
+
+`migrate dev` requires a shadow database for drift detection. Configure in `prisma.config.ts`:
+
+```typescript
+export default defineConfig({
+  datasource: {
+    url: env('DATABASE_URL'),
+    shadowDatabaseUrl: env('SHADOW_DATABASE_URL'),
+  },
+})
+```
+
+For local Prisma Postgres (`prisma dev`), shadow database is handled automatically.

--- a/.agents/skills/prisma-cli/references/migrate-dev.md
+++ b/.agents/skills/prisma-cli/references/migrate-dev.md
@@ -18,13 +18,13 @@ prisma migrate dev [options]
 
 ## Options
 
-| Option | Description |
-|--------|-------------|
-| `--name` / `-n` | Name the migration |
-| `--create-only` | Create a new migration but do not apply it |
-| `--schema` | Custom path to your Prisma schema |
-| `--config` | Custom path to your Prisma config file |
-| `--url` | Override the datasource URL from the Prisma config file |
+| Option          | Description                                             |
+| --------------- | ------------------------------------------------------- |
+| `--name` / `-n` | Name the migration                                      |
+| `--create-only` | Create a new migration but do not apply it              |
+| `--schema`      | Custom path to your Prisma schema                       |
+| `--config`      | Custom path to your Prisma config file                  |
+| `--url`         | Override the datasource URL from the Prisma config file |
 
 ### Follow-up Commands
 
@@ -135,10 +135,10 @@ prisma migrate dev --name remove_field
 
 ```typescript
 export default defineConfig({
-  datasource: {
-    url: env('DATABASE_URL'),
-    shadowDatabaseUrl: env('SHADOW_DATABASE_URL'),
-  },
+    datasource: {
+        url: env('DATABASE_URL'),
+        shadowDatabaseUrl: env('SHADOW_DATABASE_URL'),
+    },
 })
 ```
 

--- a/.agents/skills/prisma-cli/references/migrate-diff.md
+++ b/.agents/skills/prisma-cli/references/migrate-diff.md
@@ -1,0 +1,89 @@
+# prisma migrate diff
+
+Compares database schemas and generates diffs (SQL or summary).
+
+## Command
+
+```bash
+prisma migrate diff [options]
+```
+
+## What It Does
+
+- Compares two sources (`--from-...` and `--to-...`)
+- Sources can be:
+    - Empty (`empty`)
+    - Schema file (`schema`)
+    - Migrations directory (`migrations`)
+    - Database URL (`url`) or Configured Datasource (`config-datasource`)
+- Outputs the difference:
+    - Human-readable summary (default)
+    - SQL script (`--script`)
+
+## Options
+
+| Option | Description |
+|--------|-------------|
+| `--script` | Render SQL script to stdout |
+| `--exit-code` | Exit 2 if changes detected, 0 if empty, 1 if error |
+| `--config` | Custom path to your Prisma config file |
+
+### Sources (Must provide one `from` and one `to`)
+
+- `--from-empty`, `--to-empty`
+- `--from-schema <path>`, `--to-schema <path>`
+- `--from-migrations <path>`, `--to-migrations <path>`
+- `--from-url <url>`, `--to-url <url>`
+- `--from-config-datasource`, `--to-config-datasource` (uses `prisma.config.ts`)
+
+## Examples
+
+### Generate SQL for a schema change
+
+Compare current production DB to your local schema:
+
+```bash
+prisma migrate diff \
+  --from-url "$PROD_DB_URL" \
+  --to-schema ./prisma/schema.prisma \
+  --script
+```
+
+### Review pending migrations
+
+Compare database state to migrations directory:
+
+```bash
+prisma migrate diff \
+  --from-config-datasource \
+  --to-migrations ./prisma/migrations
+```
+
+### Create baseline migration
+
+Compare empty state to current schema:
+
+```bash
+prisma migrate diff \
+  --from-empty \
+  --to-schema ./prisma/schema.prisma \
+  --script > prisma/migrations/0_init/migration.sql
+```
+
+### Check for drift (CI)
+
+Check if database matches schema:
+
+```bash
+prisma migrate diff \
+  --from-config-datasource \
+  --to-schema ./prisma/schema.prisma \
+  --exit-code
+```
+
+## Use Cases
+
+- **Forward-generating migrations**: Creating SQL without `migrate dev`.
+- **Drift detection**: Checking if DB is in sync.
+- **Baselining**: Creating initial migration from existing DB.
+- **Debugging**: Understanding what `migrate dev` would do.

--- a/.agents/skills/prisma-cli/references/migrate-diff.md
+++ b/.agents/skills/prisma-cli/references/migrate-diff.md
@@ -22,11 +22,11 @@ prisma migrate diff [options]
 
 ## Options
 
-| Option | Description |
-|--------|-------------|
-| `--script` | Render SQL script to stdout |
+| Option        | Description                                        |
+| ------------- | -------------------------------------------------- |
+| `--script`    | Render SQL script to stdout                        |
 | `--exit-code` | Exit 2 if changes detected, 0 if empty, 1 if error |
-| `--config` | Custom path to your Prisma config file |
+| `--config`    | Custom path to your Prisma config file             |
 
 ### Sources (Must provide one `from` and one `to`)
 

--- a/.agents/skills/prisma-cli/references/migrate-reset.md
+++ b/.agents/skills/prisma-cli/references/migrate-reset.md
@@ -1,0 +1,78 @@
+# prisma migrate reset
+
+Resets your database and re-applies all migrations.
+
+## Command
+
+```bash
+prisma migrate reset [options]
+```
+
+## What It Does
+
+1. **Drops** the database (if possible) or deletes all data/tables
+2. **Re-creates** the database
+3. **Applies** all migrations from `prisma/migrations/`
+4. Stops there - run seed and generate explicitly if needed
+
+**Warning: All data will be lost.**
+
+## Options
+
+| Option | Description |
+|--------|-------------|
+| `--force` / `-f` | Skip confirmation prompt |
+| `--schema` | Path to schema file |
+| `--config` | Custom path to your Prisma config file |
+
+## Examples
+
+### Basic reset
+
+```bash
+prisma migrate reset
+```
+
+Prompts for confirmation in interactive terminals.
+
+### Force reset (CI/Automation)
+
+```bash
+prisma migrate reset --force
+```
+
+### With custom schema
+
+```bash
+prisma migrate reset --schema=./custom/schema.prisma
+```
+
+## When to Use
+
+- **Development**: When you want a fresh start
+- **Testing**: Resetting test database before suites
+- **Drift Recovery**: When the database is out of sync and you can't migrate
+
+## Follow-up Steps
+
+Run `prisma generate` and `prisma db seed` explicitly when you need refreshed client output or seed data after a reset.
+
+## Configuration
+
+Configure the seed script in `prisma.config.ts`, then run it explicitly after reset:
+
+```typescript
+export default defineConfig({
+  migrations: {
+    seed: 'tsx prisma/seed.ts',
+  },
+})
+```
+
+Typical workflow:
+
+```bash
+prisma migrate reset --force
+prisma generate
+prisma db seed
+```

--- a/.agents/skills/prisma-cli/references/migrate-reset.md
+++ b/.agents/skills/prisma-cli/references/migrate-reset.md
@@ -19,11 +19,11 @@ prisma migrate reset [options]
 
 ## Options
 
-| Option | Description |
-|--------|-------------|
-| `--force` / `-f` | Skip confirmation prompt |
-| `--schema` | Path to schema file |
-| `--config` | Custom path to your Prisma config file |
+| Option           | Description                            |
+| ---------------- | -------------------------------------- |
+| `--force` / `-f` | Skip confirmation prompt               |
+| `--schema`       | Path to schema file                    |
+| `--config`       | Custom path to your Prisma config file |
 
 ## Examples
 
@@ -63,9 +63,9 @@ Configure the seed script in `prisma.config.ts`, then run it explicitly after re
 
 ```typescript
 export default defineConfig({
-  migrations: {
-    seed: 'tsx prisma/seed.ts',
-  },
+    migrations: {
+        seed: 'tsx prisma/seed.ts',
+    },
 })
 ```
 

--- a/.agents/skills/prisma-cli/references/migrate-resolve.md
+++ b/.agents/skills/prisma-cli/references/migrate-resolve.md
@@ -1,0 +1,57 @@
+# prisma migrate resolve
+
+Resolves issues with database migrations, such as failed migrations or baselining.
+
+## Command
+
+```bash
+prisma migrate resolve [options]
+```
+
+## What It Does
+
+Updates the `_prisma_migrations` table to manually change the state of a migration. This is a recovery tool.
+
+## Options
+
+You must provide exactly one of `--applied` or `--rolled-back`.
+
+| Option | Description |
+|--------|-------------|
+| `--applied <name>` | Mark a migration as **applied** (success) |
+| `--rolled-back <name>` | Mark a migration as **rolled back** (ignored/failed) |
+| `--schema` | Path to schema file |
+| `--config` | Custom path to your Prisma config file |
+
+## Examples
+
+### Mark as Applied (Baselining)
+
+If you have existing tables and want to initialize migrations without running the SQL:
+
+```bash
+prisma migrate resolve --applied 20240101000000_initial_migration
+```
+
+This tells Prisma "Assume this migration has already run".
+
+### Mark as Rolled Back (Fixing Failures)
+
+If a migration failed (e.g., syntax error) and you fixed the SQL or want to retry:
+
+```bash
+prisma migrate resolve --rolled-back 20240115120000_failed_migration
+```
+
+This tells Prisma "Forget this migration run, let me try applying it again".
+
+## Use Cases
+
+1. **Baselining**: Adopting Prisma Migrate on an existing production database.
+2. **Failed Migrations**: Recovering from a failed `migrate deploy` in production.
+3. **Hotfixes**: reconciling manual database changes (rare).
+
+## References
+
+- [Baselining](https://www.prisma.io/docs/guides/database/developing-with-prisma-migrate/baselining)
+- [Troubleshooting](https://www.prisma.io/docs/guides/database/production-troubleshooting)

--- a/.agents/skills/prisma-cli/references/migrate-resolve.md
+++ b/.agents/skills/prisma-cli/references/migrate-resolve.md
@@ -16,12 +16,12 @@ Updates the `_prisma_migrations` table to manually change the state of a migrati
 
 You must provide exactly one of `--applied` or `--rolled-back`.
 
-| Option | Description |
-|--------|-------------|
-| `--applied <name>` | Mark a migration as **applied** (success) |
+| Option                 | Description                                          |
+| ---------------------- | ---------------------------------------------------- |
+| `--applied <name>`     | Mark a migration as **applied** (success)            |
 | `--rolled-back <name>` | Mark a migration as **rolled back** (ignored/failed) |
-| `--schema` | Path to schema file |
-| `--config` | Custom path to your Prisma config file |
+| `--schema`             | Path to schema file                                  |
+| `--config`             | Custom path to your Prisma config file               |
 
 ## Examples
 

--- a/.agents/skills/prisma-cli/references/migrate-status.md
+++ b/.agents/skills/prisma-cli/references/migrate-status.md
@@ -1,0 +1,65 @@
+# prisma migrate status
+
+Checks the status of your database migrations.
+
+## Command
+
+```bash
+prisma migrate status [options]
+```
+
+## What It Does
+
+- Connects to the database
+- Checks the `_prisma_migrations` table
+- Compares applied migrations with local migration files
+- Reports:
+    - **Status**: Database is up-to-date or behind
+    - **Unapplied migrations**: Count of pending migrations
+    - **Missing migrations**: Migrations present in DB but missing locally
+    - **Failed migrations**: Any migrations that failed to apply
+
+## Options
+
+| Option | Description |
+|--------|-------------|
+| `--schema` | Path to schema file |
+| `--config` | Custom path to your Prisma config file |
+
+## Examples
+
+### Check status
+
+```bash
+prisma migrate status
+```
+
+Output example (Up to date):
+```
+Database schema is up to date!
+```
+
+Output example (Pending):
+```
+Following migration have not yet been applied:
+  20240115120000_add_user
+
+To apply migrations in development, run:
+  prisma migrate dev
+
+To apply migrations in production, run:
+  prisma migrate deploy
+```
+
+## When to Use
+
+- **Debugging**: Why is `migrate dev` complaining about drift?
+- **CI/CD**: Verify database state before deploying
+- **Production**: Check if migrations are needed (`migrate deploy`) or if a deployment failed
+
+## Exit Codes
+
+- `0`: Success (may have pending migrations, but command ran successfully)
+- `1`: Error
+
+To check for pending migrations programmatically, you might need to parse the output or use `migrate diff` with exit code flags.

--- a/.agents/skills/prisma-cli/references/migrate-status.md
+++ b/.agents/skills/prisma-cli/references/migrate-status.md
@@ -21,9 +21,9 @@ prisma migrate status [options]
 
 ## Options
 
-| Option | Description |
-|--------|-------------|
-| `--schema` | Path to schema file |
+| Option     | Description                            |
+| ---------- | -------------------------------------- |
+| `--schema` | Path to schema file                    |
 | `--config` | Custom path to your Prisma config file |
 
 ## Examples
@@ -35,11 +35,13 @@ prisma migrate status
 ```
 
 Output example (Up to date):
+
 ```
 Database schema is up to date!
 ```
 
 Output example (Pending):
+
 ```
 Following migration have not yet been applied:
   20240115120000_add_user

--- a/.agents/skills/prisma-cli/references/studio.md
+++ b/.agents/skills/prisma-cli/references/studio.md
@@ -1,0 +1,137 @@
+# prisma studio
+
+Opens a visual database browser for viewing and editing data.
+
+## Command
+
+```bash
+prisma studio [options]
+```
+
+## What It Does
+
+- Starts a web-based database GUI
+- View all your models and records
+- Create, update, and delete records
+- Filter and sort data
+- Navigate relations
+
+## Options
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--port` / `-p` | Port to start Studio on | `5555` |
+| `--browser` / `-b` | Browser to open Studio in | System default |
+| `--config` | Custom path to your Prisma config file | - |
+| `--url` | Database connection string (overrides the one in your Prisma config) | - |
+
+## Examples
+
+### Open Studio
+
+```bash
+prisma studio
+```
+
+Opens at http://localhost:5555
+
+### Custom port
+
+```bash
+prisma studio --port 3000
+```
+
+### Specific browser
+
+```bash
+prisma studio --browser firefox
+```
+
+### Don't open browser
+
+```bash
+BROWSER=none prisma studio
+```
+
+Useful for remote servers.
+
+## Features
+
+### View Records
+
+- See all records in table format
+- Pagination for large datasets
+- Column sorting
+
+### Filter Data
+
+- Filter by any field
+- Multiple conditions
+- Relation filtering
+
+### Edit Records
+
+- Click to edit inline
+- Add new records
+- Delete records (with confirmation)
+
+### Navigate Relations
+
+- Click relations to view related records
+- See counts of related items
+- Follow relation links
+
+## Recent Studio Capabilities
+
+Recent Prisma Studio releases added richer editor workflows:
+
+- multi-cell selection and editing
+- full-table search and more intuitive filtering
+- command palette shortcuts
+- dark mode
+- copy selections as Markdown
+- back-relation navigation
+- SQL workflows including raw SQL queries
+
+Some recent builds also expose AI-assisted SQL authoring. Treat these as interactive Studio features rather than a replacement for checked-in migrations or application queries.
+
+## Use Cases
+
+- **Development**: Quick data inspection
+- **Debugging**: Check data state
+- **Testing**: Verify seed data
+- **Demo**: Show data to stakeholders
+
+## Limitations
+
+- Development tool only
+- Not for production use
+- Limited to configured database
+- Prisma Studio in Prisma 7 currently targets PostgreSQL, MySQL, and SQLite first
+- For reproducible application logic, prefer Prisma Client and checked-in SQL scripts
+
+## Common Workflow
+
+1. Run migrations:
+   ```bash
+   prisma migrate dev
+   ```
+
+2. Seed data:
+   ```bash
+   prisma db seed
+   ```
+
+3. Open Studio to verify:
+   ```bash
+   prisma studio
+   ```
+
+4. Make manual edits if needed
+
+## Security Note
+
+Studio provides direct database access. Only run on:
+- Local development machines
+- Secure internal networks
+- Never expose publicly

--- a/.agents/skills/prisma-cli/references/studio.md
+++ b/.agents/skills/prisma-cli/references/studio.md
@@ -18,12 +18,12 @@ prisma studio [options]
 
 ## Options
 
-| Option | Description | Default |
-|--------|-------------|---------|
-| `--port` / `-p` | Port to start Studio on | `5555` |
-| `--browser` / `-b` | Browser to open Studio in | System default |
-| `--config` | Custom path to your Prisma config file | - |
-| `--url` | Database connection string (overrides the one in your Prisma config) | - |
+| Option             | Description                                                          | Default        |
+| ------------------ | -------------------------------------------------------------------- | -------------- |
+| `--port` / `-p`    | Port to start Studio on                                              | `5555`         |
+| `--browser` / `-b` | Browser to open Studio in                                            | System default |
+| `--config`         | Custom path to your Prisma config file                               | -              |
+| `--url`            | Database connection string (overrides the one in your Prisma config) | -              |
 
 ## Examples
 
@@ -113,25 +113,29 @@ Some recent builds also expose AI-assisted SQL authoring. Treat these as interac
 ## Common Workflow
 
 1. Run migrations:
-   ```bash
-   prisma migrate dev
-   ```
+
+    ```bash
+    prisma migrate dev
+    ```
 
 2. Seed data:
-   ```bash
-   prisma db seed
-   ```
+
+    ```bash
+    prisma db seed
+    ```
 
 3. Open Studio to verify:
-   ```bash
-   prisma studio
-   ```
+
+    ```bash
+    prisma studio
+    ```
 
 4. Make manual edits if needed
 
 ## Security Note
 
 Studio provides direct database access. Only run on:
+
 - Local development machines
 - Secure internal networks
 - Never expose publicly

--- a/.agents/skills/prisma-cli/references/validate.md
+++ b/.agents/skills/prisma-cli/references/validate.md
@@ -1,0 +1,53 @@
+# prisma validate
+
+Validates your Prisma schema file.
+
+## Command
+
+```bash
+prisma validate [options]
+```
+
+## What It Does
+
+- Parses the `schema.prisma` file
+- Checks for syntax errors
+- Validates model definitions, relations, and types
+- Reports any errors or warnings without generating code
+
+## Options
+
+| Option | Description |
+|--------|-------------|
+| `--schema` | Path to schema file |
+| `--config` | Custom path to your Prisma config file |
+
+## Examples
+
+### Validate default schema
+
+```bash
+prisma validate
+```
+
+### Validate specific schema
+
+```bash
+prisma validate --schema=./custom/schema.prisma
+```
+
+### Use in CI
+
+Run `validate` in your CI pipeline to catch schema errors early:
+
+```yaml
+- name: Validate Schema
+  run: npx prisma validate
+```
+
+## Common Errors
+
+- Missing `@relation` fields
+- Invalid types
+- Duplicate model names
+- Syntax errors (missing braces, etc.)

--- a/.agents/skills/prisma-cli/references/validate.md
+++ b/.agents/skills/prisma-cli/references/validate.md
@@ -17,9 +17,9 @@ prisma validate [options]
 
 ## Options
 
-| Option | Description |
-|--------|-------------|
-| `--schema` | Path to schema file |
+| Option     | Description                            |
+| ---------- | -------------------------------------- |
+| `--schema` | Path to schema file                    |
 | `--config` | Custom path to your Prisma config file |
 
 ## Examples

--- a/.agents/skills/prisma-client-api/SKILL.md
+++ b/.agents/skills/prisma-client-api/SKILL.md
@@ -1,0 +1,216 @@
+---
+name: prisma-client-api
+description: Prisma Client API reference covering model queries, filters, operators, and client methods. Use when writing database queries, using CRUD operations, filtering data, or configuring Prisma Client. Triggers on "prisma query", "findMany", "create", "update", "delete", "$transaction".
+license: MIT
+metadata:
+  author: prisma
+  version: "7.6.0"
+---
+
+# Prisma Client API Reference
+
+Complete API reference for Prisma Client. This skill provides guidance on model queries, filtering, relations, and client methods for current Prisma projects.
+
+## When to Apply
+
+Reference this skill when:
+- Writing database queries with Prisma Client
+- Performing CRUD operations (create, read, update, delete)
+- Filtering and sorting data
+- Working with relations
+- Using transactions
+- Configuring client options
+
+## Rule Categories by Priority
+
+| Priority | Category | Impact | Prefix |
+|----------|----------|--------|--------|
+| 1 | Client Construction | HIGH | `constructor` |
+| 2 | Model Queries | CRITICAL | `model-queries` |
+| 3 | Query Shape | HIGH | `query-options` |
+| 4 | Filtering | HIGH | `filters` |
+| 5 | Relations | HIGH | `relations` |
+| 6 | Transactions | CRITICAL | `transactions` |
+| 7 | Raw SQL | CRITICAL | `raw-queries` |
+| 8 | Client Methods | MEDIUM | `client-methods` |
+
+## Quick Reference
+
+- `constructor` - `PrismaClient` setup, adapter wiring, logging, and SQL commenter plugins
+- `model-queries` - CRUD operations and bulk operations
+- `query-options` - `select`, `include`, `omit`, sort, pagination
+- `filters` - scalar and logical filter operators
+- `relations` - relation reads and nested writes
+- `transactions` - array and interactive transaction patterns
+- `raw-queries` - `$queryRaw` and `$executeRaw` safety
+- `client-methods` - lifecycle methods, extensions, and `satisfies` patterns for `prisma-client`
+
+## Client Instantiation
+
+```typescript
+import { PrismaClient } from '../generated/client'
+import { PrismaPg } from '@prisma/adapter-pg'
+
+const adapter = new PrismaPg({
+  connectionString: process.env.DATABASE_URL
+})
+
+const prisma = new PrismaClient({ adapter })
+```
+
+## Model Query Methods
+
+| Method | Description |
+|--------|-------------|
+| `findUnique()` | Find one record by unique field |
+| `findUniqueOrThrow()` | Find one or throw error |
+| `findFirst()` | Find first matching record |
+| `findFirstOrThrow()` | Find first or throw error |
+| `findMany()` | Find multiple records |
+| `create()` | Create a new record |
+| `createMany()` | Create multiple records |
+| `createManyAndReturn()` | Create multiple and return them |
+| `update()` | Update one record |
+| `updateMany()` | Update multiple records |
+| `updateManyAndReturn()` | Update multiple and return them |
+| `upsert()` | Update or create record |
+| `delete()` | Delete one record |
+| `deleteMany()` | Delete multiple records |
+| `count()` | Count matching records |
+| `aggregate()` | Aggregate values (sum, avg, etc.) |
+| `groupBy()` | Group and aggregate |
+
+## Query Options
+
+| Option | Description |
+|--------|-------------|
+| `where` | Filter conditions |
+| `select` | Fields to include |
+| `include` | Relations to load |
+| `omit` | Fields to exclude |
+| `orderBy` | Sort order |
+| `take` | Limit results |
+| `skip` | Skip results (pagination) |
+| `cursor` | Cursor-based pagination |
+| `distinct` | Unique values only |
+
+## Client Methods
+
+| Method | Description |
+|--------|-------------|
+| `$connect()` | Explicitly connect to database |
+| `$disconnect()` | Disconnect from database |
+| `$transaction()` | Execute transaction |
+| `$queryRaw()` | Execute raw SQL query |
+| `$executeRaw()` | Execute raw SQL command |
+| `$on()` | Subscribe to events |
+| `$extends()` | Add extensions |
+
+## Quick Examples
+
+### Find records
+
+```typescript
+// Find by unique field
+const user = await prisma.user.findUnique({
+  where: { email: 'alice@prisma.io' }
+})
+
+// Find with filter
+const users = await prisma.user.findMany({
+  where: { role: 'ADMIN' },
+  orderBy: { createdAt: 'desc' },
+  take: 10
+})
+```
+
+### Create records
+
+```typescript
+const user = await prisma.user.create({
+  data: {
+    email: 'alice@prisma.io',
+    name: 'Alice',
+    posts: {
+      create: { title: 'Hello World' }
+    }
+  },
+  include: { posts: true }
+})
+```
+
+### Update records
+
+```typescript
+const user = await prisma.user.update({
+  where: { id: 1 },
+  data: { name: 'Alice Smith' }
+})
+```
+
+### Delete records
+
+```typescript
+await prisma.user.delete({
+  where: { id: 1 }
+})
+```
+
+### Transactions
+
+```typescript
+const [user, post] = await prisma.$transaction([
+  prisma.user.create({ data: { email: 'alice@prisma.io' } }),
+  prisma.post.create({ data: { title: 'Hello', authorId: 1 } })
+])
+```
+
+## Rule Files
+
+Detailed API documentation:
+
+```
+references/constructor.md        - PrismaClient constructor options
+references/model-queries.md      - CRUD operations
+references/query-options.md      - select, include, omit, where, orderBy
+references/filters.md            - Filter conditions and operators
+references/relations.md          - Relation queries and nested operations
+references/transactions.md       - Transaction API
+references/raw-queries.md        - $queryRaw, $executeRaw
+references/client-methods.md     - $connect, $disconnect, $on, $extends
+```
+
+## Filter Operators
+
+| Operator | Description |
+|----------|-------------|
+| `equals` | Exact match |
+| `not` | Not equal |
+| `in` | In array |
+| `notIn` | Not in array |
+| `lt`, `lte` | Less than |
+| `gt`, `gte` | Greater than |
+| `contains` | String contains |
+| `startsWith` | String starts with |
+| `endsWith` | String ends with |
+| `mode` | Case sensitivity |
+
+## Relation Filters
+
+| Operator | Description |
+|----------|-------------|
+| `some` | At least one related record matches |
+| `every` | All related records match |
+| `none` | No related records match |
+| `is` | Related record matches (1-to-1) |
+| `isNot` | Related record doesn't match |
+
+## Resources
+
+- [Prisma Client API Reference](https://www.prisma.io/docs/orm/reference/prisma-client-reference)
+- [CRUD Operations](https://www.prisma.io/docs/orm/prisma-client/queries/crud)
+- [Filtering and Sorting](https://www.prisma.io/docs/orm/prisma-client/queries/filtering-and-sorting)
+
+## How to Use
+
+Pick the category from the table above, then open the matching reference file for implementation details and examples.

--- a/.agents/skills/prisma-client-api/SKILL.md
+++ b/.agents/skills/prisma-client-api/SKILL.md
@@ -3,8 +3,8 @@ name: prisma-client-api
 description: Prisma Client API reference covering model queries, filters, operators, and client methods. Use when writing database queries, using CRUD operations, filtering data, or configuring Prisma Client. Triggers on "prisma query", "findMany", "create", "update", "delete", "$transaction".
 license: MIT
 metadata:
-  author: prisma
-  version: "7.6.0"
+    author: prisma
+    version: '7.6.0'
 ---
 
 # Prisma Client API Reference
@@ -14,6 +14,7 @@ Complete API reference for Prisma Client. This skill provides guidance on model 
 ## When to Apply
 
 Reference this skill when:
+
 - Writing database queries with Prisma Client
 - Performing CRUD operations (create, read, update, delete)
 - Filtering and sorting data
@@ -23,16 +24,16 @@ Reference this skill when:
 
 ## Rule Categories by Priority
 
-| Priority | Category | Impact | Prefix |
-|----------|----------|--------|--------|
-| 1 | Client Construction | HIGH | `constructor` |
-| 2 | Model Queries | CRITICAL | `model-queries` |
-| 3 | Query Shape | HIGH | `query-options` |
-| 4 | Filtering | HIGH | `filters` |
-| 5 | Relations | HIGH | `relations` |
-| 6 | Transactions | CRITICAL | `transactions` |
-| 7 | Raw SQL | CRITICAL | `raw-queries` |
-| 8 | Client Methods | MEDIUM | `client-methods` |
+| Priority | Category            | Impact   | Prefix           |
+| -------- | ------------------- | -------- | ---------------- |
+| 1        | Client Construction | HIGH     | `constructor`    |
+| 2        | Model Queries       | CRITICAL | `model-queries`  |
+| 3        | Query Shape         | HIGH     | `query-options`  |
+| 4        | Filtering           | HIGH     | `filters`        |
+| 5        | Relations           | HIGH     | `relations`      |
+| 6        | Transactions        | CRITICAL | `transactions`   |
+| 7        | Raw SQL             | CRITICAL | `raw-queries`    |
+| 8        | Client Methods      | MEDIUM   | `client-methods` |
 
 ## Quick Reference
 
@@ -52,7 +53,7 @@ import { PrismaClient } from '../generated/client'
 import { PrismaPg } from '@prisma/adapter-pg'
 
 const adapter = new PrismaPg({
-  connectionString: process.env.DATABASE_URL
+    connectionString: process.env.DATABASE_URL,
 })
 
 const prisma = new PrismaClient({ adapter })
@@ -60,51 +61,51 @@ const prisma = new PrismaClient({ adapter })
 
 ## Model Query Methods
 
-| Method | Description |
-|--------|-------------|
-| `findUnique()` | Find one record by unique field |
-| `findUniqueOrThrow()` | Find one or throw error |
-| `findFirst()` | Find first matching record |
-| `findFirstOrThrow()` | Find first or throw error |
-| `findMany()` | Find multiple records |
-| `create()` | Create a new record |
-| `createMany()` | Create multiple records |
-| `createManyAndReturn()` | Create multiple and return them |
-| `update()` | Update one record |
-| `updateMany()` | Update multiple records |
-| `updateManyAndReturn()` | Update multiple and return them |
-| `upsert()` | Update or create record |
-| `delete()` | Delete one record |
-| `deleteMany()` | Delete multiple records |
-| `count()` | Count matching records |
-| `aggregate()` | Aggregate values (sum, avg, etc.) |
-| `groupBy()` | Group and aggregate |
+| Method                  | Description                       |
+| ----------------------- | --------------------------------- |
+| `findUnique()`          | Find one record by unique field   |
+| `findUniqueOrThrow()`   | Find one or throw error           |
+| `findFirst()`           | Find first matching record        |
+| `findFirstOrThrow()`    | Find first or throw error         |
+| `findMany()`            | Find multiple records             |
+| `create()`              | Create a new record               |
+| `createMany()`          | Create multiple records           |
+| `createManyAndReturn()` | Create multiple and return them   |
+| `update()`              | Update one record                 |
+| `updateMany()`          | Update multiple records           |
+| `updateManyAndReturn()` | Update multiple and return them   |
+| `upsert()`              | Update or create record           |
+| `delete()`              | Delete one record                 |
+| `deleteMany()`          | Delete multiple records           |
+| `count()`               | Count matching records            |
+| `aggregate()`           | Aggregate values (sum, avg, etc.) |
+| `groupBy()`             | Group and aggregate               |
 
 ## Query Options
 
-| Option | Description |
-|--------|-------------|
-| `where` | Filter conditions |
-| `select` | Fields to include |
-| `include` | Relations to load |
-| `omit` | Fields to exclude |
-| `orderBy` | Sort order |
-| `take` | Limit results |
-| `skip` | Skip results (pagination) |
-| `cursor` | Cursor-based pagination |
-| `distinct` | Unique values only |
+| Option     | Description               |
+| ---------- | ------------------------- |
+| `where`    | Filter conditions         |
+| `select`   | Fields to include         |
+| `include`  | Relations to load         |
+| `omit`     | Fields to exclude         |
+| `orderBy`  | Sort order                |
+| `take`     | Limit results             |
+| `skip`     | Skip results (pagination) |
+| `cursor`   | Cursor-based pagination   |
+| `distinct` | Unique values only        |
 
 ## Client Methods
 
-| Method | Description |
-|--------|-------------|
-| `$connect()` | Explicitly connect to database |
-| `$disconnect()` | Disconnect from database |
-| `$transaction()` | Execute transaction |
-| `$queryRaw()` | Execute raw SQL query |
-| `$executeRaw()` | Execute raw SQL command |
-| `$on()` | Subscribe to events |
-| `$extends()` | Add extensions |
+| Method           | Description                    |
+| ---------------- | ------------------------------ |
+| `$connect()`     | Explicitly connect to database |
+| `$disconnect()`  | Disconnect from database       |
+| `$transaction()` | Execute transaction            |
+| `$queryRaw()`    | Execute raw SQL query          |
+| `$executeRaw()`  | Execute raw SQL command        |
+| `$on()`          | Subscribe to events            |
+| `$extends()`     | Add extensions                 |
 
 ## Quick Examples
 
@@ -113,14 +114,14 @@ const prisma = new PrismaClient({ adapter })
 ```typescript
 // Find by unique field
 const user = await prisma.user.findUnique({
-  where: { email: 'alice@prisma.io' }
+    where: { email: 'alice@prisma.io' },
 })
 
 // Find with filter
 const users = await prisma.user.findMany({
-  where: { role: 'ADMIN' },
-  orderBy: { createdAt: 'desc' },
-  take: 10
+    where: { role: 'ADMIN' },
+    orderBy: { createdAt: 'desc' },
+    take: 10,
 })
 ```
 
@@ -128,14 +129,14 @@ const users = await prisma.user.findMany({
 
 ```typescript
 const user = await prisma.user.create({
-  data: {
-    email: 'alice@prisma.io',
-    name: 'Alice',
-    posts: {
-      create: { title: 'Hello World' }
-    }
-  },
-  include: { posts: true }
+    data: {
+        email: 'alice@prisma.io',
+        name: 'Alice',
+        posts: {
+            create: { title: 'Hello World' },
+        },
+    },
+    include: { posts: true },
 })
 ```
 
@@ -143,8 +144,8 @@ const user = await prisma.user.create({
 
 ```typescript
 const user = await prisma.user.update({
-  where: { id: 1 },
-  data: { name: 'Alice Smith' }
+    where: { id: 1 },
+    data: { name: 'Alice Smith' },
 })
 ```
 
@@ -152,7 +153,7 @@ const user = await prisma.user.update({
 
 ```typescript
 await prisma.user.delete({
-  where: { id: 1 }
+    where: { id: 1 },
 })
 ```
 
@@ -160,8 +161,8 @@ await prisma.user.delete({
 
 ```typescript
 const [user, post] = await prisma.$transaction([
-  prisma.user.create({ data: { email: 'alice@prisma.io' } }),
-  prisma.post.create({ data: { title: 'Hello', authorId: 1 } })
+    prisma.user.create({ data: { email: 'alice@prisma.io' } }),
+    prisma.post.create({ data: { title: 'Hello', authorId: 1 } }),
 ])
 ```
 
@@ -182,28 +183,28 @@ references/client-methods.md     - $connect, $disconnect, $on, $extends
 
 ## Filter Operators
 
-| Operator | Description |
-|----------|-------------|
-| `equals` | Exact match |
-| `not` | Not equal |
-| `in` | In array |
-| `notIn` | Not in array |
-| `lt`, `lte` | Less than |
-| `gt`, `gte` | Greater than |
-| `contains` | String contains |
+| Operator     | Description        |
+| ------------ | ------------------ |
+| `equals`     | Exact match        |
+| `not`        | Not equal          |
+| `in`         | In array           |
+| `notIn`      | Not in array       |
+| `lt`, `lte`  | Less than          |
+| `gt`, `gte`  | Greater than       |
+| `contains`   | String contains    |
 | `startsWith` | String starts with |
-| `endsWith` | String ends with |
-| `mode` | Case sensitivity |
+| `endsWith`   | String ends with   |
+| `mode`       | Case sensitivity   |
 
 ## Relation Filters
 
-| Operator | Description |
-|----------|-------------|
-| `some` | At least one related record matches |
-| `every` | All related records match |
-| `none` | No related records match |
-| `is` | Related record matches (1-to-1) |
-| `isNot` | Related record doesn't match |
+| Operator | Description                         |
+| -------- | ----------------------------------- |
+| `some`   | At least one related record matches |
+| `every`  | All related records match           |
+| `none`   | No related records match            |
+| `is`     | Related record matches (1-to-1)     |
+| `isNot`  | Related record doesn't match        |
 
 ## Resources
 

--- a/.agents/skills/prisma-client-api/references/client-methods.md
+++ b/.agents/skills/prisma-client-api/references/client-methods.md
@@ -1,0 +1,223 @@
+# Client Methods
+
+Prisma Client instance methods.
+
+## $connect()
+
+Explicitly connect to the database:
+
+```typescript
+const prisma = new PrismaClient({ adapter })
+
+// Explicit connection
+await prisma.$connect()
+```
+
+### When to use
+
+Usually not needed - Prisma connects automatically on first query. Use for:
+- Fail fast on startup
+- Health checks
+- Pre-warming connections
+
+```typescript
+async function main() {
+  try {
+    await prisma.$connect()
+    console.log('Database connected')
+  } catch (e) {
+    console.error('Failed to connect:', e)
+    process.exit(1)
+  }
+}
+```
+
+## $disconnect()
+
+Close database connection:
+
+```typescript
+await prisma.$disconnect()
+```
+
+### Graceful shutdown
+
+```typescript
+process.on('beforeExit', async () => {
+  await prisma.$disconnect()
+})
+
+// Or with SIGTERM
+process.on('SIGTERM', async () => {
+  await prisma.$disconnect()
+  process.exit(0)
+})
+```
+
+### In tests
+
+```typescript
+afterAll(async () => {
+  await prisma.$disconnect()
+})
+```
+
+## $on()
+
+Subscribe to events:
+
+### Query events
+
+```typescript
+const prisma = new PrismaClient({
+  adapter,
+  log: [{ level: 'query', emit: 'event' }]
+})
+
+prisma.$on('query', (e) => {
+  console.log('Query:', e.query)
+  console.log('Params:', e.params)
+  console.log('Duration:', e.duration, 'ms')
+})
+```
+
+### Log events
+
+```typescript
+const prisma = new PrismaClient({
+  adapter,
+  log: [
+    { level: 'info', emit: 'event' },
+    { level: 'warn', emit: 'event' },
+    { level: 'error', emit: 'event' }
+  ]
+})
+
+prisma.$on('info', (e) => console.log(e.message))
+prisma.$on('warn', (e) => console.warn(e.message))
+prisma.$on('error', (e) => console.error(e.message))
+```
+
+## $extends()
+
+Add extensions for custom behavior:
+
+### Add custom methods
+
+```typescript
+const prisma = new PrismaClient({ adapter }).$extends({
+  client: {
+    $log: (message: string) => console.log(message)
+  }
+})
+
+prisma.$log('Hello!')
+```
+
+### Add model methods
+
+```typescript
+const prisma = new PrismaClient({ adapter }).$extends({
+  model: {
+    user: {
+      async findByEmail(email: string) {
+        return prisma.user.findUnique({ where: { email } })
+      }
+    }
+  }
+})
+
+const user = await prisma.user.findByEmail('alice@prisma.io')
+```
+
+### Query extensions
+
+```typescript
+const prisma = new PrismaClient({ adapter }).$extends({
+  query: {
+    user: {
+      async findMany({ args, query }) {
+        // Add default filter
+        args.where = { ...args.where, deletedAt: null }
+        return query(args)
+      }
+    }
+  }
+})
+```
+
+### Result extensions
+
+```typescript
+const prisma = new PrismaClient({ adapter }).$extends({
+  result: {
+    user: {
+      fullName: {
+        needs: { firstName: true, lastName: true },
+        compute(user) {
+          return `${user.firstName} ${user.lastName}`
+        }
+      }
+    }
+  }
+})
+
+const user = await prisma.user.findFirst()
+console.log(user.fullName) // Computed field
+```
+
+### Chain extensions
+
+```typescript
+const prisma = new PrismaClient({ adapter })
+  .$extends(loggingExtension)
+  .$extends(softDeleteExtension)
+  .$extends(computedFieldsExtension)
+```
+
+## $transaction()
+
+See `transactions.md` for details.
+
+## $queryRaw() / $executeRaw()
+
+See `raw-queries.md` for details.
+
+## Type utilities
+
+### Prisma namespace
+
+```typescript
+import { Prisma } from '../generated/client'
+
+// Input types
+type UserCreateInput = Prisma.UserCreateInput
+type UserWhereInput = Prisma.UserWhereInput
+
+// Output types
+type User = Prisma.UserGetPayload<{}>
+type UserWithPosts = Prisma.UserGetPayload<{
+  include: { posts: true }
+}>
+```
+
+### Type-safe query fragments with satisfies
+
+Type-safe query fragments:
+
+```typescript
+import { Prisma } from '../generated/client'
+
+const userSelect = {
+  id: true,
+  email: true,
+  name: true
+} satisfies Prisma.UserSelect
+
+const user = await prisma.user.findUnique({
+  where: { id: 1 },
+  select: userSelect
+})
+```
+
+With the `prisma-client` generator, use TypeScript `satisfies` for typed query fragments. You may still see older examples that use `Prisma.validator()` with `prisma-client-js`.

--- a/.agents/skills/prisma-client-api/references/client-methods.md
+++ b/.agents/skills/prisma-client-api/references/client-methods.md
@@ -16,19 +16,20 @@ await prisma.$connect()
 ### When to use
 
 Usually not needed - Prisma connects automatically on first query. Use for:
+
 - Fail fast on startup
 - Health checks
 - Pre-warming connections
 
 ```typescript
 async function main() {
-  try {
-    await prisma.$connect()
-    console.log('Database connected')
-  } catch (e) {
-    console.error('Failed to connect:', e)
-    process.exit(1)
-  }
+    try {
+        await prisma.$connect()
+        console.log('Database connected')
+    } catch (e) {
+        console.error('Failed to connect:', e)
+        process.exit(1)
+    }
 }
 ```
 
@@ -44,13 +45,13 @@ await prisma.$disconnect()
 
 ```typescript
 process.on('beforeExit', async () => {
-  await prisma.$disconnect()
+    await prisma.$disconnect()
 })
 
 // Or with SIGTERM
 process.on('SIGTERM', async () => {
-  await prisma.$disconnect()
-  process.exit(0)
+    await prisma.$disconnect()
+    process.exit(0)
 })
 ```
 
@@ -58,7 +59,7 @@ process.on('SIGTERM', async () => {
 
 ```typescript
 afterAll(async () => {
-  await prisma.$disconnect()
+    await prisma.$disconnect()
 })
 ```
 
@@ -70,14 +71,14 @@ Subscribe to events:
 
 ```typescript
 const prisma = new PrismaClient({
-  adapter,
-  log: [{ level: 'query', emit: 'event' }]
+    adapter,
+    log: [{ level: 'query', emit: 'event' }],
 })
 
-prisma.$on('query', (e) => {
-  console.log('Query:', e.query)
-  console.log('Params:', e.params)
-  console.log('Duration:', e.duration, 'ms')
+prisma.$on('query', e => {
+    console.log('Query:', e.query)
+    console.log('Params:', e.params)
+    console.log('Duration:', e.duration, 'ms')
 })
 ```
 
@@ -85,17 +86,17 @@ prisma.$on('query', (e) => {
 
 ```typescript
 const prisma = new PrismaClient({
-  adapter,
-  log: [
-    { level: 'info', emit: 'event' },
-    { level: 'warn', emit: 'event' },
-    { level: 'error', emit: 'event' }
-  ]
+    adapter,
+    log: [
+        { level: 'info', emit: 'event' },
+        { level: 'warn', emit: 'event' },
+        { level: 'error', emit: 'event' },
+    ],
 })
 
-prisma.$on('info', (e) => console.log(e.message))
-prisma.$on('warn', (e) => console.warn(e.message))
-prisma.$on('error', (e) => console.error(e.message))
+prisma.$on('info', e => console.log(e.message))
+prisma.$on('warn', e => console.warn(e.message))
+prisma.$on('error', e => console.error(e.message))
 ```
 
 ## $extends()
@@ -106,9 +107,9 @@ Add extensions for custom behavior:
 
 ```typescript
 const prisma = new PrismaClient({ adapter }).$extends({
-  client: {
-    $log: (message: string) => console.log(message)
-  }
+    client: {
+        $log: (message: string) => console.log(message),
+    },
 })
 
 prisma.$log('Hello!')
@@ -118,13 +119,13 @@ prisma.$log('Hello!')
 
 ```typescript
 const prisma = new PrismaClient({ adapter }).$extends({
-  model: {
-    user: {
-      async findByEmail(email: string) {
-        return prisma.user.findUnique({ where: { email } })
-      }
-    }
-  }
+    model: {
+        user: {
+            async findByEmail(email: string) {
+                return prisma.user.findUnique({ where: { email } })
+            },
+        },
+    },
 })
 
 const user = await prisma.user.findByEmail('alice@prisma.io')
@@ -134,15 +135,15 @@ const user = await prisma.user.findByEmail('alice@prisma.io')
 
 ```typescript
 const prisma = new PrismaClient({ adapter }).$extends({
-  query: {
-    user: {
-      async findMany({ args, query }) {
-        // Add default filter
-        args.where = { ...args.where, deletedAt: null }
-        return query(args)
-      }
-    }
-  }
+    query: {
+        user: {
+            async findMany({ args, query }) {
+                // Add default filter
+                args.where = { ...args.where, deletedAt: null }
+                return query(args)
+            },
+        },
+    },
 })
 ```
 
@@ -150,16 +151,16 @@ const prisma = new PrismaClient({ adapter }).$extends({
 
 ```typescript
 const prisma = new PrismaClient({ adapter }).$extends({
-  result: {
-    user: {
-      fullName: {
-        needs: { firstName: true, lastName: true },
-        compute(user) {
-          return `${user.firstName} ${user.lastName}`
-        }
-      }
-    }
-  }
+    result: {
+        user: {
+            fullName: {
+                needs: { firstName: true, lastName: true },
+                compute(user) {
+                    return `${user.firstName} ${user.lastName}`
+                },
+            },
+        },
+    },
 })
 
 const user = await prisma.user.findFirst()
@@ -170,9 +171,9 @@ console.log(user.fullName) // Computed field
 
 ```typescript
 const prisma = new PrismaClient({ adapter })
-  .$extends(loggingExtension)
-  .$extends(softDeleteExtension)
-  .$extends(computedFieldsExtension)
+    .$extends(loggingExtension)
+    .$extends(softDeleteExtension)
+    .$extends(computedFieldsExtension)
 ```
 
 ## $transaction()
@@ -197,7 +198,7 @@ type UserWhereInput = Prisma.UserWhereInput
 // Output types
 type User = Prisma.UserGetPayload<{}>
 type UserWithPosts = Prisma.UserGetPayload<{
-  include: { posts: true }
+    include: { posts: true }
 }>
 ```
 
@@ -209,14 +210,14 @@ Type-safe query fragments:
 import { Prisma } from '../generated/client'
 
 const userSelect = {
-  id: true,
-  email: true,
-  name: true
+    id: true,
+    email: true,
+    name: true,
 } satisfies Prisma.UserSelect
 
 const user = await prisma.user.findUnique({
-  where: { id: 1 },
-  select: userSelect
+    where: { id: 1 },
+    select: userSelect,
 })
 ```
 

--- a/.agents/skills/prisma-client-api/references/constructor.md
+++ b/.agents/skills/prisma-client-api/references/constructor.md
@@ -1,0 +1,208 @@
+# PrismaClient Constructor
+
+Configure Prisma Client when instantiating.
+
+## Basic Instantiation
+
+```typescript
+import { PrismaClient } from '../generated/client'
+import { PrismaPg } from '@prisma/adapter-pg'
+
+const adapter = new PrismaPg({
+  connectionString: process.env.DATABASE_URL
+})
+
+const prisma = new PrismaClient({ adapter })
+```
+
+## Constructor Options
+
+### adapter (Required for the SQL provider workflow)
+
+Driver adapter instance:
+
+```typescript
+import { PrismaPg } from '@prisma/adapter-pg'
+
+const adapter = new PrismaPg({
+  connectionString: process.env.DATABASE_URL
+})
+
+const prisma = new PrismaClient({ adapter })
+```
+
+### accelerateUrl (For Accelerate users)
+
+```typescript
+import { withAccelerate } from '@prisma/extension-accelerate'
+
+const prisma = new PrismaClient({
+  accelerateUrl: process.env.DATABASE_URL,  // prisma:// URL
+}).$extends(withAccelerate())
+```
+
+### log
+
+Configure logging:
+
+```typescript
+const prisma = new PrismaClient({
+  adapter,
+  log: ['query', 'info', 'warn', 'error'],
+})
+```
+
+#### Log levels
+
+| Level | Description |
+|-------|-------------|
+| `query` | All SQL queries |
+| `info` | Informational messages |
+| `warn` | Warnings |
+| `error` | Errors |
+
+#### Log to events
+
+```typescript
+const prisma = new PrismaClient({
+  adapter,
+  log: [
+    { level: 'query', emit: 'event' },
+    { level: 'error', emit: 'stdout' },
+  ],
+})
+
+prisma.$on('query', (e) => {
+  console.log('Query:', e.query)
+  console.log('Duration:', e.duration, 'ms')
+})
+```
+
+### errorFormat
+
+Control error formatting:
+
+```typescript
+const prisma = new PrismaClient({
+  adapter,
+  errorFormat: 'pretty',  // 'pretty' | 'colorless' | 'minimal'
+})
+```
+
+### comments
+
+Attach SQL commenter plugins for observability, tracing, or query insights:
+
+```typescript
+import { PrismaClient } from '../generated/client'
+import { PrismaPg } from '@prisma/adapter-pg'
+import { prismaQueryInsights } from '@prisma/sqlcommenter-query-insights'
+import { queryTags, withQueryTags } from '@prisma/sqlcommenter-query-tags'
+import { traceContext } from '@prisma/sqlcommenter-trace-context'
+
+const prisma = new PrismaClient({
+  adapter: new PrismaPg(process.env.DATABASE_URL!),
+  comments: [prismaQueryInsights(), traceContext(), queryTags()],
+})
+
+await withQueryTags({ route: '/api/users', requestId: 'req-123' }, () =>
+  prisma.user.findMany(),
+)
+```
+
+Use `comments` only for SQL providers. This is the clean way to add trace or query-shape metadata without changing your query calls.
+
+### transactionOptions
+
+Default transaction settings:
+
+```typescript
+const prisma = new PrismaClient({
+  adapter,
+  transactionOptions: {
+    maxWait: 5000,      // Max wait to acquire transaction (ms)
+    timeout: 10000,     // Max transaction duration (ms)
+    isolationLevel: 'Serializable',
+  },
+})
+```
+
+## Singleton Pattern
+
+Prevent multiple client instances in development:
+
+```typescript
+// lib/prisma.ts
+import { PrismaClient } from '../generated/client'
+import { PrismaPg } from '@prisma/adapter-pg'
+
+const globalForPrisma = globalThis as unknown as {
+  prisma: PrismaClient | undefined
+}
+
+function createPrismaClient() {
+  const adapter = new PrismaPg({
+    connectionString: process.env.DATABASE_URL!
+  })
+  return new PrismaClient({ adapter })
+}
+
+export const prisma = globalForPrisma.prisma ?? createPrismaClient()
+
+if (process.env.NODE_ENV !== 'production') {
+  globalForPrisma.prisma = prisma
+}
+```
+
+## Next.js Pattern
+
+```typescript
+// lib/prisma.ts
+import { PrismaClient } from '@/generated/client'
+import { PrismaPg } from '@prisma/adapter-pg'
+
+const createAdapter = () => new PrismaPg({
+  connectionString: process.env.DATABASE_URL!
+})
+
+const prismaClientSingleton = () => {
+  return new PrismaClient({ adapter: createAdapter() })
+}
+
+declare const globalThis: {
+  prismaGlobal: ReturnType<typeof prismaClientSingleton>
+} & typeof global
+
+const prisma = globalThis.prismaGlobal ?? prismaClientSingleton()
+
+export default prisma
+
+if (process.env.NODE_ENV !== 'production') {
+  globalThis.prismaGlobal = prisma
+}
+```
+
+## Query Events
+
+Listen to query events:
+
+```typescript
+const prisma = new PrismaClient({
+  adapter,
+  log: [{ level: 'query', emit: 'event' }],
+})
+
+prisma.$on('query', (e) => {
+  console.log('Query:', e.query)
+  console.log('Params:', e.params)
+  console.log('Duration:', e.duration)
+})
+```
+
+## Log Events
+
+```typescript
+prisma.$on('info', (e) => console.log(e.message))
+prisma.$on('warn', (e) => console.warn(e.message))
+prisma.$on('error', (e) => console.error(e.message))
+```

--- a/.agents/skills/prisma-client-api/references/constructor.md
+++ b/.agents/skills/prisma-client-api/references/constructor.md
@@ -9,7 +9,7 @@ import { PrismaClient } from '../generated/client'
 import { PrismaPg } from '@prisma/adapter-pg'
 
 const adapter = new PrismaPg({
-  connectionString: process.env.DATABASE_URL
+    connectionString: process.env.DATABASE_URL,
 })
 
 const prisma = new PrismaClient({ adapter })
@@ -25,7 +25,7 @@ Driver adapter instance:
 import { PrismaPg } from '@prisma/adapter-pg'
 
 const adapter = new PrismaPg({
-  connectionString: process.env.DATABASE_URL
+    connectionString: process.env.DATABASE_URL,
 })
 
 const prisma = new PrismaClient({ adapter })
@@ -37,7 +37,7 @@ const prisma = new PrismaClient({ adapter })
 import { withAccelerate } from '@prisma/extension-accelerate'
 
 const prisma = new PrismaClient({
-  accelerateUrl: process.env.DATABASE_URL,  // prisma:// URL
+    accelerateUrl: process.env.DATABASE_URL, // prisma:// URL
 }).$extends(withAccelerate())
 ```
 
@@ -47,34 +47,34 @@ Configure logging:
 
 ```typescript
 const prisma = new PrismaClient({
-  adapter,
-  log: ['query', 'info', 'warn', 'error'],
+    adapter,
+    log: ['query', 'info', 'warn', 'error'],
 })
 ```
 
 #### Log levels
 
-| Level | Description |
-|-------|-------------|
-| `query` | All SQL queries |
-| `info` | Informational messages |
-| `warn` | Warnings |
-| `error` | Errors |
+| Level   | Description            |
+| ------- | ---------------------- |
+| `query` | All SQL queries        |
+| `info`  | Informational messages |
+| `warn`  | Warnings               |
+| `error` | Errors                 |
 
 #### Log to events
 
 ```typescript
 const prisma = new PrismaClient({
-  adapter,
-  log: [
-    { level: 'query', emit: 'event' },
-    { level: 'error', emit: 'stdout' },
-  ],
+    adapter,
+    log: [
+        { level: 'query', emit: 'event' },
+        { level: 'error', emit: 'stdout' },
+    ],
 })
 
-prisma.$on('query', (e) => {
-  console.log('Query:', e.query)
-  console.log('Duration:', e.duration, 'ms')
+prisma.$on('query', e => {
+    console.log('Query:', e.query)
+    console.log('Duration:', e.duration, 'ms')
 })
 ```
 
@@ -84,8 +84,8 @@ Control error formatting:
 
 ```typescript
 const prisma = new PrismaClient({
-  adapter,
-  errorFormat: 'pretty',  // 'pretty' | 'colorless' | 'minimal'
+    adapter,
+    errorFormat: 'pretty', // 'pretty' | 'colorless' | 'minimal'
 })
 ```
 
@@ -101,12 +101,12 @@ import { queryTags, withQueryTags } from '@prisma/sqlcommenter-query-tags'
 import { traceContext } from '@prisma/sqlcommenter-trace-context'
 
 const prisma = new PrismaClient({
-  adapter: new PrismaPg(process.env.DATABASE_URL!),
-  comments: [prismaQueryInsights(), traceContext(), queryTags()],
+    adapter: new PrismaPg(process.env.DATABASE_URL!),
+    comments: [prismaQueryInsights(), traceContext(), queryTags()],
 })
 
 await withQueryTags({ route: '/api/users', requestId: 'req-123' }, () =>
-  prisma.user.findMany(),
+    prisma.user.findMany(),
 )
 ```
 
@@ -118,12 +118,12 @@ Default transaction settings:
 
 ```typescript
 const prisma = new PrismaClient({
-  adapter,
-  transactionOptions: {
-    maxWait: 5000,      // Max wait to acquire transaction (ms)
-    timeout: 10000,     // Max transaction duration (ms)
-    isolationLevel: 'Serializable',
-  },
+    adapter,
+    transactionOptions: {
+        maxWait: 5000, // Max wait to acquire transaction (ms)
+        timeout: 10000, // Max transaction duration (ms)
+        isolationLevel: 'Serializable',
+    },
 })
 ```
 
@@ -137,20 +137,20 @@ import { PrismaClient } from '../generated/client'
 import { PrismaPg } from '@prisma/adapter-pg'
 
 const globalForPrisma = globalThis as unknown as {
-  prisma: PrismaClient | undefined
+    prisma: PrismaClient | undefined
 }
 
 function createPrismaClient() {
-  const adapter = new PrismaPg({
-    connectionString: process.env.DATABASE_URL!
-  })
-  return new PrismaClient({ adapter })
+    const adapter = new PrismaPg({
+        connectionString: process.env.DATABASE_URL!,
+    })
+    return new PrismaClient({ adapter })
 }
 
 export const prisma = globalForPrisma.prisma ?? createPrismaClient()
 
 if (process.env.NODE_ENV !== 'production') {
-  globalForPrisma.prisma = prisma
+    globalForPrisma.prisma = prisma
 }
 ```
 
@@ -161,16 +161,17 @@ if (process.env.NODE_ENV !== 'production') {
 import { PrismaClient } from '@/generated/client'
 import { PrismaPg } from '@prisma/adapter-pg'
 
-const createAdapter = () => new PrismaPg({
-  connectionString: process.env.DATABASE_URL!
-})
+const createAdapter = () =>
+    new PrismaPg({
+        connectionString: process.env.DATABASE_URL!,
+    })
 
 const prismaClientSingleton = () => {
-  return new PrismaClient({ adapter: createAdapter() })
+    return new PrismaClient({ adapter: createAdapter() })
 }
 
 declare const globalThis: {
-  prismaGlobal: ReturnType<typeof prismaClientSingleton>
+    prismaGlobal: ReturnType<typeof prismaClientSingleton>
 } & typeof global
 
 const prisma = globalThis.prismaGlobal ?? prismaClientSingleton()
@@ -178,7 +179,7 @@ const prisma = globalThis.prismaGlobal ?? prismaClientSingleton()
 export default prisma
 
 if (process.env.NODE_ENV !== 'production') {
-  globalThis.prismaGlobal = prisma
+    globalThis.prismaGlobal = prisma
 }
 ```
 
@@ -188,21 +189,21 @@ Listen to query events:
 
 ```typescript
 const prisma = new PrismaClient({
-  adapter,
-  log: [{ level: 'query', emit: 'event' }],
+    adapter,
+    log: [{ level: 'query', emit: 'event' }],
 })
 
-prisma.$on('query', (e) => {
-  console.log('Query:', e.query)
-  console.log('Params:', e.params)
-  console.log('Duration:', e.duration)
+prisma.$on('query', e => {
+    console.log('Query:', e.query)
+    console.log('Params:', e.params)
+    console.log('Duration:', e.duration)
 })
 ```
 
 ## Log Events
 
 ```typescript
-prisma.$on('info', (e) => console.log(e.message))
-prisma.$on('warn', (e) => console.warn(e.message))
-prisma.$on('error', (e) => console.error(e.message))
+prisma.$on('info', e => console.log(e.message))
+prisma.$on('warn', e => console.warn(e.message))
+prisma.$on('error', e => console.error(e.message))
 ```

--- a/.agents/skills/prisma-client-api/references/filters.md
+++ b/.agents/skills/prisma-client-api/references/filters.md
@@ -1,0 +1,256 @@
+# Filter Conditions and Operators
+
+Filter operators for the `where` clause.
+
+## Equality
+
+```typescript
+// Exact match (implicit)
+where: { email: 'alice@prisma.io' }
+
+// Explicit equals
+where: { email: { equals: 'alice@prisma.io' } }
+
+// Not equal
+where: { email: { not: 'alice@prisma.io' } }
+```
+
+## Comparison
+
+```typescript
+// Greater than
+where: { age: { gt: 18 } }
+
+// Greater than or equal
+where: { age: { gte: 18 } }
+
+// Less than
+where: { age: { lt: 65 } }
+
+// Less than or equal
+where: { age: { lte: 65 } }
+
+// Combined
+where: { age: { gte: 18, lte: 65 } }
+```
+
+## Lists
+
+```typescript
+// In array
+where: { role: { in: ['ADMIN', 'MODERATOR'] } }
+
+// Not in array
+where: { role: { notIn: ['GUEST', 'BANNED'] } }
+```
+
+## String Filters
+
+```typescript
+// Contains
+where: { email: { contains: 'prisma' } }
+
+// Starts with
+where: { email: { startsWith: 'alice' } }
+
+// Ends with
+where: { email: { endsWith: '@prisma.io' } }
+
+// Case-insensitive (default for some databases)
+where: { 
+  email: { 
+    contains: 'PRISMA',
+    mode: 'insensitive' 
+  } 
+}
+```
+
+## Null Checks
+
+```typescript
+// Is null
+where: { deletedAt: null }
+
+// Is not null
+where: { deletedAt: { not: null } }
+
+// Using isSet (for optional fields)
+where: { middleName: { isSet: true } }
+```
+
+## Logical Operators
+
+### AND (implicit)
+
+```typescript
+// Multiple conditions = AND
+where: {
+  email: { contains: '@prisma.io' },
+  role: 'ADMIN'
+}
+```
+
+### AND (explicit)
+
+```typescript
+where: {
+  AND: [
+    { email: { contains: '@prisma.io' } },
+    { role: 'ADMIN' }
+  ]
+}
+```
+
+### OR
+
+```typescript
+where: {
+  OR: [
+    { email: { contains: '@gmail.com' } },
+    { email: { contains: '@prisma.io' } }
+  ]
+}
+```
+
+### NOT
+
+```typescript
+where: {
+  NOT: {
+    role: 'GUEST'
+  }
+}
+
+// Multiple NOT conditions
+where: {
+  NOT: [
+    { role: 'GUEST' },
+    { verified: false }
+  ]
+}
+```
+
+### Combined
+
+```typescript
+where: {
+  AND: [
+    { verified: true },
+    {
+      OR: [
+        { role: 'ADMIN' },
+        { role: 'MODERATOR' }
+      ]
+    }
+  ],
+  NOT: { deletedAt: { not: null } }
+}
+```
+
+## Relation Filters
+
+### some
+
+At least one related record matches:
+
+```typescript
+// Users with at least one published post
+where: {
+  posts: {
+    some: { published: true }
+  }
+}
+```
+
+### every
+
+All related records match:
+
+```typescript
+// Users where all posts are published
+where: {
+  posts: {
+    every: { published: true }
+  }
+}
+```
+
+### none
+
+No related records match:
+
+```typescript
+// Users with no published posts
+where: {
+  posts: {
+    none: { published: true }
+  }
+}
+```
+
+### is / isNot (1-to-1)
+
+```typescript
+// Users with profile in specific country
+where: {
+  profile: {
+    is: { country: 'USA' }
+  }
+}
+
+// Users without profile
+where: {
+  profile: {
+    isNot: null
+  }
+}
+```
+
+## Array Field Filters
+
+For fields like `String[]`:
+
+```typescript
+// Has element
+where: { tags: { has: 'typescript' } }
+
+// Has some elements
+where: { tags: { hasSome: ['typescript', 'javascript'] } }
+
+// Has every element
+where: { tags: { hasEvery: ['typescript', 'prisma'] } }
+
+// Is empty
+where: { tags: { isEmpty: true } }
+```
+
+## JSON Filters
+
+```typescript
+// Path-based filter
+where: {
+  metadata: {
+    path: ['settings', 'theme'],
+    equals: 'dark'
+  }
+}
+
+// String contains in JSON
+where: {
+  metadata: {
+    path: ['bio'],
+    string_contains: 'developer'
+  }
+}
+```
+
+## Full-Text Search
+
+```typescript
+// Requires @@fulltext index
+where: {
+  content: {
+    search: 'prisma database'
+  }
+}
+```

--- a/.agents/skills/prisma-client-api/references/filters.md
+++ b/.agents/skills/prisma-client-api/references/filters.md
@@ -6,13 +6,23 @@ Filter operators for the `where` clause.
 
 ```typescript
 // Exact match (implicit)
-where: { email: 'alice@prisma.io' }
+where: {
+    email: 'alice@prisma.io'
+}
 
 // Explicit equals
-where: { email: { equals: 'alice@prisma.io' } }
+where: {
+    email: {
+        equals: 'alice@prisma.io'
+    }
+}
 
 // Not equal
-where: { email: { not: 'alice@prisma.io' } }
+where: {
+    email: {
+        not: 'alice@prisma.io'
+    }
+}
 ```
 
 ## Comparison
@@ -57,11 +67,11 @@ where: { email: { startsWith: 'alice' } }
 where: { email: { endsWith: '@prisma.io' } }
 
 // Case-insensitive (default for some databases)
-where: { 
-  email: { 
+where: {
+  email: {
     contains: 'PRISMA',
-    mode: 'insensitive' 
-  } 
+    mode: 'insensitive'
+  }
 }
 ```
 
@@ -69,13 +79,23 @@ where: {
 
 ```typescript
 // Is null
-where: { deletedAt: null }
+where: {
+    deletedAt: null
+}
 
 // Is not null
-where: { deletedAt: { not: null } }
+where: {
+    deletedAt: {
+        not: null
+    }
+}
 
 // Using isSet (for optional fields)
-where: { middleName: { isSet: true } }
+where: {
+    middleName: {
+        isSet: true
+    }
+}
 ```
 
 ## Logical Operators
@@ -94,10 +114,7 @@ where: {
 
 ```typescript
 where: {
-  AND: [
-    { email: { contains: '@prisma.io' } },
-    { role: 'ADMIN' }
-  ]
+    AND: [{ email: { contains: '@prisma.io' } }, { role: 'ADMIN' }]
 }
 ```
 
@@ -105,10 +122,10 @@ where: {
 
 ```typescript
 where: {
-  OR: [
-    { email: { contains: '@gmail.com' } },
-    { email: { contains: '@prisma.io' } }
-  ]
+    OR: [
+        { email: { contains: '@gmail.com' } },
+        { email: { contains: '@prisma.io' } },
+    ]
 }
 ```
 
@@ -116,17 +133,14 @@ where: {
 
 ```typescript
 where: {
-  NOT: {
-    role: 'GUEST'
-  }
+    NOT: {
+        role: 'GUEST'
+    }
 }
 
 // Multiple NOT conditions
 where: {
-  NOT: [
-    { role: 'GUEST' },
-    { verified: false }
-  ]
+    NOT: [{ role: 'GUEST' }, { verified: false }]
 }
 ```
 
@@ -156,9 +170,11 @@ At least one related record matches:
 ```typescript
 // Users with at least one published post
 where: {
-  posts: {
-    some: { published: true }
-  }
+    posts: {
+        some: {
+            published: true
+        }
+    }
 }
 ```
 
@@ -169,9 +185,11 @@ All related records match:
 ```typescript
 // Users where all posts are published
 where: {
-  posts: {
-    every: { published: true }
-  }
+    posts: {
+        every: {
+            published: true
+        }
+    }
 }
 ```
 
@@ -182,9 +200,11 @@ No related records match:
 ```typescript
 // Users with no published posts
 where: {
-  posts: {
-    none: { published: true }
-  }
+    posts: {
+        none: {
+            published: true
+        }
+    }
 }
 ```
 
@@ -193,16 +213,18 @@ where: {
 ```typescript
 // Users with profile in specific country
 where: {
-  profile: {
-    is: { country: 'USA' }
-  }
+    profile: {
+        is: {
+            country: 'USA'
+        }
+    }
 }
 
 // Users without profile
 where: {
-  profile: {
-    isNot: null
-  }
+    profile: {
+        isNot: null
+    }
 }
 ```
 
@@ -212,16 +234,32 @@ For fields like `String[]`:
 
 ```typescript
 // Has element
-where: { tags: { has: 'typescript' } }
+where: {
+    tags: {
+        has: 'typescript'
+    }
+}
 
 // Has some elements
-where: { tags: { hasSome: ['typescript', 'javascript'] } }
+where: {
+    tags: {
+        hasSome: ['typescript', 'javascript']
+    }
+}
 
 // Has every element
-where: { tags: { hasEvery: ['typescript', 'prisma'] } }
+where: {
+    tags: {
+        hasEvery: ['typescript', 'prisma']
+    }
+}
 
 // Is empty
-where: { tags: { isEmpty: true } }
+where: {
+    tags: {
+        isEmpty: true
+    }
+}
 ```
 
 ## JSON Filters
@@ -249,8 +287,8 @@ where: {
 ```typescript
 // Requires @@fulltext index
 where: {
-  content: {
-    search: 'prisma database'
-  }
+    content: {
+        search: 'prisma database'
+    }
 }
 ```

--- a/.agents/skills/prisma-client-api/references/model-queries.md
+++ b/.agents/skills/prisma-client-api/references/model-queries.md
@@ -1,0 +1,281 @@
+# Model Queries
+
+CRUD operations for your Prisma models.
+
+## Read Operations
+
+### findUnique
+
+Find a single record by unique field:
+
+```typescript
+const user = await prisma.user.findUnique({
+  where: { id: 1 }
+})
+
+const user = await prisma.user.findUnique({
+  where: { email: 'alice@prisma.io' }
+})
+```
+
+#### With composite unique key
+
+```typescript
+// Model with @@unique([firstName, lastName])
+const user = await prisma.user.findUnique({
+  where: {
+    firstName_lastName: {
+      firstName: 'Alice',
+      lastName: 'Smith'
+    }
+  }
+})
+```
+
+### findUniqueOrThrow
+
+Same as findUnique but throws if not found:
+
+```typescript
+const user = await prisma.user.findUniqueOrThrow({
+  where: { id: 1 }
+})
+// Throws PrismaClientKnownRequestError if not found
+```
+
+### findFirst
+
+Find first matching record:
+
+```typescript
+const user = await prisma.user.findFirst({
+  where: { role: 'ADMIN' },
+  orderBy: { createdAt: 'desc' }
+})
+```
+
+### findFirstOrThrow
+
+```typescript
+const user = await prisma.user.findFirstOrThrow({
+  where: { role: 'ADMIN' }
+})
+```
+
+### findMany
+
+Find multiple records:
+
+```typescript
+const users = await prisma.user.findMany({
+  where: { role: 'USER' },
+  orderBy: { name: 'asc' },
+  take: 10,
+  skip: 0
+})
+```
+
+## Create Operations
+
+### create
+
+Create a single record:
+
+```typescript
+const user = await prisma.user.create({
+  data: {
+    email: 'alice@prisma.io',
+    name: 'Alice'
+  }
+})
+```
+
+#### With relations
+
+```typescript
+const user = await prisma.user.create({
+  data: {
+    email: 'alice@prisma.io',
+    posts: {
+      create: [
+        { title: 'First Post' },
+        { title: 'Second Post' }
+      ]
+    }
+  },
+  include: { posts: true }
+})
+```
+
+### createMany
+
+Create multiple records:
+
+```typescript
+const result = await prisma.user.createMany({
+  data: [
+    { email: 'alice@prisma.io', name: 'Alice' },
+    { email: 'bob@prisma.io', name: 'Bob' }
+  ],
+  skipDuplicates: true  // Skip records with duplicate unique fields
+})
+// Returns { count: 2 }
+```
+
+### createManyAndReturn
+
+Create multiple and return them:
+
+```typescript
+const users = await prisma.user.createManyAndReturn({
+  data: [
+    { email: 'alice@prisma.io', name: 'Alice' },
+    { email: 'bob@prisma.io', name: 'Bob' }
+  ]
+})
+// Returns array of created users
+```
+
+## Update Operations
+
+### update
+
+Update a single record:
+
+```typescript
+const user = await prisma.user.update({
+  where: { id: 1 },
+  data: { name: 'Alice Smith' }
+})
+```
+
+#### Atomic operations
+
+```typescript
+const post = await prisma.post.update({
+  where: { id: 1 },
+  data: {
+    views: { increment: 1 },
+    likes: { decrement: 1 },
+    score: { multiply: 2 },
+    rating: { divide: 2 },
+    version: { set: 5 }
+  }
+})
+```
+
+### updateMany
+
+Update multiple records:
+
+```typescript
+const result = await prisma.user.updateMany({
+  where: { role: 'USER' },
+  data: { verified: true }
+})
+// Returns { count: 42 }
+```
+
+### updateManyAndReturn
+
+```typescript
+const users = await prisma.user.updateManyAndReturn({
+  where: { role: 'USER' },
+  data: { verified: true }
+})
+// Returns array of updated users
+```
+
+### upsert
+
+Update or create:
+
+```typescript
+const user = await prisma.user.upsert({
+  where: { email: 'alice@prisma.io' },
+  update: { name: 'Alice Smith' },
+  create: { email: 'alice@prisma.io', name: 'Alice' }
+})
+```
+
+## Delete Operations
+
+### delete
+
+Delete a single record:
+
+```typescript
+const user = await prisma.user.delete({
+  where: { id: 1 }
+})
+// Returns deleted record
+```
+
+### deleteMany
+
+Delete multiple records:
+
+```typescript
+const result = await prisma.user.deleteMany({
+  where: { role: 'GUEST' }
+})
+// Returns { count: 5 }
+
+// Delete all
+const result = await prisma.user.deleteMany({})
+```
+
+## Aggregation Operations
+
+### count
+
+```typescript
+const count = await prisma.user.count({
+  where: { role: 'ADMIN' }
+})
+```
+
+### aggregate
+
+```typescript
+const result = await prisma.post.aggregate({
+  _avg: { views: true },
+  _sum: { views: true },
+  _min: { views: true },
+  _max: { views: true },
+  _count: { _all: true }
+})
+```
+
+### groupBy
+
+```typescript
+const groups = await prisma.user.groupBy({
+  by: ['country'],
+  _count: { _all: true },
+  _avg: { age: true },
+  having: {
+    age: { _avg: { gt: 30 } }
+  }
+})
+```
+
+## Return Types
+
+| Method | Returns |
+|--------|---------|
+| `findUnique` | Record \| null |
+| `findUniqueOrThrow` | Record (throws if not found) |
+| `findFirst` | Record \| null |
+| `findFirstOrThrow` | Record (throws if not found) |
+| `findMany` | Record[] |
+| `create` | Record |
+| `createMany` | { count: number } |
+| `createManyAndReturn` | Record[] |
+| `update` | Record |
+| `updateMany` | { count: number } |
+| `delete` | Record |
+| `deleteMany` | { count: number } |
+| `count` | number |
+| `aggregate` | Aggregate result |
+| `groupBy` | Group result[] |

--- a/.agents/skills/prisma-client-api/references/model-queries.md
+++ b/.agents/skills/prisma-client-api/references/model-queries.md
@@ -10,11 +10,11 @@ Find a single record by unique field:
 
 ```typescript
 const user = await prisma.user.findUnique({
-  where: { id: 1 }
+    where: { id: 1 },
 })
 
 const user = await prisma.user.findUnique({
-  where: { email: 'alice@prisma.io' }
+    where: { email: 'alice@prisma.io' },
 })
 ```
 
@@ -23,12 +23,12 @@ const user = await prisma.user.findUnique({
 ```typescript
 // Model with @@unique([firstName, lastName])
 const user = await prisma.user.findUnique({
-  where: {
-    firstName_lastName: {
-      firstName: 'Alice',
-      lastName: 'Smith'
-    }
-  }
+    where: {
+        firstName_lastName: {
+            firstName: 'Alice',
+            lastName: 'Smith',
+        },
+    },
 })
 ```
 
@@ -38,7 +38,7 @@ Same as findUnique but throws if not found:
 
 ```typescript
 const user = await prisma.user.findUniqueOrThrow({
-  where: { id: 1 }
+    where: { id: 1 },
 })
 // Throws PrismaClientKnownRequestError if not found
 ```
@@ -49,8 +49,8 @@ Find first matching record:
 
 ```typescript
 const user = await prisma.user.findFirst({
-  where: { role: 'ADMIN' },
-  orderBy: { createdAt: 'desc' }
+    where: { role: 'ADMIN' },
+    orderBy: { createdAt: 'desc' },
 })
 ```
 
@@ -58,7 +58,7 @@ const user = await prisma.user.findFirst({
 
 ```typescript
 const user = await prisma.user.findFirstOrThrow({
-  where: { role: 'ADMIN' }
+    where: { role: 'ADMIN' },
 })
 ```
 
@@ -68,10 +68,10 @@ Find multiple records:
 
 ```typescript
 const users = await prisma.user.findMany({
-  where: { role: 'USER' },
-  orderBy: { name: 'asc' },
-  take: 10,
-  skip: 0
+    where: { role: 'USER' },
+    orderBy: { name: 'asc' },
+    take: 10,
+    skip: 0,
 })
 ```
 
@@ -83,10 +83,10 @@ Create a single record:
 
 ```typescript
 const user = await prisma.user.create({
-  data: {
-    email: 'alice@prisma.io',
-    name: 'Alice'
-  }
+    data: {
+        email: 'alice@prisma.io',
+        name: 'Alice',
+    },
 })
 ```
 
@@ -94,16 +94,13 @@ const user = await prisma.user.create({
 
 ```typescript
 const user = await prisma.user.create({
-  data: {
-    email: 'alice@prisma.io',
-    posts: {
-      create: [
-        { title: 'First Post' },
-        { title: 'Second Post' }
-      ]
-    }
-  },
-  include: { posts: true }
+    data: {
+        email: 'alice@prisma.io',
+        posts: {
+            create: [{ title: 'First Post' }, { title: 'Second Post' }],
+        },
+    },
+    include: { posts: true },
 })
 ```
 
@@ -113,11 +110,11 @@ Create multiple records:
 
 ```typescript
 const result = await prisma.user.createMany({
-  data: [
-    { email: 'alice@prisma.io', name: 'Alice' },
-    { email: 'bob@prisma.io', name: 'Bob' }
-  ],
-  skipDuplicates: true  // Skip records with duplicate unique fields
+    data: [
+        { email: 'alice@prisma.io', name: 'Alice' },
+        { email: 'bob@prisma.io', name: 'Bob' },
+    ],
+    skipDuplicates: true, // Skip records with duplicate unique fields
 })
 // Returns { count: 2 }
 ```
@@ -128,10 +125,10 @@ Create multiple and return them:
 
 ```typescript
 const users = await prisma.user.createManyAndReturn({
-  data: [
-    { email: 'alice@prisma.io', name: 'Alice' },
-    { email: 'bob@prisma.io', name: 'Bob' }
-  ]
+    data: [
+        { email: 'alice@prisma.io', name: 'Alice' },
+        { email: 'bob@prisma.io', name: 'Bob' },
+    ],
 })
 // Returns array of created users
 ```
@@ -144,8 +141,8 @@ Update a single record:
 
 ```typescript
 const user = await prisma.user.update({
-  where: { id: 1 },
-  data: { name: 'Alice Smith' }
+    where: { id: 1 },
+    data: { name: 'Alice Smith' },
 })
 ```
 
@@ -153,14 +150,14 @@ const user = await prisma.user.update({
 
 ```typescript
 const post = await prisma.post.update({
-  where: { id: 1 },
-  data: {
-    views: { increment: 1 },
-    likes: { decrement: 1 },
-    score: { multiply: 2 },
-    rating: { divide: 2 },
-    version: { set: 5 }
-  }
+    where: { id: 1 },
+    data: {
+        views: { increment: 1 },
+        likes: { decrement: 1 },
+        score: { multiply: 2 },
+        rating: { divide: 2 },
+        version: { set: 5 },
+    },
 })
 ```
 
@@ -170,8 +167,8 @@ Update multiple records:
 
 ```typescript
 const result = await prisma.user.updateMany({
-  where: { role: 'USER' },
-  data: { verified: true }
+    where: { role: 'USER' },
+    data: { verified: true },
 })
 // Returns { count: 42 }
 ```
@@ -180,8 +177,8 @@ const result = await prisma.user.updateMany({
 
 ```typescript
 const users = await prisma.user.updateManyAndReturn({
-  where: { role: 'USER' },
-  data: { verified: true }
+    where: { role: 'USER' },
+    data: { verified: true },
 })
 // Returns array of updated users
 ```
@@ -192,9 +189,9 @@ Update or create:
 
 ```typescript
 const user = await prisma.user.upsert({
-  where: { email: 'alice@prisma.io' },
-  update: { name: 'Alice Smith' },
-  create: { email: 'alice@prisma.io', name: 'Alice' }
+    where: { email: 'alice@prisma.io' },
+    update: { name: 'Alice Smith' },
+    create: { email: 'alice@prisma.io', name: 'Alice' },
 })
 ```
 
@@ -206,7 +203,7 @@ Delete a single record:
 
 ```typescript
 const user = await prisma.user.delete({
-  where: { id: 1 }
+    where: { id: 1 },
 })
 // Returns deleted record
 ```
@@ -217,7 +214,7 @@ Delete multiple records:
 
 ```typescript
 const result = await prisma.user.deleteMany({
-  where: { role: 'GUEST' }
+    where: { role: 'GUEST' },
 })
 // Returns { count: 5 }
 
@@ -231,7 +228,7 @@ const result = await prisma.user.deleteMany({})
 
 ```typescript
 const count = await prisma.user.count({
-  where: { role: 'ADMIN' }
+    where: { role: 'ADMIN' },
 })
 ```
 
@@ -239,11 +236,11 @@ const count = await prisma.user.count({
 
 ```typescript
 const result = await prisma.post.aggregate({
-  _avg: { views: true },
-  _sum: { views: true },
-  _min: { views: true },
-  _max: { views: true },
-  _count: { _all: true }
+    _avg: { views: true },
+    _sum: { views: true },
+    _min: { views: true },
+    _max: { views: true },
+    _count: { _all: true },
 })
 ```
 
@@ -251,31 +248,31 @@ const result = await prisma.post.aggregate({
 
 ```typescript
 const groups = await prisma.user.groupBy({
-  by: ['country'],
-  _count: { _all: true },
-  _avg: { age: true },
-  having: {
-    age: { _avg: { gt: 30 } }
-  }
+    by: ['country'],
+    _count: { _all: true },
+    _avg: { age: true },
+    having: {
+        age: { _avg: { gt: 30 } },
+    },
 })
 ```
 
 ## Return Types
 
-| Method | Returns |
-|--------|---------|
-| `findUnique` | Record \| null |
-| `findUniqueOrThrow` | Record (throws if not found) |
-| `findFirst` | Record \| null |
-| `findFirstOrThrow` | Record (throws if not found) |
-| `findMany` | Record[] |
-| `create` | Record |
-| `createMany` | { count: number } |
-| `createManyAndReturn` | Record[] |
-| `update` | Record |
-| `updateMany` | { count: number } |
-| `delete` | Record |
-| `deleteMany` | { count: number } |
-| `count` | number |
-| `aggregate` | Aggregate result |
-| `groupBy` | Group result[] |
+| Method                | Returns                      |
+| --------------------- | ---------------------------- |
+| `findUnique`          | Record \| null               |
+| `findUniqueOrThrow`   | Record (throws if not found) |
+| `findFirst`           | Record \| null               |
+| `findFirstOrThrow`    | Record (throws if not found) |
+| `findMany`            | Record[]                     |
+| `create`              | Record                       |
+| `createMany`          | { count: number }            |
+| `createManyAndReturn` | Record[]                     |
+| `update`              | Record                       |
+| `updateMany`          | { count: number }            |
+| `delete`              | Record                       |
+| `deleteMany`          | { count: number }            |
+| `count`               | number                       |
+| `aggregate`           | Aggregate result             |
+| `groupBy`             | Group result[]               |

--- a/.agents/skills/prisma-client-api/references/query-options.md
+++ b/.agents/skills/prisma-client-api/references/query-options.md
@@ -1,0 +1,276 @@
+# Query Options
+
+Options for controlling query behavior.
+
+## select
+
+Choose specific fields to return:
+
+```typescript
+const user = await prisma.user.findUnique({
+  where: { id: 1 },
+  select: {
+    id: true,
+    name: true,
+    email: true,
+    // password: false (excluded by not including)
+  }
+})
+// Returns: { id: 1, name: 'Alice', email: 'alice@prisma.io' }
+```
+
+### Select relations
+
+```typescript
+const user = await prisma.user.findUnique({
+  where: { id: 1 },
+  select: {
+    name: true,
+    posts: {
+      select: {
+        title: true,
+        published: true
+      }
+    }
+  }
+})
+```
+
+### Select with include inside
+
+```typescript
+const user = await prisma.user.findMany({
+  select: {
+    name: true,
+    posts: {
+      include: {
+        comments: true
+      }
+    }
+  }
+})
+```
+
+### Select relation count
+
+```typescript
+const users = await prisma.user.findMany({
+  select: {
+    name: true,
+    _count: {
+      select: { posts: true }
+    }
+  }
+})
+// Returns: { name: 'Alice', _count: { posts: 5 } }
+```
+
+## include
+
+Include related records:
+
+```typescript
+const user = await prisma.user.findUnique({
+  where: { id: 1 },
+  include: {
+    posts: true,
+    profile: true
+  }
+})
+```
+
+### Filtered include
+
+```typescript
+const user = await prisma.user.findUnique({
+  where: { id: 1 },
+  include: {
+    posts: {
+      where: { published: true },
+      orderBy: { createdAt: 'desc' },
+      take: 5
+    }
+  }
+})
+```
+
+### Nested include
+
+```typescript
+const user = await prisma.user.findUnique({
+  where: { id: 1 },
+  include: {
+    posts: {
+      include: {
+        comments: {
+          include: {
+            author: true
+          }
+        }
+      }
+    }
+  }
+})
+```
+
+### Include relation count
+
+```typescript
+const users = await prisma.user.findMany({
+  include: {
+    _count: {
+      select: { posts: true, followers: true }
+    }
+  }
+})
+```
+
+## omit
+
+Exclude specific fields:
+
+```typescript
+const user = await prisma.user.findUnique({
+  where: { id: 1 },
+  omit: {
+    password: true
+  }
+})
+// Returns all fields except password
+```
+
+### Omit in relations
+
+```typescript
+const users = await prisma.user.findMany({
+  omit: { password: true },
+  include: {
+    posts: {
+      omit: { content: true }
+    }
+  }
+})
+```
+
+**Note:** Cannot use `select` and `omit` together.
+
+## where
+
+Filter records:
+
+```typescript
+const users = await prisma.user.findMany({
+  where: {
+    email: { contains: '@prisma.io' },
+    role: 'ADMIN'
+  }
+})
+```
+
+See `filters.md` for detailed filter operators.
+
+## orderBy
+
+Sort results:
+
+```typescript
+// Single field
+const users = await prisma.user.findMany({
+  orderBy: { name: 'asc' }
+})
+
+// Multiple fields
+const users = await prisma.user.findMany({
+  orderBy: [
+    { role: 'desc' },
+    { name: 'asc' }
+  ]
+})
+```
+
+### Order by relation
+
+```typescript
+const users = await prisma.user.findMany({
+  orderBy: {
+    posts: { _count: 'desc' }
+  }
+})
+```
+
+### Null handling
+
+```typescript
+const users = await prisma.user.findMany({
+  orderBy: {
+    name: { sort: 'asc', nulls: 'last' }
+  }
+})
+```
+
+## take & skip
+
+Pagination:
+
+```typescript
+// First page
+const users = await prisma.user.findMany({
+  take: 10,
+  skip: 0
+})
+
+// Second page
+const users = await prisma.user.findMany({
+  take: 10,
+  skip: 10
+})
+```
+
+### Negative take (reverse)
+
+```typescript
+const lastUsers = await prisma.user.findMany({
+  take: -10,
+  orderBy: { id: 'asc' }
+})
+// Returns last 10 users
+```
+
+## cursor
+
+Cursor-based pagination:
+
+```typescript
+// First page
+const firstPage = await prisma.user.findMany({
+  take: 10,
+  orderBy: { id: 'asc' }
+})
+
+// Next page using cursor
+const nextPage = await prisma.user.findMany({
+  take: 10,
+  skip: 1,  // Skip the cursor record
+  cursor: { id: firstPage[firstPage.length - 1].id },
+  orderBy: { id: 'asc' }
+})
+```
+
+## distinct
+
+Return unique values:
+
+```typescript
+const cities = await prisma.user.findMany({
+  distinct: ['city'],
+  select: { city: true }
+})
+```
+
+### Multiple distinct fields
+
+```typescript
+const locations = await prisma.user.findMany({
+  distinct: ['city', 'country']
+})
+```

--- a/.agents/skills/prisma-client-api/references/query-options.md
+++ b/.agents/skills/prisma-client-api/references/query-options.md
@@ -8,13 +8,13 @@ Choose specific fields to return:
 
 ```typescript
 const user = await prisma.user.findUnique({
-  where: { id: 1 },
-  select: {
-    id: true,
-    name: true,
-    email: true,
-    // password: false (excluded by not including)
-  }
+    where: { id: 1 },
+    select: {
+        id: true,
+        name: true,
+        email: true,
+        // password: false (excluded by not including)
+    },
 })
 // Returns: { id: 1, name: 'Alice', email: 'alice@prisma.io' }
 ```
@@ -23,16 +23,16 @@ const user = await prisma.user.findUnique({
 
 ```typescript
 const user = await prisma.user.findUnique({
-  where: { id: 1 },
-  select: {
-    name: true,
-    posts: {
-      select: {
-        title: true,
-        published: true
-      }
-    }
-  }
+    where: { id: 1 },
+    select: {
+        name: true,
+        posts: {
+            select: {
+                title: true,
+                published: true,
+            },
+        },
+    },
 })
 ```
 
@@ -40,14 +40,14 @@ const user = await prisma.user.findUnique({
 
 ```typescript
 const user = await prisma.user.findMany({
-  select: {
-    name: true,
-    posts: {
-      include: {
-        comments: true
-      }
-    }
-  }
+    select: {
+        name: true,
+        posts: {
+            include: {
+                comments: true,
+            },
+        },
+    },
 })
 ```
 
@@ -55,12 +55,12 @@ const user = await prisma.user.findMany({
 
 ```typescript
 const users = await prisma.user.findMany({
-  select: {
-    name: true,
-    _count: {
-      select: { posts: true }
-    }
-  }
+    select: {
+        name: true,
+        _count: {
+            select: { posts: true },
+        },
+    },
 })
 // Returns: { name: 'Alice', _count: { posts: 5 } }
 ```
@@ -71,11 +71,11 @@ Include related records:
 
 ```typescript
 const user = await prisma.user.findUnique({
-  where: { id: 1 },
-  include: {
-    posts: true,
-    profile: true
-  }
+    where: { id: 1 },
+    include: {
+        posts: true,
+        profile: true,
+    },
 })
 ```
 
@@ -83,14 +83,14 @@ const user = await prisma.user.findUnique({
 
 ```typescript
 const user = await prisma.user.findUnique({
-  where: { id: 1 },
-  include: {
-    posts: {
-      where: { published: true },
-      orderBy: { createdAt: 'desc' },
-      take: 5
-    }
-  }
+    where: { id: 1 },
+    include: {
+        posts: {
+            where: { published: true },
+            orderBy: { createdAt: 'desc' },
+            take: 5,
+        },
+    },
 })
 ```
 
@@ -98,18 +98,18 @@ const user = await prisma.user.findUnique({
 
 ```typescript
 const user = await prisma.user.findUnique({
-  where: { id: 1 },
-  include: {
-    posts: {
-      include: {
-        comments: {
-          include: {
-            author: true
-          }
-        }
-      }
-    }
-  }
+    where: { id: 1 },
+    include: {
+        posts: {
+            include: {
+                comments: {
+                    include: {
+                        author: true,
+                    },
+                },
+            },
+        },
+    },
 })
 ```
 
@@ -117,11 +117,11 @@ const user = await prisma.user.findUnique({
 
 ```typescript
 const users = await prisma.user.findMany({
-  include: {
-    _count: {
-      select: { posts: true, followers: true }
-    }
-  }
+    include: {
+        _count: {
+            select: { posts: true, followers: true },
+        },
+    },
 })
 ```
 
@@ -131,10 +131,10 @@ Exclude specific fields:
 
 ```typescript
 const user = await prisma.user.findUnique({
-  where: { id: 1 },
-  omit: {
-    password: true
-  }
+    where: { id: 1 },
+    omit: {
+        password: true,
+    },
 })
 // Returns all fields except password
 ```
@@ -143,12 +143,12 @@ const user = await prisma.user.findUnique({
 
 ```typescript
 const users = await prisma.user.findMany({
-  omit: { password: true },
-  include: {
-    posts: {
-      omit: { content: true }
-    }
-  }
+    omit: { password: true },
+    include: {
+        posts: {
+            omit: { content: true },
+        },
+    },
 })
 ```
 
@@ -160,10 +160,10 @@ Filter records:
 
 ```typescript
 const users = await prisma.user.findMany({
-  where: {
-    email: { contains: '@prisma.io' },
-    role: 'ADMIN'
-  }
+    where: {
+        email: { contains: '@prisma.io' },
+        role: 'ADMIN',
+    },
 })
 ```
 
@@ -176,15 +176,12 @@ Sort results:
 ```typescript
 // Single field
 const users = await prisma.user.findMany({
-  orderBy: { name: 'asc' }
+    orderBy: { name: 'asc' },
 })
 
 // Multiple fields
 const users = await prisma.user.findMany({
-  orderBy: [
-    { role: 'desc' },
-    { name: 'asc' }
-  ]
+    orderBy: [{ role: 'desc' }, { name: 'asc' }],
 })
 ```
 
@@ -192,9 +189,9 @@ const users = await prisma.user.findMany({
 
 ```typescript
 const users = await prisma.user.findMany({
-  orderBy: {
-    posts: { _count: 'desc' }
-  }
+    orderBy: {
+        posts: { _count: 'desc' },
+    },
 })
 ```
 
@@ -202,9 +199,9 @@ const users = await prisma.user.findMany({
 
 ```typescript
 const users = await prisma.user.findMany({
-  orderBy: {
-    name: { sort: 'asc', nulls: 'last' }
-  }
+    orderBy: {
+        name: { sort: 'asc', nulls: 'last' },
+    },
 })
 ```
 
@@ -215,14 +212,14 @@ Pagination:
 ```typescript
 // First page
 const users = await prisma.user.findMany({
-  take: 10,
-  skip: 0
+    take: 10,
+    skip: 0,
 })
 
 // Second page
 const users = await prisma.user.findMany({
-  take: 10,
-  skip: 10
+    take: 10,
+    skip: 10,
 })
 ```
 
@@ -230,8 +227,8 @@ const users = await prisma.user.findMany({
 
 ```typescript
 const lastUsers = await prisma.user.findMany({
-  take: -10,
-  orderBy: { id: 'asc' }
+    take: -10,
+    orderBy: { id: 'asc' },
 })
 // Returns last 10 users
 ```
@@ -243,16 +240,16 @@ Cursor-based pagination:
 ```typescript
 // First page
 const firstPage = await prisma.user.findMany({
-  take: 10,
-  orderBy: { id: 'asc' }
+    take: 10,
+    orderBy: { id: 'asc' },
 })
 
 // Next page using cursor
 const nextPage = await prisma.user.findMany({
-  take: 10,
-  skip: 1,  // Skip the cursor record
-  cursor: { id: firstPage[firstPage.length - 1].id },
-  orderBy: { id: 'asc' }
+    take: 10,
+    skip: 1, // Skip the cursor record
+    cursor: { id: firstPage[firstPage.length - 1].id },
+    orderBy: { id: 'asc' },
 })
 ```
 
@@ -262,8 +259,8 @@ Return unique values:
 
 ```typescript
 const cities = await prisma.user.findMany({
-  distinct: ['city'],
-  select: { city: true }
+    distinct: ['city'],
+    select: { city: true },
 })
 ```
 
@@ -271,6 +268,6 @@ const cities = await prisma.user.findMany({
 
 ```typescript
 const locations = await prisma.user.findMany({
-  distinct: ['city', 'country']
+    distinct: ['city', 'country'],
 })
 ```

--- a/.agents/skills/prisma-client-api/references/raw-queries.md
+++ b/.agents/skills/prisma-client-api/references/raw-queries.md
@@ -1,0 +1,194 @@
+# Raw Queries
+
+Execute raw SQL when Prisma's query API isn't sufficient.
+
+## $queryRaw
+
+Execute SELECT queries and get typed results:
+
+```typescript
+const users = await prisma.$queryRaw`
+  SELECT * FROM "User" WHERE email LIKE ${'%@prisma.io'}
+`
+```
+
+### With type
+
+```typescript
+type User = { id: number; email: string; name: string | null }
+
+const users = await prisma.$queryRaw<User[]>`
+  SELECT id, email, name FROM "User" WHERE role = ${'ADMIN'}
+`
+```
+
+### Dynamic table/column names
+
+Use `Prisma.raw()` for identifiers (not safe for user input):
+
+```typescript
+import { Prisma } from '../generated/client'
+
+const column = 'email'
+const users = await prisma.$queryRaw`
+  SELECT ${Prisma.raw(column)} FROM "User"
+`
+```
+
+### With Prisma.sql
+
+Build queries dynamically:
+
+```typescript
+import { Prisma } from '../generated/client'
+
+const email = 'alice@prisma.io'
+const query = Prisma.sql`SELECT * FROM "User" WHERE email = ${email}`
+const users = await prisma.$queryRaw(query)
+```
+
+### Join multiple SQL fragments
+
+```typescript
+import { Prisma } from '../generated/client'
+
+const conditions = [
+  Prisma.sql`role = ${'ADMIN'}`,
+  Prisma.sql`verified = ${true}`
+]
+
+const users = await prisma.$queryRaw`
+  SELECT * FROM "User" 
+  WHERE ${Prisma.join(conditions, ' AND ')}
+`
+```
+
+## $executeRaw
+
+Execute INSERT, UPDATE, DELETE (returns affected count):
+
+```typescript
+const count = await prisma.$executeRaw`
+  UPDATE "User" SET verified = true WHERE email LIKE ${'%@prisma.io'}
+`
+console.log(`Updated ${count} users`)
+```
+
+### Delete example
+
+```typescript
+const deleted = await prisma.$executeRaw`
+  DELETE FROM "User" WHERE "deletedAt" < ${thirtyDaysAgo}
+`
+```
+
+### Insert example
+
+```typescript
+const inserted = await prisma.$executeRaw`
+  INSERT INTO "Log" (message, level, timestamp)
+  VALUES (${message}, ${level}, ${new Date()})
+`
+```
+
+## $queryRawUnsafe / $executeRawUnsafe
+
+For fully dynamic queries (use with caution!):
+
+```typescript
+// ⚠️ SQL injection risk - only use with trusted input
+const table = 'User'
+const users = await prisma.$queryRawUnsafe(
+  `SELECT * FROM "${table}" WHERE id = $1`,
+  userId
+)
+```
+
+### Parameterized unsafe query
+
+```typescript
+const result = await prisma.$executeRawUnsafe(
+  'UPDATE "User" SET name = $1 WHERE id = $2',
+  'Alice',
+  1
+)
+```
+
+## SQL Injection Prevention
+
+### Safe (parameterized)
+
+```typescript
+// ✅ User input is parameterized
+const email = userInput
+const users = await prisma.$queryRaw`
+  SELECT * FROM "User" WHERE email = ${email}
+`
+```
+
+### Unsafe (concatenation)
+
+```typescript
+// ❌ SQL injection vulnerability!
+const email = userInput
+const users = await prisma.$queryRawUnsafe(
+  `SELECT * FROM "User" WHERE email = '${email}'`
+)
+```
+
+## Database-Specific Features
+
+### PostgreSQL
+
+```typescript
+// Array operations
+const users = await prisma.$queryRaw`
+  SELECT * FROM "User" WHERE 'admin' = ANY(roles)
+`
+
+// JSON operations
+const users = await prisma.$queryRaw`
+  SELECT * FROM "User" WHERE metadata->>'theme' = 'dark'
+`
+```
+
+### MySQL
+
+```typescript
+// Full-text search
+const posts = await prisma.$queryRaw`
+  SELECT * FROM Post WHERE MATCH(title, content) AGAINST(${searchTerm})
+`
+```
+
+## Transactions with Raw Queries
+
+```typescript
+await prisma.$transaction(async (tx) => {
+  await tx.$executeRaw`UPDATE "Account" SET balance = balance - ${amount} WHERE id = ${senderId}`
+  await tx.$executeRaw`UPDATE "Account" SET balance = balance + ${amount} WHERE id = ${recipientId}`
+})
+```
+
+## Handling Results
+
+### BigInt handling
+
+PostgreSQL returns BigInt for COUNT:
+
+```typescript
+const result = await prisma.$queryRaw<[{ count: bigint }]>`
+  SELECT COUNT(*) as count FROM "User"
+`
+const count = Number(result[0].count)
+```
+
+### Date handling
+
+```typescript
+type Result = { createdAt: Date }
+const users = await prisma.$queryRaw<Result[]>`
+  SELECT "createdAt" FROM "User"
+`
+// createdAt is already a Date object
+```

--- a/.agents/skills/prisma-client-api/references/raw-queries.md
+++ b/.agents/skills/prisma-client-api/references/raw-queries.md
@@ -53,8 +53,8 @@ const users = await prisma.$queryRaw(query)
 import { Prisma } from '../generated/client'
 
 const conditions = [
-  Prisma.sql`role = ${'ADMIN'}`,
-  Prisma.sql`verified = ${true}`
+    Prisma.sql`role = ${'ADMIN'}`,
+    Prisma.sql`verified = ${true}`,
 ]
 
 const users = await prisma.$queryRaw`
@@ -99,8 +99,8 @@ For fully dynamic queries (use with caution!):
 // ⚠️ SQL injection risk - only use with trusted input
 const table = 'User'
 const users = await prisma.$queryRawUnsafe(
-  `SELECT * FROM "${table}" WHERE id = $1`,
-  userId
+    `SELECT * FROM "${table}" WHERE id = $1`,
+    userId,
 )
 ```
 
@@ -108,9 +108,9 @@ const users = await prisma.$queryRawUnsafe(
 
 ```typescript
 const result = await prisma.$executeRawUnsafe(
-  'UPDATE "User" SET name = $1 WHERE id = $2',
-  'Alice',
-  1
+    'UPDATE "User" SET name = $1 WHERE id = $2',
+    'Alice',
+    1,
 )
 ```
 
@@ -132,7 +132,7 @@ const users = await prisma.$queryRaw`
 // ❌ SQL injection vulnerability!
 const email = userInput
 const users = await prisma.$queryRawUnsafe(
-  `SELECT * FROM "User" WHERE email = '${email}'`
+    `SELECT * FROM "User" WHERE email = '${email}'`,
 )
 ```
 
@@ -164,9 +164,9 @@ const posts = await prisma.$queryRaw`
 ## Transactions with Raw Queries
 
 ```typescript
-await prisma.$transaction(async (tx) => {
-  await tx.$executeRaw`UPDATE "Account" SET balance = balance - ${amount} WHERE id = ${senderId}`
-  await tx.$executeRaw`UPDATE "Account" SET balance = balance + ${amount} WHERE id = ${recipientId}`
+await prisma.$transaction(async tx => {
+    await tx.$executeRaw`UPDATE "Account" SET balance = balance - ${amount} WHERE id = ${senderId}`
+    await tx.$executeRaw`UPDATE "Account" SET balance = balance + ${amount} WHERE id = ${recipientId}`
 })
 ```
 

--- a/.agents/skills/prisma-client-api/references/relations.md
+++ b/.agents/skills/prisma-client-api/references/relations.md
@@ -1,0 +1,308 @@
+# Relation Queries
+
+Query and modify related records.
+
+## Include Relations
+
+Load related records:
+
+```typescript
+const user = await prisma.user.findUnique({
+  where: { id: 1 },
+  include: {
+    posts: true,
+    profile: true
+  }
+})
+```
+
+### Filtered include
+
+```typescript
+const user = await prisma.user.findUnique({
+  where: { id: 1 },
+  include: {
+    posts: {
+      where: { published: true },
+      orderBy: { createdAt: 'desc' },
+      take: 5,
+      select: { id: true, title: true }
+    }
+  }
+})
+```
+
+### Nested include
+
+```typescript
+const user = await prisma.user.findUnique({
+  where: { id: 1 },
+  include: {
+    posts: {
+      include: {
+        comments: {
+          include: { author: true }
+        }
+      }
+    }
+  }
+})
+```
+
+## Select Relations
+
+```typescript
+const user = await prisma.user.findUnique({
+  where: { id: 1 },
+  select: {
+    name: true,
+    posts: {
+      select: { title: true }
+    }
+  }
+})
+```
+
+## Nested Writes
+
+### Create with relations
+
+```typescript
+const user = await prisma.user.create({
+  data: {
+    email: 'alice@prisma.io',
+    posts: {
+      create: [
+        { title: 'Post 1' },
+        { title: 'Post 2' }
+      ]
+    },
+    profile: {
+      create: { bio: 'Hello!' }
+    }
+  }
+})
+```
+
+### Create or connect
+
+```typescript
+const post = await prisma.post.create({
+  data: {
+    title: 'New Post',
+    author: {
+      connectOrCreate: {
+        where: { email: 'alice@prisma.io' },
+        create: { email: 'alice@prisma.io', name: 'Alice' }
+      }
+    }
+  }
+})
+```
+
+### Connect existing
+
+```typescript
+const post = await prisma.post.create({
+  data: {
+    title: 'New Post',
+    author: {
+      connect: { id: 1 }
+    }
+  }
+})
+
+// Shorthand for foreign key
+const post = await prisma.post.create({
+  data: {
+    title: 'New Post',
+    authorId: 1
+  }
+})
+```
+
+## Update Relations
+
+### Update related records
+
+```typescript
+const user = await prisma.user.update({
+  where: { id: 1 },
+  data: {
+    posts: {
+      update: {
+        where: { id: 1 },
+        data: { title: 'Updated Title' }
+      }
+    }
+  }
+})
+```
+
+### Update many related
+
+```typescript
+const user = await prisma.user.update({
+  where: { id: 1 },
+  data: {
+    posts: {
+      updateMany: {
+        where: { published: false },
+        data: { published: true }
+      }
+    }
+  }
+})
+```
+
+### Upsert related
+
+```typescript
+const user = await prisma.user.update({
+  where: { id: 1 },
+  data: {
+    profile: {
+      upsert: {
+        create: { bio: 'New bio' },
+        update: { bio: 'Updated bio' }
+      }
+    }
+  }
+})
+```
+
+### Disconnect
+
+```typescript
+// 1-to-1 optional
+const user = await prisma.user.update({
+  where: { id: 1 },
+  data: {
+    profile: { disconnect: true }
+  }
+})
+
+// Many-to-many
+const post = await prisma.post.update({
+  where: { id: 1 },
+  data: {
+    tags: {
+      disconnect: [{ id: 1 }, { id: 2 }]
+    }
+  }
+})
+```
+
+### Delete related
+
+```typescript
+const user = await prisma.user.update({
+  where: { id: 1 },
+  data: {
+    posts: {
+      delete: { id: 1 }
+    }
+  }
+})
+
+// Delete many
+const user = await prisma.user.update({
+  where: { id: 1 },
+  data: {
+    posts: {
+      deleteMany: { published: false }
+    }
+  }
+})
+```
+
+### Set (replace all)
+
+```typescript
+// Replace all related records
+const post = await prisma.post.update({
+  where: { id: 1 },
+  data: {
+    tags: {
+      set: [{ id: 1 }, { id: 2 }]
+    }
+  }
+})
+```
+
+## Relation Filters
+
+### some
+
+At least one matches:
+
+```typescript
+const users = await prisma.user.findMany({
+  where: {
+    posts: { some: { published: true } }
+  }
+})
+```
+
+### every
+
+All match:
+
+```typescript
+const users = await prisma.user.findMany({
+  where: {
+    posts: { every: { published: true } }
+  }
+})
+```
+
+### none
+
+None match:
+
+```typescript
+const users = await prisma.user.findMany({
+  where: {
+    posts: { none: { published: true } }
+  }
+})
+```
+
+### is / isNot (1-to-1)
+
+```typescript
+const users = await prisma.user.findMany({
+  where: {
+    profile: { is: { country: 'USA' } }
+  }
+})
+```
+
+## Count Relations
+
+```typescript
+const users = await prisma.user.findMany({
+  select: {
+    name: true,
+    _count: {
+      select: { posts: true, followers: true }
+    }
+  }
+})
+// { name: 'Alice', _count: { posts: 5, followers: 100 } }
+```
+
+### Filter counted relations
+
+```typescript
+const users = await prisma.user.findMany({
+  select: {
+    name: true,
+    _count: {
+      select: {
+        posts: { where: { published: true } }
+      }
+    }
+  }
+})
+```

--- a/.agents/skills/prisma-client-api/references/relations.md
+++ b/.agents/skills/prisma-client-api/references/relations.md
@@ -8,11 +8,11 @@ Load related records:
 
 ```typescript
 const user = await prisma.user.findUnique({
-  where: { id: 1 },
-  include: {
-    posts: true,
-    profile: true
-  }
+    where: { id: 1 },
+    include: {
+        posts: true,
+        profile: true,
+    },
 })
 ```
 
@@ -20,15 +20,15 @@ const user = await prisma.user.findUnique({
 
 ```typescript
 const user = await prisma.user.findUnique({
-  where: { id: 1 },
-  include: {
-    posts: {
-      where: { published: true },
-      orderBy: { createdAt: 'desc' },
-      take: 5,
-      select: { id: true, title: true }
-    }
-  }
+    where: { id: 1 },
+    include: {
+        posts: {
+            where: { published: true },
+            orderBy: { createdAt: 'desc' },
+            take: 5,
+            select: { id: true, title: true },
+        },
+    },
 })
 ```
 
@@ -36,16 +36,16 @@ const user = await prisma.user.findUnique({
 
 ```typescript
 const user = await prisma.user.findUnique({
-  where: { id: 1 },
-  include: {
-    posts: {
-      include: {
-        comments: {
-          include: { author: true }
-        }
-      }
-    }
-  }
+    where: { id: 1 },
+    include: {
+        posts: {
+            include: {
+                comments: {
+                    include: { author: true },
+                },
+            },
+        },
+    },
 })
 ```
 
@@ -53,13 +53,13 @@ const user = await prisma.user.findUnique({
 
 ```typescript
 const user = await prisma.user.findUnique({
-  where: { id: 1 },
-  select: {
-    name: true,
-    posts: {
-      select: { title: true }
-    }
-  }
+    where: { id: 1 },
+    select: {
+        name: true,
+        posts: {
+            select: { title: true },
+        },
+    },
 })
 ```
 
@@ -69,18 +69,15 @@ const user = await prisma.user.findUnique({
 
 ```typescript
 const user = await prisma.user.create({
-  data: {
-    email: 'alice@prisma.io',
-    posts: {
-      create: [
-        { title: 'Post 1' },
-        { title: 'Post 2' }
-      ]
+    data: {
+        email: 'alice@prisma.io',
+        posts: {
+            create: [{ title: 'Post 1' }, { title: 'Post 2' }],
+        },
+        profile: {
+            create: { bio: 'Hello!' },
+        },
     },
-    profile: {
-      create: { bio: 'Hello!' }
-    }
-  }
 })
 ```
 
@@ -88,15 +85,15 @@ const user = await prisma.user.create({
 
 ```typescript
 const post = await prisma.post.create({
-  data: {
-    title: 'New Post',
-    author: {
-      connectOrCreate: {
-        where: { email: 'alice@prisma.io' },
-        create: { email: 'alice@prisma.io', name: 'Alice' }
-      }
-    }
-  }
+    data: {
+        title: 'New Post',
+        author: {
+            connectOrCreate: {
+                where: { email: 'alice@prisma.io' },
+                create: { email: 'alice@prisma.io', name: 'Alice' },
+            },
+        },
+    },
 })
 ```
 
@@ -104,20 +101,20 @@ const post = await prisma.post.create({
 
 ```typescript
 const post = await prisma.post.create({
-  data: {
-    title: 'New Post',
-    author: {
-      connect: { id: 1 }
-    }
-  }
+    data: {
+        title: 'New Post',
+        author: {
+            connect: { id: 1 },
+        },
+    },
 })
 
 // Shorthand for foreign key
 const post = await prisma.post.create({
-  data: {
-    title: 'New Post',
-    authorId: 1
-  }
+    data: {
+        title: 'New Post',
+        authorId: 1,
+    },
 })
 ```
 
@@ -127,15 +124,15 @@ const post = await prisma.post.create({
 
 ```typescript
 const user = await prisma.user.update({
-  where: { id: 1 },
-  data: {
-    posts: {
-      update: {
-        where: { id: 1 },
-        data: { title: 'Updated Title' }
-      }
-    }
-  }
+    where: { id: 1 },
+    data: {
+        posts: {
+            update: {
+                where: { id: 1 },
+                data: { title: 'Updated Title' },
+            },
+        },
+    },
 })
 ```
 
@@ -143,15 +140,15 @@ const user = await prisma.user.update({
 
 ```typescript
 const user = await prisma.user.update({
-  where: { id: 1 },
-  data: {
-    posts: {
-      updateMany: {
-        where: { published: false },
-        data: { published: true }
-      }
-    }
-  }
+    where: { id: 1 },
+    data: {
+        posts: {
+            updateMany: {
+                where: { published: false },
+                data: { published: true },
+            },
+        },
+    },
 })
 ```
 
@@ -159,15 +156,15 @@ const user = await prisma.user.update({
 
 ```typescript
 const user = await prisma.user.update({
-  where: { id: 1 },
-  data: {
-    profile: {
-      upsert: {
-        create: { bio: 'New bio' },
-        update: { bio: 'Updated bio' }
-      }
-    }
-  }
+    where: { id: 1 },
+    data: {
+        profile: {
+            upsert: {
+                create: { bio: 'New bio' },
+                update: { bio: 'Updated bio' },
+            },
+        },
+    },
 })
 ```
 
@@ -176,20 +173,20 @@ const user = await prisma.user.update({
 ```typescript
 // 1-to-1 optional
 const user = await prisma.user.update({
-  where: { id: 1 },
-  data: {
-    profile: { disconnect: true }
-  }
+    where: { id: 1 },
+    data: {
+        profile: { disconnect: true },
+    },
 })
 
 // Many-to-many
 const post = await prisma.post.update({
-  where: { id: 1 },
-  data: {
-    tags: {
-      disconnect: [{ id: 1 }, { id: 2 }]
-    }
-  }
+    where: { id: 1 },
+    data: {
+        tags: {
+            disconnect: [{ id: 1 }, { id: 2 }],
+        },
+    },
 })
 ```
 
@@ -197,22 +194,22 @@ const post = await prisma.post.update({
 
 ```typescript
 const user = await prisma.user.update({
-  where: { id: 1 },
-  data: {
-    posts: {
-      delete: { id: 1 }
-    }
-  }
+    where: { id: 1 },
+    data: {
+        posts: {
+            delete: { id: 1 },
+        },
+    },
 })
 
 // Delete many
 const user = await prisma.user.update({
-  where: { id: 1 },
-  data: {
-    posts: {
-      deleteMany: { published: false }
-    }
-  }
+    where: { id: 1 },
+    data: {
+        posts: {
+            deleteMany: { published: false },
+        },
+    },
 })
 ```
 
@@ -221,12 +218,12 @@ const user = await prisma.user.update({
 ```typescript
 // Replace all related records
 const post = await prisma.post.update({
-  where: { id: 1 },
-  data: {
-    tags: {
-      set: [{ id: 1 }, { id: 2 }]
-    }
-  }
+    where: { id: 1 },
+    data: {
+        tags: {
+            set: [{ id: 1 }, { id: 2 }],
+        },
+    },
 })
 ```
 
@@ -238,9 +235,9 @@ At least one matches:
 
 ```typescript
 const users = await prisma.user.findMany({
-  where: {
-    posts: { some: { published: true } }
-  }
+    where: {
+        posts: { some: { published: true } },
+    },
 })
 ```
 
@@ -250,9 +247,9 @@ All match:
 
 ```typescript
 const users = await prisma.user.findMany({
-  where: {
-    posts: { every: { published: true } }
-  }
+    where: {
+        posts: { every: { published: true } },
+    },
 })
 ```
 
@@ -262,9 +259,9 @@ None match:
 
 ```typescript
 const users = await prisma.user.findMany({
-  where: {
-    posts: { none: { published: true } }
-  }
+    where: {
+        posts: { none: { published: true } },
+    },
 })
 ```
 
@@ -272,9 +269,9 @@ const users = await prisma.user.findMany({
 
 ```typescript
 const users = await prisma.user.findMany({
-  where: {
-    profile: { is: { country: 'USA' } }
-  }
+    where: {
+        profile: { is: { country: 'USA' } },
+    },
 })
 ```
 
@@ -282,12 +279,12 @@ const users = await prisma.user.findMany({
 
 ```typescript
 const users = await prisma.user.findMany({
-  select: {
-    name: true,
-    _count: {
-      select: { posts: true, followers: true }
-    }
-  }
+    select: {
+        name: true,
+        _count: {
+            select: { posts: true, followers: true },
+        },
+    },
 })
 // { name: 'Alice', _count: { posts: 5, followers: 100 } }
 ```
@@ -296,13 +293,13 @@ const users = await prisma.user.findMany({
 
 ```typescript
 const users = await prisma.user.findMany({
-  select: {
-    name: true,
-    _count: {
-      select: {
-        posts: { where: { published: true } }
-      }
-    }
-  }
+    select: {
+        name: true,
+        _count: {
+            select: {
+                posts: { where: { published: true } },
+            },
+        },
+    },
 })
 ```

--- a/.agents/skills/prisma-client-api/references/transactions.md
+++ b/.agents/skills/prisma-client-api/references/transactions.md
@@ -1,0 +1,184 @@
+# Transactions
+
+Execute multiple operations atomically.
+
+## Sequential Transactions
+
+Array of operations executed in order:
+
+```typescript
+const [user, post] = await prisma.$transaction([
+  prisma.user.create({ data: { email: 'alice@prisma.io' } }),
+  prisma.post.create({ data: { title: 'Hello', authorId: 1 } })
+])
+```
+
+### All or nothing
+
+If any operation fails, all are rolled back:
+
+```typescript
+try {
+  await prisma.$transaction([
+    prisma.user.create({ data: { email: 'alice@prisma.io' } }),
+    prisma.user.create({ data: { email: 'alice@prisma.io' } }) // Duplicate!
+  ])
+} catch (e) {
+  // Both operations rolled back
+}
+```
+
+## Interactive Transactions
+
+For complex logic and dependent operations:
+
+```typescript
+await prisma.$transaction(async (tx) => {
+  // Decrement sender balance
+  const sender = await tx.account.update({
+    where: { id: senderId },
+    data: { balance: { decrement: amount } }
+  })
+  
+  // Check balance
+  if (sender.balance < 0) {
+    throw new Error('Insufficient funds')
+  }
+  
+  // Increment recipient balance
+  await tx.account.update({
+    where: { id: recipientId },
+    data: { balance: { increment: amount } }
+  })
+})
+```
+
+### Transaction options
+
+```typescript
+await prisma.$transaction(
+  async (tx) => {
+    // operations
+  },
+  {
+    maxWait: 5000,    // Max wait to acquire lock (ms)
+    timeout: 10000,   // Max transaction duration (ms)
+    isolationLevel: 'Serializable'  // Isolation level
+  }
+)
+```
+
+### Isolation levels
+
+| Level | Description |
+|-------|-------------|
+| `ReadUncommitted` | Lowest isolation, can read uncommitted changes |
+| `ReadCommitted` | Only read committed changes |
+| `RepeatableRead` | Consistent reads within transaction |
+| `Serializable` | Highest isolation, serialized execution |
+
+## Nested Writes
+
+Automatic transactions for nested operations:
+
+```typescript
+// This is automatically a transaction
+const user = await prisma.user.create({
+  data: {
+    email: 'alice@prisma.io',
+    posts: {
+      create: [
+        { title: 'Post 1' },
+        { title: 'Post 2' }
+      ]
+    },
+    profile: {
+      create: { bio: 'Hello!' }
+    }
+  }
+})
+```
+
+## Transaction Client
+
+The `tx` parameter is a Prisma Client scoped to the transaction:
+
+```typescript
+await prisma.$transaction(async (tx) => {
+  // Use tx instead of prisma
+  await tx.user.create({ ... })
+  await tx.post.create({ ... })
+  
+  // Can call methods
+  const count = await tx.user.count()
+})
+```
+
+## OrThrow in Transactions
+
+Use with interactive transactions:
+
+```typescript
+await prisma.$transaction(async (tx) => {
+  // If not found, throws and rolls back entire transaction
+  const user = await tx.user.findUniqueOrThrow({
+    where: { id: 1 }
+  })
+  
+  await tx.post.create({
+    data: { title: 'New Post', authorId: user.id }
+  })
+})
+```
+
+## Best Practices
+
+### Keep transactions short
+
+```typescript
+// Good - only DB operations in transaction
+const data = prepareData() // Outside transaction
+await prisma.$transaction(async (tx) => {
+  await tx.user.create({ data })
+})
+```
+
+### Handle errors
+
+```typescript
+try {
+  await prisma.$transaction(async (tx) => {
+    // operations
+  })
+} catch (e) {
+  if (e.code === 'P2002') {
+    // Handle unique constraint violation
+  }
+  throw e
+}
+```
+
+### Use appropriate isolation
+
+```typescript
+// Default is fine for most cases
+await prisma.$transaction(async (tx) => {
+  // operations
+})
+
+// Use Serializable for strict consistency
+await prisma.$transaction(
+  async (tx) => { /* operations */ },
+  { isolationLevel: 'Serializable' }
+)
+```
+
+## Sequential vs Interactive
+
+| Feature | Sequential | Interactive |
+|---------|------------|-------------|
+| Syntax | Array | Async function |
+| Dependent ops | No | Yes |
+| Conditional logic | No | Yes |
+| Performance | Better | More flexible |
+| Use case | Simple batch | Complex logic |

--- a/.agents/skills/prisma-client-api/references/transactions.md
+++ b/.agents/skills/prisma-client-api/references/transactions.md
@@ -8,8 +8,8 @@ Array of operations executed in order:
 
 ```typescript
 const [user, post] = await prisma.$transaction([
-  prisma.user.create({ data: { email: 'alice@prisma.io' } }),
-  prisma.post.create({ data: { title: 'Hello', authorId: 1 } })
+    prisma.user.create({ data: { email: 'alice@prisma.io' } }),
+    prisma.post.create({ data: { title: 'Hello', authorId: 1 } }),
 ])
 ```
 
@@ -19,12 +19,12 @@ If any operation fails, all are rolled back:
 
 ```typescript
 try {
-  await prisma.$transaction([
-    prisma.user.create({ data: { email: 'alice@prisma.io' } }),
-    prisma.user.create({ data: { email: 'alice@prisma.io' } }) // Duplicate!
-  ])
+    await prisma.$transaction([
+        prisma.user.create({ data: { email: 'alice@prisma.io' } }),
+        prisma.user.create({ data: { email: 'alice@prisma.io' } }), // Duplicate!
+    ])
 } catch (e) {
-  // Both operations rolled back
+    // Both operations rolled back
 }
 ```
 
@@ -33,23 +33,23 @@ try {
 For complex logic and dependent operations:
 
 ```typescript
-await prisma.$transaction(async (tx) => {
-  // Decrement sender balance
-  const sender = await tx.account.update({
-    where: { id: senderId },
-    data: { balance: { decrement: amount } }
-  })
-  
-  // Check balance
-  if (sender.balance < 0) {
-    throw new Error('Insufficient funds')
-  }
-  
-  // Increment recipient balance
-  await tx.account.update({
-    where: { id: recipientId },
-    data: { balance: { increment: amount } }
-  })
+await prisma.$transaction(async tx => {
+    // Decrement sender balance
+    const sender = await tx.account.update({
+        where: { id: senderId },
+        data: { balance: { decrement: amount } },
+    })
+
+    // Check balance
+    if (sender.balance < 0) {
+        throw new Error('Insufficient funds')
+    }
+
+    // Increment recipient balance
+    await tx.account.update({
+        where: { id: recipientId },
+        data: { balance: { increment: amount } },
+    })
 })
 ```
 
@@ -57,25 +57,25 @@ await prisma.$transaction(async (tx) => {
 
 ```typescript
 await prisma.$transaction(
-  async (tx) => {
-    // operations
-  },
-  {
-    maxWait: 5000,    // Max wait to acquire lock (ms)
-    timeout: 10000,   // Max transaction duration (ms)
-    isolationLevel: 'Serializable'  // Isolation level
-  }
+    async tx => {
+        // operations
+    },
+    {
+        maxWait: 5000, // Max wait to acquire lock (ms)
+        timeout: 10000, // Max transaction duration (ms)
+        isolationLevel: 'Serializable', // Isolation level
+    },
 )
 ```
 
 ### Isolation levels
 
-| Level | Description |
-|-------|-------------|
+| Level             | Description                                    |
+| ----------------- | ---------------------------------------------- |
 | `ReadUncommitted` | Lowest isolation, can read uncommitted changes |
-| `ReadCommitted` | Only read committed changes |
-| `RepeatableRead` | Consistent reads within transaction |
-| `Serializable` | Highest isolation, serialized execution |
+| `ReadCommitted`   | Only read committed changes                    |
+| `RepeatableRead`  | Consistent reads within transaction            |
+| `Serializable`    | Highest isolation, serialized execution        |
 
 ## Nested Writes
 
@@ -84,18 +84,15 @@ Automatic transactions for nested operations:
 ```typescript
 // This is automatically a transaction
 const user = await prisma.user.create({
-  data: {
-    email: 'alice@prisma.io',
-    posts: {
-      create: [
-        { title: 'Post 1' },
-        { title: 'Post 2' }
-      ]
+    data: {
+        email: 'alice@prisma.io',
+        posts: {
+            create: [{ title: 'Post 1' }, { title: 'Post 2' }],
+        },
+        profile: {
+            create: { bio: 'Hello!' },
+        },
     },
-    profile: {
-      create: { bio: 'Hello!' }
-    }
-  }
 })
 ```
 
@@ -108,7 +105,7 @@ await prisma.$transaction(async (tx) => {
   // Use tx instead of prisma
   await tx.user.create({ ... })
   await tx.post.create({ ... })
-  
+
   // Can call methods
   const count = await tx.user.count()
 })
@@ -119,15 +116,15 @@ await prisma.$transaction(async (tx) => {
 Use with interactive transactions:
 
 ```typescript
-await prisma.$transaction(async (tx) => {
-  // If not found, throws and rolls back entire transaction
-  const user = await tx.user.findUniqueOrThrow({
-    where: { id: 1 }
-  })
-  
-  await tx.post.create({
-    data: { title: 'New Post', authorId: user.id }
-  })
+await prisma.$transaction(async tx => {
+    // If not found, throws and rolls back entire transaction
+    const user = await tx.user.findUniqueOrThrow({
+        where: { id: 1 },
+    })
+
+    await tx.post.create({
+        data: { title: 'New Post', authorId: user.id },
+    })
 })
 ```
 
@@ -138,8 +135,8 @@ await prisma.$transaction(async (tx) => {
 ```typescript
 // Good - only DB operations in transaction
 const data = prepareData() // Outside transaction
-await prisma.$transaction(async (tx) => {
-  await tx.user.create({ data })
+await prisma.$transaction(async tx => {
+    await tx.user.create({ data })
 })
 ```
 
@@ -147,14 +144,14 @@ await prisma.$transaction(async (tx) => {
 
 ```typescript
 try {
-  await prisma.$transaction(async (tx) => {
-    // operations
-  })
+    await prisma.$transaction(async tx => {
+        // operations
+    })
 } catch (e) {
-  if (e.code === 'P2002') {
-    // Handle unique constraint violation
-  }
-  throw e
+    if (e.code === 'P2002') {
+        // Handle unique constraint violation
+    }
+    throw e
 }
 ```
 
@@ -162,23 +159,25 @@ try {
 
 ```typescript
 // Default is fine for most cases
-await prisma.$transaction(async (tx) => {
-  // operations
+await prisma.$transaction(async tx => {
+    // operations
 })
 
 // Use Serializable for strict consistency
 await prisma.$transaction(
-  async (tx) => { /* operations */ },
-  { isolationLevel: 'Serializable' }
+    async tx => {
+        /* operations */
+    },
+    { isolationLevel: 'Serializable' },
 )
 ```
 
 ## Sequential vs Interactive
 
-| Feature | Sequential | Interactive |
-|---------|------------|-------------|
-| Syntax | Array | Async function |
-| Dependent ops | No | Yes |
-| Conditional logic | No | Yes |
-| Performance | Better | More flexible |
-| Use case | Simple batch | Complex logic |
+| Feature           | Sequential   | Interactive    |
+| ----------------- | ------------ | -------------- |
+| Syntax            | Array        | Async function |
+| Dependent ops     | No           | Yes            |
+| Conditional logic | No           | Yes            |
+| Performance       | Better       | More flexible  |
+| Use case          | Simple batch | Complex logic  |

--- a/.agents/skills/prisma-database-setup/SKILL.md
+++ b/.agents/skills/prisma-database-setup/SKILL.md
@@ -1,0 +1,192 @@
+---
+name: prisma-database-setup
+description: Guides for configuring Prisma with different database providers (PostgreSQL, MySQL, SQLite, MongoDB, etc.). Use when setting up a new project, changing databases, or troubleshooting connection issues. Triggers on "configure postgres", "connect to mysql", "setup mongodb", "sqlite setup".
+license: MIT
+metadata:
+  author: prisma
+  version: "7.6.0"
+---
+
+# Prisma Database Setup
+
+Comprehensive guides for configuring Prisma ORM with various database providers.
+
+## When to Apply
+
+Reference this skill when:
+- Initializing a new Prisma project
+- Switching database providers
+- Configuring connection strings and environment variables
+- Troubleshooting database connection issues
+- Setting up database-specific features
+- Generating and instantiating Prisma Client
+
+## Rule Categories by Priority
+
+| Priority | Category | Impact | Prefix |
+|----------|----------|--------|--------|
+| 1 | Provider Guides | CRITICAL | provider names |
+| 2 | Prisma Postgres | HIGH | `prisma-postgres` |
+| 3 | Client Setup | CRITICAL | `prisma-client-setup` |
+
+## System Prerequisites
+
+- **Node.js 20.19.0+**
+- **TypeScript 5.4.0+**
+
+## Bun Runtime
+
+If you're using Bun, run Prisma CLI commands with `bunx --bun prisma ...` so Prisma uses the Bun runtime instead of falling back to Node.js.
+
+## Supported Databases
+
+| Database | Provider String | Notes |
+|----------|-----------------|-------|
+| PostgreSQL | `postgresql` | Default, full feature support |
+| MySQL | `mysql` | Widespread support, some JSON diffs |
+| SQLite | `sqlite` | Local file-based, no enum/scalar lists |
+| MongoDB | `mongodb` | Mongo-specific workflow; do not apply SQL driver-adapter guidance |
+| SQL Server | `sqlserver` | Microsoft ecosystem |
+| CockroachDB | `cockroachdb` | Distributed SQL, Postgres-compatible |
+| Prisma Postgres | `postgresql` | Managed serverless database |
+
+## Configuration Files
+
+Your configuration shape depends on the provider and Prisma major version:
+
+1. **All providers** use **`prisma/schema.prisma`**.
+2. **Prisma 7 SQL setups** typically use **`prisma.config.ts`** for datasource URLs.
+3. **MongoDB projects should stay on Prisma 6.x**, keep `url = env("DATABASE_URL")` in the schema, and continue using the classic MongoDB setup.
+
+## Driver Adapters
+
+The standard SQL workflow uses a driver adapter. Choose the adapter and driver for your database and pass the adapter to `PrismaClient`.
+
+| Database | Adapter | JS Driver |
+|----------|---------|-----------|
+| PostgreSQL | `@prisma/adapter-pg` | `pg` |
+| CockroachDB | `@prisma/adapter-pg` | `pg` |
+| Prisma Postgres (Node.js) | `@prisma/adapter-pg` | `pg` |
+| Prisma Postgres (edge/serverless) | `@prisma/adapter-ppg` | `@prisma/ppg` |
+| MySQL / MariaDB | `@prisma/adapter-mariadb` | `mariadb` |
+| SQLite | `@prisma/adapter-better-sqlite3` | `better-sqlite3` |
+| SQLite (Turso/LibSQL) | `@prisma/adapter-libsql` | `@libsql/client` |
+| SQL Server | `@prisma/adapter-mssql` | `node-mssql` |
+
+MongoDB should not follow the Prisma 7 SQL adapter workflow. Use the latest Prisma 6.x release for MongoDB projects and do not install a SQL `@prisma/adapter-*` package for it.
+
+Example (PostgreSQL):
+
+```ts
+import 'dotenv/config'
+import { PrismaClient } from '../generated/client'
+import { PrismaPg } from '@prisma/adapter-pg'
+
+const adapter = new PrismaPg({ connectionString: process.env.DATABASE_URL })
+const prisma = new PrismaClient({ adapter })
+```
+
+## Prisma Client Setup (Required)
+
+Prisma Client must be installed and generated for any database.
+
+1. Install Prisma CLI and Prisma Client:
+   ```bash
+   npm install prisma --save-dev
+   npm install @prisma/client
+   ```
+
+1. Add a generator block (`prisma-client` requires an explicit output path):
+   ```prisma
+   generator client {
+     provider = "prisma-client"
+     output   = "../generated"
+   }
+   ```
+
+1. Generate Prisma Client:
+   ```bash
+   npx prisma generate
+   ```
+
+1. For SQL providers, instantiate Prisma Client with the database-specific driver adapter:
+   ```typescript
+   import { PrismaClient } from '../generated/client'
+   import { PrismaPg } from '@prisma/adapter-pg'
+
+   const adapter = new PrismaPg({ connectionString: process.env.DATABASE_URL })
+   const prisma = new PrismaClient({ adapter })
+   ```
+
+1. Re-run `prisma generate` after every schema change.
+
+## Quick Reference
+
+### PostgreSQL
+```prisma
+datasource db {
+  provider = "postgresql"
+}
+
+generator client {
+  provider = "prisma-client"
+  output   = "../generated"
+}
+```
+
+### MySQL
+```prisma
+datasource db {
+  provider = "mysql"
+}
+
+generator client {
+  provider = "prisma-client"
+  output   = "../generated"
+}
+```
+
+### SQLite
+```prisma
+datasource db {
+  provider = "sqlite"
+}
+
+generator client {
+  provider = "prisma-client"
+  output   = "../generated"
+}
+```
+
+### MongoDB
+```prisma
+datasource db {
+  provider = "mongodb"
+  url      = env("DATABASE_URL")
+}
+
+generator client {
+  provider = "prisma-client-js"
+}
+```
+
+For MongoDB, stay on the latest Prisma 6.x line and keep the connection URL in `schema.prisma`. Do not move a MongoDB project to the Prisma 7 SQL adapter setup.
+
+## Rule Files
+
+See individual rule files for detailed setup instructions:
+
+```
+references/postgresql.md
+references/mysql.md
+references/sqlite.md
+references/mongodb.md
+references/sqlserver.md
+references/cockroachdb.md
+references/prisma-postgres.md
+references/prisma-client-setup.md
+```
+
+## How to Use
+
+Choose the provider reference file for your database, then apply `references/prisma-client-setup.md` to complete client generation and adapter setup. For MongoDB, use `references/mongodb.md` instead of copying the SQL adapter examples or Prisma 7 config pattern.

--- a/.agents/skills/prisma-database-setup/SKILL.md
+++ b/.agents/skills/prisma-database-setup/SKILL.md
@@ -3,8 +3,8 @@ name: prisma-database-setup
 description: Guides for configuring Prisma with different database providers (PostgreSQL, MySQL, SQLite, MongoDB, etc.). Use when setting up a new project, changing databases, or troubleshooting connection issues. Triggers on "configure postgres", "connect to mysql", "setup mongodb", "sqlite setup".
 license: MIT
 metadata:
-  author: prisma
-  version: "7.6.0"
+    author: prisma
+    version: '7.6.0'
 ---
 
 # Prisma Database Setup
@@ -14,6 +14,7 @@ Comprehensive guides for configuring Prisma ORM with various database providers.
 ## When to Apply
 
 Reference this skill when:
+
 - Initializing a new Prisma project
 - Switching database providers
 - Configuring connection strings and environment variables
@@ -23,11 +24,11 @@ Reference this skill when:
 
 ## Rule Categories by Priority
 
-| Priority | Category | Impact | Prefix |
-|----------|----------|--------|--------|
-| 1 | Provider Guides | CRITICAL | provider names |
-| 2 | Prisma Postgres | HIGH | `prisma-postgres` |
-| 3 | Client Setup | CRITICAL | `prisma-client-setup` |
+| Priority | Category        | Impact   | Prefix                |
+| -------- | --------------- | -------- | --------------------- |
+| 1        | Provider Guides | CRITICAL | provider names        |
+| 2        | Prisma Postgres | HIGH     | `prisma-postgres`     |
+| 3        | Client Setup    | CRITICAL | `prisma-client-setup` |
 
 ## System Prerequisites
 
@@ -40,15 +41,15 @@ If you're using Bun, run Prisma CLI commands with `bunx --bun prisma ...` so Pri
 
 ## Supported Databases
 
-| Database | Provider String | Notes |
-|----------|-----------------|-------|
-| PostgreSQL | `postgresql` | Default, full feature support |
-| MySQL | `mysql` | Widespread support, some JSON diffs |
-| SQLite | `sqlite` | Local file-based, no enum/scalar lists |
-| MongoDB | `mongodb` | Mongo-specific workflow; do not apply SQL driver-adapter guidance |
-| SQL Server | `sqlserver` | Microsoft ecosystem |
-| CockroachDB | `cockroachdb` | Distributed SQL, Postgres-compatible |
-| Prisma Postgres | `postgresql` | Managed serverless database |
+| Database        | Provider String | Notes                                                             |
+| --------------- | --------------- | ----------------------------------------------------------------- |
+| PostgreSQL      | `postgresql`    | Default, full feature support                                     |
+| MySQL           | `mysql`         | Widespread support, some JSON diffs                               |
+| SQLite          | `sqlite`        | Local file-based, no enum/scalar lists                            |
+| MongoDB         | `mongodb`       | Mongo-specific workflow; do not apply SQL driver-adapter guidance |
+| SQL Server      | `sqlserver`     | Microsoft ecosystem                                               |
+| CockroachDB     | `cockroachdb`   | Distributed SQL, Postgres-compatible                              |
+| Prisma Postgres | `postgresql`    | Managed serverless database                                       |
 
 ## Configuration Files
 
@@ -62,16 +63,16 @@ Your configuration shape depends on the provider and Prisma major version:
 
 The standard SQL workflow uses a driver adapter. Choose the adapter and driver for your database and pass the adapter to `PrismaClient`.
 
-| Database | Adapter | JS Driver |
-|----------|---------|-----------|
-| PostgreSQL | `@prisma/adapter-pg` | `pg` |
-| CockroachDB | `@prisma/adapter-pg` | `pg` |
-| Prisma Postgres (Node.js) | `@prisma/adapter-pg` | `pg` |
-| Prisma Postgres (edge/serverless) | `@prisma/adapter-ppg` | `@prisma/ppg` |
-| MySQL / MariaDB | `@prisma/adapter-mariadb` | `mariadb` |
-| SQLite | `@prisma/adapter-better-sqlite3` | `better-sqlite3` |
-| SQLite (Turso/LibSQL) | `@prisma/adapter-libsql` | `@libsql/client` |
-| SQL Server | `@prisma/adapter-mssql` | `node-mssql` |
+| Database                          | Adapter                          | JS Driver        |
+| --------------------------------- | -------------------------------- | ---------------- |
+| PostgreSQL                        | `@prisma/adapter-pg`             | `pg`             |
+| CockroachDB                       | `@prisma/adapter-pg`             | `pg`             |
+| Prisma Postgres (Node.js)         | `@prisma/adapter-pg`             | `pg`             |
+| Prisma Postgres (edge/serverless) | `@prisma/adapter-ppg`            | `@prisma/ppg`    |
+| MySQL / MariaDB                   | `@prisma/adapter-mariadb`        | `mariadb`        |
+| SQLite                            | `@prisma/adapter-better-sqlite3` | `better-sqlite3` |
+| SQLite (Turso/LibSQL)             | `@prisma/adapter-libsql`         | `@libsql/client` |
+| SQL Server                        | `@prisma/adapter-mssql`          | `node-mssql`     |
 
 MongoDB should not follow the Prisma 7 SQL adapter workflow. Use the latest Prisma 6.x release for MongoDB projects and do not install a SQL `@prisma/adapter-*` package for it.
 
@@ -91,38 +92,43 @@ const prisma = new PrismaClient({ adapter })
 Prisma Client must be installed and generated for any database.
 
 1. Install Prisma CLI and Prisma Client:
-   ```bash
-   npm install prisma --save-dev
-   npm install @prisma/client
-   ```
+
+    ```bash
+    npm install prisma --save-dev
+    npm install @prisma/client
+    ```
 
 1. Add a generator block (`prisma-client` requires an explicit output path):
-   ```prisma
-   generator client {
-     provider = "prisma-client"
-     output   = "../generated"
-   }
-   ```
+
+    ```prisma
+    generator client {
+      provider = "prisma-client"
+      output   = "../generated"
+    }
+    ```
 
 1. Generate Prisma Client:
-   ```bash
-   npx prisma generate
-   ```
+
+    ```bash
+    npx prisma generate
+    ```
 
 1. For SQL providers, instantiate Prisma Client with the database-specific driver adapter:
-   ```typescript
-   import { PrismaClient } from '../generated/client'
-   import { PrismaPg } from '@prisma/adapter-pg'
 
-   const adapter = new PrismaPg({ connectionString: process.env.DATABASE_URL })
-   const prisma = new PrismaClient({ adapter })
-   ```
+    ```typescript
+    import { PrismaClient } from '../generated/client'
+    import { PrismaPg } from '@prisma/adapter-pg'
+
+    const adapter = new PrismaPg({ connectionString: process.env.DATABASE_URL })
+    const prisma = new PrismaClient({ adapter })
+    ```
 
 1. Re-run `prisma generate` after every schema change.
 
 ## Quick Reference
 
 ### PostgreSQL
+
 ```prisma
 datasource db {
   provider = "postgresql"
@@ -135,6 +141,7 @@ generator client {
 ```
 
 ### MySQL
+
 ```prisma
 datasource db {
   provider = "mysql"
@@ -147,6 +154,7 @@ generator client {
 ```
 
 ### SQLite
+
 ```prisma
 datasource db {
   provider = "sqlite"
@@ -159,6 +167,7 @@ generator client {
 ```
 
 ### MongoDB
+
 ```prisma
 datasource db {
   provider = "mongodb"

--- a/.agents/skills/prisma-database-setup/references/cockroachdb.md
+++ b/.agents/skills/prisma-database-setup/references/cockroachdb.md
@@ -1,0 +1,89 @@
+# CockroachDB Setup
+
+Configure Prisma with CockroachDB.
+
+## Prerequisites
+
+- CockroachDB cluster
+
+## 1. Schema Configuration
+
+In `prisma/schema.prisma`:
+
+```prisma
+datasource db {
+  provider = "cockroachdb"
+}
+
+generator client {
+  provider = "prisma-client"
+  output   = "../generated"
+}
+```
+
+## 2. Config Configuration
+
+In `prisma.config.ts`:
+
+```typescript
+import { defineConfig, env } from 'prisma/config'
+
+export default defineConfig({
+  schema: 'prisma/schema.prisma',
+  datasource: {
+    url: env('DATABASE_URL'),
+  },
+})
+```
+
+## 3. Environment Variable
+
+In `.env`:
+
+```env
+DATABASE_URL="postgresql://user:password@host:26257/db?sslmode=verify-full"
+```
+
+Note: CockroachDB uses the PostgreSQL wire protocol, so the URL often looks like postgresql, but the provider **MUST** be `cockroachdb` in the schema to handle specific CRDB features correctly.
+
+## Driver Adapter
+
+Use a driver adapter for the standard SQL workflow. CockroachDB is PostgreSQL-compatible, so use the PostgreSQL adapter.
+
+1. Install adapter and driver:
+   ```bash
+   npm install @prisma/adapter-pg pg
+   ```
+
+2. Instantiate Prisma Client with the adapter:
+   ```typescript
+   import 'dotenv/config'
+   import { PrismaClient } from '../generated/client'
+   import { PrismaPg } from '@prisma/adapter-pg'
+
+   const adapter = new PrismaPg({ connectionString: process.env.DATABASE_URL })
+   const prisma = new PrismaClient({ adapter })
+   ```
+
+## ID Generation
+
+CockroachDB uses `BigInt` or `UUID` for IDs efficiently.
+
+```prisma
+model User {
+  id BigInt @id @default(autoincrement()) // Uses unique_rowid()
+}
+```
+
+Or using string UUIDs:
+
+```prisma
+model User {
+  id String @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+}
+```
+
+## Common Issues
+
+### Schema Introspection
+Always use `provider = "cockroachdb"` to ensure correct type mapping during `db pull`.

--- a/.agents/skills/prisma-database-setup/references/cockroachdb.md
+++ b/.agents/skills/prisma-database-setup/references/cockroachdb.md
@@ -29,10 +29,10 @@ In `prisma.config.ts`:
 import { defineConfig, env } from 'prisma/config'
 
 export default defineConfig({
-  schema: 'prisma/schema.prisma',
-  datasource: {
-    url: env('DATABASE_URL'),
-  },
+    schema: 'prisma/schema.prisma',
+    datasource: {
+        url: env('DATABASE_URL'),
+    },
 })
 ```
 
@@ -51,19 +51,21 @@ Note: CockroachDB uses the PostgreSQL wire protocol, so the URL often looks like
 Use a driver adapter for the standard SQL workflow. CockroachDB is PostgreSQL-compatible, so use the PostgreSQL adapter.
 
 1. Install adapter and driver:
-   ```bash
-   npm install @prisma/adapter-pg pg
-   ```
+
+    ```bash
+    npm install @prisma/adapter-pg pg
+    ```
 
 2. Instantiate Prisma Client with the adapter:
-   ```typescript
-   import 'dotenv/config'
-   import { PrismaClient } from '../generated/client'
-   import { PrismaPg } from '@prisma/adapter-pg'
 
-   const adapter = new PrismaPg({ connectionString: process.env.DATABASE_URL })
-   const prisma = new PrismaClient({ adapter })
-   ```
+    ```typescript
+    import 'dotenv/config'
+    import { PrismaClient } from '../generated/client'
+    import { PrismaPg } from '@prisma/adapter-pg'
+
+    const adapter = new PrismaPg({ connectionString: process.env.DATABASE_URL })
+    const prisma = new PrismaClient({ adapter })
+    ```
 
 ## ID Generation
 
@@ -86,4 +88,5 @@ model User {
 ## Common Issues
 
 ### Schema Introspection
+
 Always use `provider = "cockroachdb"` to ensure correct type mapping during `db pull`.

--- a/.agents/skills/prisma-database-setup/references/mongodb.md
+++ b/.agents/skills/prisma-database-setup/references/mongodb.md
@@ -1,0 +1,90 @@
+# MongoDB Setup
+
+MongoDB projects should stay on the latest Prisma 6.x release. Do not upgrade a MongoDB app to Prisma 7's SQL client path.
+
+## Prerequisites
+
+- MongoDB 4.2+
+- Replica Set configured (required for transactions)
+- Latest Prisma 6.x release, or your team's pinned Prisma 6 version
+- Node.js 20.19.0+
+- TypeScript 5.4.0+
+
+## 1. Schema Configuration
+
+Use the standard Prisma 6 MongoDB setup with `prisma-client-js`.
+
+In `prisma/schema.prisma`:
+
+```prisma
+datasource db {
+  provider = "mongodb"
+  url      = env("DATABASE_URL")
+}
+
+generator client {
+  provider = "prisma-client-js"
+}
+```
+
+### Driver Adapters
+
+Do **not** apply the Prisma 7 SQL adapter setup here. MongoDB does not use a SQL `@prisma/adapter-*` package.
+
+### ID Field Requirement
+
+MongoDB models **must** have a mapped `_id` field using `@id` and `@map("_id")`, usually of type `String` with `auto()` and `db.ObjectId`.
+
+```prisma
+model User {
+  id    String @id @default(auto()) @map("_id") @db.ObjectId
+  email String @unique
+  name  String?
+}
+```
+
+### Relations
+
+Relations in MongoDB expect IDs to be `db.ObjectId` type.
+
+```prisma
+model Post {
+  id       String @id @default(auto()) @map("_id") @db.ObjectId
+  author   User   @relation(fields: [authorId], references: [id])
+  authorId String @db.ObjectId
+}
+```
+
+## 2. Environment Variable
+
+In `.env`:
+
+```env
+DATABASE_URL="mongodb+srv://user:password@cluster.mongodb.net/mydb?retryWrites=true&w=majority"
+```
+
+## Migrations vs Introspection
+
+- **No Migrations**: MongoDB is schema-less. `prisma migrate` commands **do not work**.
+- **db push**: Use `prisma db push` to sync indexes and constraints.
+- **db pull**: Use `prisma db pull` to generate schema from existing data (sampling).
+
+## Current Verification Notes
+
+- `prisma init --datasource-provider mongodb` is still implemented in Prisma's CLI source.
+- Prisma's upstream repo still contains MongoDB fixtures and tests.
+- Local verification shows Prisma 7 can still recognize MongoDB inputs, but the generated client path does not provide a supported MongoDB upgrade path.
+- Local verification shows Prisma 6.x works end to end with `prisma-client-js`, `prisma db push`, and `new PrismaClient()` against a MongoDB replica set.
+
+## Version Guidance
+
+- For MongoDB, stay on the latest available Prisma 6.x release.
+- Treat Prisma 7 MongoDB migration attempts as unsupported until Prisma ships a real MongoDB upgrade path.
+
+## Common Issues
+
+### "Transactions not supported"
+Ensure your MongoDB instance is a **Replica Set**. Standalone instances do not support transactions. Atlas clusters are replica sets by default.
+
+### "Invalid ObjectID"
+Ensure fields referencing IDs are decorated with `@db.ObjectId` if the target is an ObjectID.

--- a/.agents/skills/prisma-database-setup/references/mongodb.md
+++ b/.agents/skills/prisma-database-setup/references/mongodb.md
@@ -84,7 +84,9 @@ DATABASE_URL="mongodb+srv://user:password@cluster.mongodb.net/mydb?retryWrites=t
 ## Common Issues
 
 ### "Transactions not supported"
+
 Ensure your MongoDB instance is a **Replica Set**. Standalone instances do not support transactions. Atlas clusters are replica sets by default.
 
 ### "Invalid ObjectID"
+
 Ensure fields referencing IDs are decorated with `@db.ObjectId` if the target is an ObjectID.

--- a/.agents/skills/prisma-database-setup/references/mysql.md
+++ b/.agents/skills/prisma-database-setup/references/mysql.md
@@ -1,0 +1,126 @@
+# MySQL Setup
+
+Configure Prisma with MySQL (or MariaDB).
+
+## Prerequisites
+
+- MySQL or MariaDB database
+- Connection string
+
+## 1. Schema Configuration
+
+In `prisma/schema.prisma`:
+
+```prisma
+datasource db {
+  provider = "mysql"
+}
+
+generator client {
+  provider = "prisma-client"
+  output   = "../generated"
+}
+```
+
+## 2. Config Configuration
+
+In `prisma.config.ts`:
+
+```typescript
+import { defineConfig, env } from 'prisma/config'
+
+export default defineConfig({
+  schema: 'prisma/schema.prisma',
+  datasource: {
+    url: env('DATABASE_URL'),
+  },
+})
+```
+
+## 3. Environment Variable
+
+In `.env`:
+
+```env
+DATABASE_URL="mysql://user:password@localhost:3306/mydb"
+```
+
+### Connection String Format
+
+```
+mysql://USER:PASSWORD@HOST:PORT/DATABASE
+```
+
+- **USER**: Database user
+- **PASSWORD**: Password
+- **HOST**: Hostname
+- **PORT**: Port (default 3306)
+- **DATABASE**: Database name
+
+## Driver Adapter
+
+Use a driver adapter for the standard SQL workflow.
+
+1. Install adapter and driver:
+   ```bash
+   npm install @prisma/adapter-mariadb mariadb
+   ```
+
+2. Instantiate Prisma Client with the adapter:
+   ```typescript
+   import 'dotenv/config'
+   import { PrismaClient } from '../generated/client'
+   import { PrismaMariaDb } from '@prisma/adapter-mariadb'
+
+   const adapter = new PrismaMariaDb({
+     host: 'localhost',
+     port: 3306,
+     connectionLimit: 5,
+     user: process.env.MYSQL_USER,
+     password: process.env.MYSQL_PASSWORD,
+     database: process.env.MYSQL_DATABASE,
+   })
+
+   const prisma = new PrismaClient({ adapter })
+   ```
+
+### Text protocol option
+
+If you need the MariaDB driver's text protocol instead of the default binary `execute()` path, enable `useTextProtocol` explicitly:
+
+```typescript
+import { PrismaClient } from '../generated/client'
+import { PrismaMariaDb } from '@prisma/adapter-mariadb'
+
+const adapter = new PrismaMariaDb(process.env.DATABASE_URL!, {
+  useTextProtocol: true,
+})
+
+const prisma = new PrismaClient({ adapter })
+```
+
+Use this only when you specifically need text-protocol compatibility for your MariaDB setup.
+
+## PlanetScale Setup
+
+PlanetScale uses MySQL but requires specific settings because it doesn't support foreign key constraints.
+
+In `prisma/schema.prisma`:
+
+```prisma
+datasource db {
+  provider     = "mysql"
+  relationMode = "prisma" // Emulate foreign keys in Prisma
+}
+```
+
+## Common Issues
+
+### "Too many connections"
+MySQL has a connection limit. Adjust connection pool size in URL:
+```env
+DATABASE_URL="mysql://...?connection_limit=5"
+```
+
+### JSON Support
+MySQL 5.7+ supports JSON. MariaDB 10.2+ supports JSON (as an alias for LONGTEXT with check constraints). Prisma handles this, but verify your version.

--- a/.agents/skills/prisma-database-setup/references/mysql.md
+++ b/.agents/skills/prisma-database-setup/references/mysql.md
@@ -30,10 +30,10 @@ In `prisma.config.ts`:
 import { defineConfig, env } from 'prisma/config'
 
 export default defineConfig({
-  schema: 'prisma/schema.prisma',
-  datasource: {
-    url: env('DATABASE_URL'),
-  },
+    schema: 'prisma/schema.prisma',
+    datasource: {
+        url: env('DATABASE_URL'),
+    },
 })
 ```
 
@@ -62,27 +62,29 @@ mysql://USER:PASSWORD@HOST:PORT/DATABASE
 Use a driver adapter for the standard SQL workflow.
 
 1. Install adapter and driver:
-   ```bash
-   npm install @prisma/adapter-mariadb mariadb
-   ```
+
+    ```bash
+    npm install @prisma/adapter-mariadb mariadb
+    ```
 
 2. Instantiate Prisma Client with the adapter:
-   ```typescript
-   import 'dotenv/config'
-   import { PrismaClient } from '../generated/client'
-   import { PrismaMariaDb } from '@prisma/adapter-mariadb'
 
-   const adapter = new PrismaMariaDb({
-     host: 'localhost',
-     port: 3306,
-     connectionLimit: 5,
-     user: process.env.MYSQL_USER,
-     password: process.env.MYSQL_PASSWORD,
-     database: process.env.MYSQL_DATABASE,
-   })
+    ```typescript
+    import 'dotenv/config'
+    import { PrismaClient } from '../generated/client'
+    import { PrismaMariaDb } from '@prisma/adapter-mariadb'
 
-   const prisma = new PrismaClient({ adapter })
-   ```
+    const adapter = new PrismaMariaDb({
+        host: 'localhost',
+        port: 3306,
+        connectionLimit: 5,
+        user: process.env.MYSQL_USER,
+        password: process.env.MYSQL_PASSWORD,
+        database: process.env.MYSQL_DATABASE,
+    })
+
+    const prisma = new PrismaClient({ adapter })
+    ```
 
 ### Text protocol option
 
@@ -93,7 +95,7 @@ import { PrismaClient } from '../generated/client'
 import { PrismaMariaDb } from '@prisma/adapter-mariadb'
 
 const adapter = new PrismaMariaDb(process.env.DATABASE_URL!, {
-  useTextProtocol: true,
+    useTextProtocol: true,
 })
 
 const prisma = new PrismaClient({ adapter })
@@ -117,10 +119,13 @@ datasource db {
 ## Common Issues
 
 ### "Too many connections"
+
 MySQL has a connection limit. Adjust connection pool size in URL:
+
 ```env
 DATABASE_URL="mysql://...?connection_limit=5"
 ```
 
 ### JSON Support
+
 MySQL 5.7+ supports JSON. MariaDB 10.2+ supports JSON (as an alias for LONGTEXT with check constraints). Prisma handles this, but verify your version.

--- a/.agents/skills/prisma-database-setup/references/postgresql.md
+++ b/.agents/skills/prisma-database-setup/references/postgresql.md
@@ -1,0 +1,92 @@
+# PostgreSQL Setup
+
+Configure Prisma with PostgreSQL.
+
+## Prerequisites
+
+- PostgreSQL database (local or cloud)
+- Connection string
+
+## 1. Schema Configuration
+
+In `prisma/schema.prisma`:
+
+```prisma
+datasource db {
+  provider = "postgresql"
+}
+
+generator client {
+  provider = "prisma-client"
+  output   = "../generated"
+}
+```
+
+## 2. Config Configuration
+
+In `prisma.config.ts`:
+
+```typescript
+import { defineConfig, env } from 'prisma/config'
+
+export default defineConfig({
+  schema: 'prisma/schema.prisma',
+  datasource: {
+    url: env('DATABASE_URL'),
+  },
+})
+```
+
+## 3. Environment Variable
+
+In `.env`:
+
+```env
+DATABASE_URL="postgresql://user:password@localhost:5432/mydb?schema=public"
+```
+
+### Connection String Format
+
+```
+postgresql://USER:PASSWORD@HOST:PORT/DATABASE?schema=SCHEMA
+```
+
+- **USER**: Database user
+- **PASSWORD**: Password (URL encoded if special chars)
+- **HOST**: Hostname (localhost, IP, or domain)
+- **PORT**: Port (default 5432)
+- **DATABASE**: Database name
+- **SCHEMA**: Schema name (default `public`)
+
+## Driver Adapter
+
+Use a driver adapter for the standard SQL workflow.
+
+1. Install adapter and driver:
+   ```bash
+   npm install @prisma/adapter-pg pg
+   ```
+
+2. Instantiate Prisma Client with the adapter:
+   ```typescript
+   import 'dotenv/config'
+   import { PrismaClient } from '../generated/client'
+   import { PrismaPg } from '@prisma/adapter-pg'
+
+   const adapter = new PrismaPg({ connectionString: process.env.DATABASE_URL })
+   const prisma = new PrismaClient({ adapter })
+   ```
+
+## Common Issues
+
+### "Can't reach database server"
+- Check host and port
+- Check firewall settings
+- Ensure database is running
+
+### "Authentication failed"
+- Check user/password
+- Special characters in password must be URL-encoded
+
+### "Schema does not exist"
+- Ensure `?schema=public` (or your schema) is in the URL

--- a/.agents/skills/prisma-database-setup/references/postgresql.md
+++ b/.agents/skills/prisma-database-setup/references/postgresql.md
@@ -30,10 +30,10 @@ In `prisma.config.ts`:
 import { defineConfig, env } from 'prisma/config'
 
 export default defineConfig({
-  schema: 'prisma/schema.prisma',
-  datasource: {
-    url: env('DATABASE_URL'),
-  },
+    schema: 'prisma/schema.prisma',
+    datasource: {
+        url: env('DATABASE_URL'),
+    },
 })
 ```
 
@@ -63,30 +63,35 @@ postgresql://USER:PASSWORD@HOST:PORT/DATABASE?schema=SCHEMA
 Use a driver adapter for the standard SQL workflow.
 
 1. Install adapter and driver:
-   ```bash
-   npm install @prisma/adapter-pg pg
-   ```
+
+    ```bash
+    npm install @prisma/adapter-pg pg
+    ```
 
 2. Instantiate Prisma Client with the adapter:
-   ```typescript
-   import 'dotenv/config'
-   import { PrismaClient } from '../generated/client'
-   import { PrismaPg } from '@prisma/adapter-pg'
 
-   const adapter = new PrismaPg({ connectionString: process.env.DATABASE_URL })
-   const prisma = new PrismaClient({ adapter })
-   ```
+    ```typescript
+    import 'dotenv/config'
+    import { PrismaClient } from '../generated/client'
+    import { PrismaPg } from '@prisma/adapter-pg'
+
+    const adapter = new PrismaPg({ connectionString: process.env.DATABASE_URL })
+    const prisma = new PrismaClient({ adapter })
+    ```
 
 ## Common Issues
 
 ### "Can't reach database server"
+
 - Check host and port
 - Check firewall settings
 - Ensure database is running
 
 ### "Authentication failed"
+
 - Check user/password
 - Special characters in password must be URL-encoded
 
 ### "Schema does not exist"
+
 - Ensure `?schema=public` (or your schema) is in the URL

--- a/.agents/skills/prisma-database-setup/references/prisma-client-setup.md
+++ b/.agents/skills/prisma-database-setup/references/prisma-client-setup.md
@@ -1,0 +1,47 @@
+# Prisma Client Setup
+
+Generate and instantiate Prisma Client for Prisma's standard SQL provider workflow. For MongoDB, follow the provider-specific notes in `references/mongodb.md` instead of copying the SQL adapter example below.
+
+## 1. Install dependencies
+
+```bash
+npm install prisma --save-dev
+npm install @prisma/client
+```
+
+## 2. Add generator block
+
+In `prisma/schema.prisma`:
+
+```prisma
+generator client {
+  provider = "prisma-client"
+  output   = "../generated"
+}
+```
+
+`prisma-client` requires an explicit `output` path and does not generate into `node_modules` by default.
+
+## 3. Generate Prisma Client
+
+```bash
+npx prisma generate
+```
+
+Re-run `prisma generate` after every schema change to keep the client in sync.
+
+## 4. Instantiate Prisma Client
+
+```typescript
+import { PrismaClient } from '../generated/client'
+import { PrismaPg } from '@prisma/adapter-pg'
+
+const adapter = new PrismaPg({ connectionString: process.env.DATABASE_URL })
+const prisma = new PrismaClient({ adapter })
+```
+
+If you change the generator `output`, update the import path to match. For the SQL provider workflow, replace `PrismaPg` with the adapter for your database.
+
+## 5. Use a single instance
+
+Each `PrismaClient` instance creates a connection pool. Reuse a single instance per app process to avoid exhausting database connections.

--- a/.agents/skills/prisma-database-setup/references/prisma-postgres.md
+++ b/.agents/skills/prisma-database-setup/references/prisma-postgres.md
@@ -1,0 +1,130 @@
+# Prisma Postgres Setup
+
+Configure Prisma with Prisma Postgres (Managed).
+
+## Overview
+
+Prisma Postgres is a serverless, managed PostgreSQL database optimized for Prisma.
+
+## Setup via CLI
+
+You can provision a Prisma Postgres instance directly via the CLI:
+
+```bash
+prisma init --db
+```
+
+This will:
+1. Log you into Prisma Data Platform.
+2. Create a new project and database instance.
+3. Update your `.env` with the connection string.
+
+## Connection String
+
+For Prisma CLI flows and Accelerate-style usage, you may see a `prisma+postgres://` URL.
+
+For Prisma Client with a driver adapter in Node.js, prefer the direct TCP connection string from the Prisma Postgres dashboard:
+
+```env
+DATABASE_URL="postgres://identifier:key@db.prisma.io:5432/postgres?sslmode=require"
+```
+
+## 1. Schema Configuration
+
+In `prisma/schema.prisma`:
+
+```prisma
+datasource db {
+  provider = "postgresql" // Use postgresql provider
+}
+
+generator client {
+  provider = "prisma-client"
+  output   = "../generated"
+}
+```
+
+## 2. Config Configuration
+
+In `prisma.config.ts`:
+
+```typescript
+import { defineConfig, env } from 'prisma/config'
+
+export default defineConfig({
+  schema: 'prisma/schema.prisma',
+  datasource: {
+    url: env('DATABASE_URL'),
+  },
+})
+```
+
+## Driver Adapter
+
+Use a driver adapter for Prisma Postgres in the standard SQL workflow.
+
+### Recommended for standard Node.js apps
+
+1. Install adapter and driver:
+   ```bash
+   npm install @prisma/adapter-pg pg
+   ```
+
+2. Use the direct TCP connection string from Prisma Console:
+   ```typescript
+   import 'dotenv/config'
+   import { PrismaClient } from '../generated/client'
+   import { PrismaPg } from '@prisma/adapter-pg'
+
+   const adapter = new PrismaPg({ connectionString: process.env.DATABASE_URL })
+   const prisma = new PrismaClient({ adapter })
+   ```
+
+`PrismaPg` also accepts the connection string directly:
+
+```typescript
+const adapter = new PrismaPg(process.env.DATABASE_URL!)
+const prisma = new PrismaClient({ adapter })
+```
+
+For PostgreSQL prepared statement naming, pass adapter options as the second argument:
+
+```typescript
+import { createHash } from 'node:crypto'
+
+const adapter = new PrismaPg(process.env.DATABASE_URL!, {
+  statementNameGenerator: ({ sql }) =>
+    `prisma_${createHash('sha1').update(sql).digest('hex').slice(0, 16)}`,
+})
+```
+
+### Edge/serverless option
+
+Use the Prisma Postgres serverless driver only when you need HTTP/WebSocket transport in environments like Workers or Edge Functions:
+
+```bash
+npm install @prisma/adapter-ppg @prisma/ppg
+```
+
+```typescript
+import { PrismaClient } from '../generated/client'
+import { PrismaPostgresAdapter } from '@prisma/adapter-ppg'
+
+const prisma = new PrismaClient({
+  adapter: new PrismaPostgresAdapter({
+    connectionString: process.env.PRISMA_DIRECT_TCP_URL,
+  }),
+})
+```
+
+This serverless driver is the specialized path for HTTP/WebSocket-based edge and serverless runtimes, not the default recommendation for standard Node.js apps.
+
+## Features
+
+- **Serverless**: Scales to zero.
+- **Caching**: Integrated query caching (Accelerate).
+- **Real-time**: Database events (Pulse).
+
+## Using with Prisma Client
+
+Use the Prisma Postgres adapter shown above when instantiating Prisma Client.

--- a/.agents/skills/prisma-database-setup/references/prisma-postgres.md
+++ b/.agents/skills/prisma-database-setup/references/prisma-postgres.md
@@ -15,6 +15,7 @@ prisma init --db
 ```
 
 This will:
+
 1. Log you into Prisma Data Platform.
 2. Create a new project and database instance.
 3. Update your `.env` with the connection string.
@@ -52,10 +53,10 @@ In `prisma.config.ts`:
 import { defineConfig, env } from 'prisma/config'
 
 export default defineConfig({
-  schema: 'prisma/schema.prisma',
-  datasource: {
-    url: env('DATABASE_URL'),
-  },
+    schema: 'prisma/schema.prisma',
+    datasource: {
+        url: env('DATABASE_URL'),
+    },
 })
 ```
 
@@ -66,19 +67,21 @@ Use a driver adapter for Prisma Postgres in the standard SQL workflow.
 ### Recommended for standard Node.js apps
 
 1. Install adapter and driver:
-   ```bash
-   npm install @prisma/adapter-pg pg
-   ```
+
+    ```bash
+    npm install @prisma/adapter-pg pg
+    ```
 
 2. Use the direct TCP connection string from Prisma Console:
-   ```typescript
-   import 'dotenv/config'
-   import { PrismaClient } from '../generated/client'
-   import { PrismaPg } from '@prisma/adapter-pg'
 
-   const adapter = new PrismaPg({ connectionString: process.env.DATABASE_URL })
-   const prisma = new PrismaClient({ adapter })
-   ```
+    ```typescript
+    import 'dotenv/config'
+    import { PrismaClient } from '../generated/client'
+    import { PrismaPg } from '@prisma/adapter-pg'
+
+    const adapter = new PrismaPg({ connectionString: process.env.DATABASE_URL })
+    const prisma = new PrismaClient({ adapter })
+    ```
 
 `PrismaPg` also accepts the connection string directly:
 
@@ -93,8 +96,8 @@ For PostgreSQL prepared statement naming, pass adapter options as the second arg
 import { createHash } from 'node:crypto'
 
 const adapter = new PrismaPg(process.env.DATABASE_URL!, {
-  statementNameGenerator: ({ sql }) =>
-    `prisma_${createHash('sha1').update(sql).digest('hex').slice(0, 16)}`,
+    statementNameGenerator: ({ sql }) =>
+        `prisma_${createHash('sha1').update(sql).digest('hex').slice(0, 16)}`,
 })
 ```
 
@@ -111,9 +114,9 @@ import { PrismaClient } from '../generated/client'
 import { PrismaPostgresAdapter } from '@prisma/adapter-ppg'
 
 const prisma = new PrismaClient({
-  adapter: new PrismaPostgresAdapter({
-    connectionString: process.env.PRISMA_DIRECT_TCP_URL,
-  }),
+    adapter: new PrismaPostgresAdapter({
+        connectionString: process.env.PRISMA_DIRECT_TCP_URL,
+    }),
 })
 ```
 

--- a/.agents/skills/prisma-database-setup/references/sqlite.md
+++ b/.agents/skills/prisma-database-setup/references/sqlite.md
@@ -1,0 +1,106 @@
+# SQLite Setup
+
+Configure Prisma with SQLite.
+
+## Prerequisites
+
+- None (file-based)
+
+## 1. Schema Configuration
+
+In `prisma/schema.prisma`:
+
+```prisma
+datasource db {
+  provider = "sqlite"
+}
+
+generator client {
+  provider = "prisma-client"
+  output   = "../generated"
+}
+```
+
+## 2. Config Configuration
+
+In `prisma.config.ts`:
+
+```typescript
+import { defineConfig, env } from 'prisma/config'
+
+export default defineConfig({
+  schema: 'prisma/schema.prisma',
+  datasource: {
+    url: env('DATABASE_URL'),
+  },
+})
+```
+
+## 3. Environment Variable
+
+In `.env`:
+
+```env
+DATABASE_URL="file:./dev.db"
+```
+
+### Connection String Format
+
+```
+file:PATH
+```
+
+- **PATH**: Relative path to the database file. Check `prisma.config.ts` if you need to confirm how your app resolves it.
+
+## Driver Adapter
+
+Use a driver adapter for the standard SQL workflow.
+
+1. Install adapter and driver:
+   ```bash
+   npm install @prisma/adapter-better-sqlite3 better-sqlite3
+   ```
+
+2. Instantiate Prisma Client with the adapter:
+   ```typescript
+   import { PrismaClient } from '../generated/client'
+   import { PrismaBetterSqlite3 } from '@prisma/adapter-better-sqlite3'
+
+   const adapter = new PrismaBetterSqlite3({
+     url: process.env.DATABASE_URL ?? 'file:./dev.db',
+   })
+
+   const prisma = new PrismaClient({ adapter })
+   ```
+
+## Using Driver Adapter (LibSQL / Turso)
+
+For edge compatibility or Turso:
+
+1. Install:
+   ```bash
+   npm install @prisma/adapter-libsql @libsql/client
+   ```
+
+2. Instantiate:
+   ```typescript
+   import { PrismaClient } from '../generated/client'
+   import { PrismaLibSql } from '@prisma/adapter-libsql'
+
+   const adapter = new PrismaLibSql({
+     url: process.env.TURSO_DATABASE_URL,
+     authToken: process.env.TURSO_AUTH_TOKEN,
+   })
+   const prisma = new PrismaClient({ adapter })
+   ```
+
+## Limitations
+
+- **No Enums**: SQLite doesn't support enums (Prisma polyfills them or treats as String).
+- **No Scalar Lists**: `String[]` is not supported directly.
+- **Concurrency**: Write operations lock the file.
+
+## Common Issues
+
+### "Database file not found"
+Ensure the path in `DATABASE_URL` is correct relative to where Prisma is running or the schema file. `file:./dev.db` creates it next to schema.

--- a/.agents/skills/prisma-database-setup/references/sqlite.md
+++ b/.agents/skills/prisma-database-setup/references/sqlite.md
@@ -29,10 +29,10 @@ In `prisma.config.ts`:
 import { defineConfig, env } from 'prisma/config'
 
 export default defineConfig({
-  schema: 'prisma/schema.prisma',
-  datasource: {
-    url: env('DATABASE_URL'),
-  },
+    schema: 'prisma/schema.prisma',
+    datasource: {
+        url: env('DATABASE_URL'),
+    },
 })
 ```
 
@@ -57,42 +57,46 @@ file:PATH
 Use a driver adapter for the standard SQL workflow.
 
 1. Install adapter and driver:
-   ```bash
-   npm install @prisma/adapter-better-sqlite3 better-sqlite3
-   ```
+
+    ```bash
+    npm install @prisma/adapter-better-sqlite3 better-sqlite3
+    ```
 
 2. Instantiate Prisma Client with the adapter:
-   ```typescript
-   import { PrismaClient } from '../generated/client'
-   import { PrismaBetterSqlite3 } from '@prisma/adapter-better-sqlite3'
 
-   const adapter = new PrismaBetterSqlite3({
-     url: process.env.DATABASE_URL ?? 'file:./dev.db',
-   })
+    ```typescript
+    import { PrismaClient } from '../generated/client'
+    import { PrismaBetterSqlite3 } from '@prisma/adapter-better-sqlite3'
 
-   const prisma = new PrismaClient({ adapter })
-   ```
+    const adapter = new PrismaBetterSqlite3({
+        url: process.env.DATABASE_URL ?? 'file:./dev.db',
+    })
+
+    const prisma = new PrismaClient({ adapter })
+    ```
 
 ## Using Driver Adapter (LibSQL / Turso)
 
 For edge compatibility or Turso:
 
 1. Install:
-   ```bash
-   npm install @prisma/adapter-libsql @libsql/client
-   ```
+
+    ```bash
+    npm install @prisma/adapter-libsql @libsql/client
+    ```
 
 2. Instantiate:
-   ```typescript
-   import { PrismaClient } from '../generated/client'
-   import { PrismaLibSql } from '@prisma/adapter-libsql'
 
-   const adapter = new PrismaLibSql({
-     url: process.env.TURSO_DATABASE_URL,
-     authToken: process.env.TURSO_AUTH_TOKEN,
-   })
-   const prisma = new PrismaClient({ adapter })
-   ```
+    ```typescript
+    import { PrismaClient } from '../generated/client'
+    import { PrismaLibSql } from '@prisma/adapter-libsql'
+
+    const adapter = new PrismaLibSql({
+        url: process.env.TURSO_DATABASE_URL,
+        authToken: process.env.TURSO_AUTH_TOKEN,
+    })
+    const prisma = new PrismaClient({ adapter })
+    ```
 
 ## Limitations
 
@@ -103,4 +107,5 @@ For edge compatibility or Turso:
 ## Common Issues
 
 ### "Database file not found"
+
 Ensure the path in `DATABASE_URL` is correct relative to where Prisma is running or the schema file. `file:./dev.db` creates it next to schema.

--- a/.agents/skills/prisma-database-setup/references/sqlserver.md
+++ b/.agents/skills/prisma-database-setup/references/sqlserver.md
@@ -1,0 +1,94 @@
+# SQL Server Setup
+
+Configure Prisma with Microsoft SQL Server.
+
+## Prerequisites
+
+- SQL Server 2017, 2019, 2022, or Azure SQL
+- TCP/IP enabled
+
+## 1. Schema Configuration
+
+In `prisma/schema.prisma`:
+
+```prisma
+datasource db {
+  provider = "sqlserver"
+}
+
+generator client {
+  provider = "prisma-client"
+  output   = "../generated"
+}
+```
+
+## 2. Config Configuration
+
+In `prisma.config.ts`:
+
+```typescript
+import { defineConfig, env } from 'prisma/config'
+
+export default defineConfig({
+  schema: 'prisma/schema.prisma',
+  datasource: {
+    url: env('DATABASE_URL'),
+  },
+})
+```
+
+## 3. Environment Variable
+
+In `.env`:
+
+```env
+DATABASE_URL="sqlserver://localhost:1433;database=mydb;user=sa;password=Password123;encrypt=true;trustServerCertificate=true"
+```
+
+### Connection String Format
+
+```
+sqlserver://HOST:PORT;database=DB;user=USER;password=PASS;encrypt=true;trustServerCertificate=true
+```
+
+- **encrypt**: Required for Azure (true).
+- **trustServerCertificate**: True for self-signed certs (local dev).
+
+## Driver Adapter
+
+Use a driver adapter for the standard SQL workflow.
+
+1. Install adapter and driver:
+   ```bash
+   npm install @prisma/adapter-mssql mssql
+   ```
+
+2. Instantiate Prisma Client with the adapter:
+   ```typescript
+   import 'dotenv/config'
+   import { PrismaClient } from '../generated/client'
+   import { PrismaMssql } from '@prisma/adapter-mssql'
+
+   const adapter = new PrismaMssql({
+     server: 'localhost',
+     port: 1433,
+     database: 'mydb',
+     user: process.env.SQLSERVER_USER,
+     password: process.env.SQLSERVER_PASSWORD,
+     options: {
+       encrypt: true,
+       trustServerCertificate: true,
+     },
+   })
+
+   const prisma = new PrismaClient({ adapter })
+   ```
+
+## Common Issues
+
+### "Login failed for user"
+- SQL Server auth vs Windows auth. Prisma typically uses SQL Server authentication (username/password).
+- Ensure TCP/IP is enabled in SQL Server Configuration Manager.
+
+### "Table not found" (dbo schema)
+Prisma assumes `dbo` schema by default. If using another schema, update the model or connection string? SQL Server provider mostly sticks to default schema.

--- a/.agents/skills/prisma-database-setup/references/sqlserver.md
+++ b/.agents/skills/prisma-database-setup/references/sqlserver.md
@@ -30,10 +30,10 @@ In `prisma.config.ts`:
 import { defineConfig, env } from 'prisma/config'
 
 export default defineConfig({
-  schema: 'prisma/schema.prisma',
-  datasource: {
-    url: env('DATABASE_URL'),
-  },
+    schema: 'prisma/schema.prisma',
+    datasource: {
+        url: env('DATABASE_URL'),
+    },
 })
 ```
 
@@ -59,36 +59,40 @@ sqlserver://HOST:PORT;database=DB;user=USER;password=PASS;encrypt=true;trustServ
 Use a driver adapter for the standard SQL workflow.
 
 1. Install adapter and driver:
-   ```bash
-   npm install @prisma/adapter-mssql mssql
-   ```
+
+    ```bash
+    npm install @prisma/adapter-mssql mssql
+    ```
 
 2. Instantiate Prisma Client with the adapter:
-   ```typescript
-   import 'dotenv/config'
-   import { PrismaClient } from '../generated/client'
-   import { PrismaMssql } from '@prisma/adapter-mssql'
 
-   const adapter = new PrismaMssql({
-     server: 'localhost',
-     port: 1433,
-     database: 'mydb',
-     user: process.env.SQLSERVER_USER,
-     password: process.env.SQLSERVER_PASSWORD,
-     options: {
-       encrypt: true,
-       trustServerCertificate: true,
-     },
-   })
+    ```typescript
+    import 'dotenv/config'
+    import { PrismaClient } from '../generated/client'
+    import { PrismaMssql } from '@prisma/adapter-mssql'
 
-   const prisma = new PrismaClient({ adapter })
-   ```
+    const adapter = new PrismaMssql({
+        server: 'localhost',
+        port: 1433,
+        database: 'mydb',
+        user: process.env.SQLSERVER_USER,
+        password: process.env.SQLSERVER_PASSWORD,
+        options: {
+            encrypt: true,
+            trustServerCertificate: true,
+        },
+    })
+
+    const prisma = new PrismaClient({ adapter })
+    ```
 
 ## Common Issues
 
 ### "Login failed for user"
+
 - SQL Server auth vs Windows auth. Prisma typically uses SQL Server authentication (username/password).
 - Ensure TCP/IP is enabled in SQL Server Configuration Manager.
 
 ### "Table not found" (dbo schema)
+
 Prisma assumes `dbo` schema by default. If using another schema, update the model or connection string? SQL Server provider mostly sticks to default schema.

--- a/.agents/skills/prisma-postgres/SKILL.md
+++ b/.agents/skills/prisma-postgres/SKILL.md
@@ -1,0 +1,127 @@
+---
+name: prisma-postgres
+description: Prisma Postgres setup and operations guidance across Console, create-db CLI, Management API, and Management API SDK. Use when creating Prisma Postgres databases, working in Prisma Console, provisioning with create-db/create-pg/create-postgres, or integrating programmatic provisioning with service tokens or OAuth.
+license: MIT
+metadata:
+  author: prisma
+  version: "7.6.0"
+---
+
+# Prisma Postgres
+
+Guidance for creating, managing, and integrating Prisma Postgres across interactive and programmatic workflows.
+
+## When to Apply
+
+Reference this skill when:
+- Setting up Prisma Postgres from Prisma Console
+- Provisioning instant temporary databases with `create-db`
+- Linking an existing local project with `prisma postgres link`
+- Managing Prisma Postgres resources via Management API
+- Using `@prisma/management-api-sdk` in TypeScript/JavaScript
+- Handling claim URLs, connection strings, regions, and auth flows
+
+## Rule Categories by Priority
+
+| Priority | Category | Impact | Prefix |
+|----------|----------|--------|--------|
+| 1 | CLI Provisioning | CRITICAL | `create-db-cli` |
+| 2 | Management API | CRITICAL | `management-api` |
+| 3 | Management API SDK | HIGH | `management-api-sdk` |
+| 4 | Console and Connections | HIGH | `console-and-connections` |
+
+## Quick Reference
+
+- `create-db-cli` - instant databases and current CLI flags (`--ttl`, `--copy`, `--quiet`, `--open`)
+- `management-api` - service token and OAuth API workflows
+- `management-api-sdk` - typed SDK usage with token storage
+- `console-and-connections` - Console operations, `prisma postgres link`, direct TCP connections, and serverless-driver choices
+
+## Core Workflows
+
+### 1. Console-first workflow
+
+Use Prisma Console for manual setup and operations:
+
+- Open `https://console.prisma.io`
+- Create/select workspace and project
+- Use Studio in the project sidebar to view/edit data
+- Retrieve direct connection details from the project UI
+
+### 2. Quick provisioning with create-db
+
+Use `create-db` when you need a database immediately:
+
+```bash
+npx create-db@latest
+```
+
+Aliases:
+
+```bash
+npx create-pg@latest
+npx create-postgres@latest
+```
+
+For app integrations, you can also use the programmatic API (`create()` / `regions()`) from the `create-db` npm package.
+
+Temporary databases auto-delete after ~24 hours unless claimed.
+
+### 3. Link an existing local project
+
+Use `prisma postgres link` when the database already exists and you want to wire a local project to it:
+
+```bash
+prisma postgres link
+```
+
+For CI or other non-interactive environments:
+
+```bash
+prisma postgres link --api-key "<your-api-key>" --database "db_..."
+```
+
+This flow updates your local `.env` with `DATABASE_URL`, then you can run `prisma generate` and `prisma migrate dev`.
+
+### 4. Programmatic provisioning with Management API
+
+Use API endpoints on:
+
+```text
+https://api.prisma.io/v1
+```
+
+Explore the schema and endpoints using:
+
+- OpenAPI docs: `https://api.prisma.io/v1/doc`
+- Swagger Editor: `https://api.prisma.io/v1/swagger-editor`
+
+Auth options:
+
+- Service token (workspace server-to-server)
+- OAuth 2.0 (act on behalf of users)
+
+### 5. Type-safe integration with Management API SDK
+
+Install and use:
+
+```bash
+npm install @prisma/management-api-sdk
+```
+
+Use `createManagementApiClient` for existing tokens, or `createManagementApiSdk` for OAuth + token refresh.
+
+## Rule Files
+
+Detailed guidance lives in:
+
+```
+references/console-and-connections.md
+references/create-db-cli.md
+references/management-api.md
+references/management-api-sdk.md
+```
+
+## How to Use
+
+Start with `references/create-db-cli.md` for fast setup, then switch to `references/management-api.md` or `references/management-api-sdk.md` when you need programmatic provisioning.

--- a/.agents/skills/prisma-postgres/SKILL.md
+++ b/.agents/skills/prisma-postgres/SKILL.md
@@ -3,8 +3,8 @@ name: prisma-postgres
 description: Prisma Postgres setup and operations guidance across Console, create-db CLI, Management API, and Management API SDK. Use when creating Prisma Postgres databases, working in Prisma Console, provisioning with create-db/create-pg/create-postgres, or integrating programmatic provisioning with service tokens or OAuth.
 license: MIT
 metadata:
-  author: prisma
-  version: "7.6.0"
+    author: prisma
+    version: '7.6.0'
 ---
 
 # Prisma Postgres
@@ -14,6 +14,7 @@ Guidance for creating, managing, and integrating Prisma Postgres across interact
 ## When to Apply
 
 Reference this skill when:
+
 - Setting up Prisma Postgres from Prisma Console
 - Provisioning instant temporary databases with `create-db`
 - Linking an existing local project with `prisma postgres link`
@@ -23,12 +24,12 @@ Reference this skill when:
 
 ## Rule Categories by Priority
 
-| Priority | Category | Impact | Prefix |
-|----------|----------|--------|--------|
-| 1 | CLI Provisioning | CRITICAL | `create-db-cli` |
-| 2 | Management API | CRITICAL | `management-api` |
-| 3 | Management API SDK | HIGH | `management-api-sdk` |
-| 4 | Console and Connections | HIGH | `console-and-connections` |
+| Priority | Category                | Impact   | Prefix                    |
+| -------- | ----------------------- | -------- | ------------------------- |
+| 1        | CLI Provisioning        | CRITICAL | `create-db-cli`           |
+| 2        | Management API          | CRITICAL | `management-api`          |
+| 3        | Management API SDK      | HIGH     | `management-api-sdk`      |
+| 4        | Console and Connections | HIGH     | `console-and-connections` |
 
 ## Quick Reference
 

--- a/.agents/skills/prisma-postgres/references/console-and-connections.md
+++ b/.agents/skills/prisma-postgres/references/console-and-connections.md
@@ -1,0 +1,67 @@
+# console-and-connections
+
+Use Prisma Console workflows for project visibility, data inspection, and connection setup.
+
+## Priority
+
+HIGH
+
+## Why It Matters
+
+Many Prisma Postgres tasks are quickest in the Console: viewing Studio data, checking metrics, and retrieving connection details. This avoids unnecessary API or CLI work for simple operational tasks.
+
+## Console workflow
+
+1. Open `https://console.prisma.io`.
+2. Select workspace and project.
+3. Use dashboard metrics for usage and billing visibility.
+4. Open the **Studio** tab in the sidebar to inspect and edit data.
+
+## Local Studio
+
+You can also inspect data locally:
+
+```bash
+npx prisma studio
+```
+
+## Linking an existing project
+
+If the Prisma Postgres database already exists, link the local project instead of provisioning a new one:
+
+```bash
+prisma postgres link
+```
+
+For CI or non-interactive usage:
+
+```bash
+prisma postgres link --api-key "<your-api-key>" --database "db_..."
+```
+
+This command updates or creates `.env` with `DATABASE_URL`. If the project is already linked, use `--force` to re-link. After linking, run `prisma generate`, then `prisma migrate dev` if you need to apply the schema.
+
+## Connection setup
+
+For direct PostgreSQL tools and drivers:
+
+- Generate/copy direct connection credentials from the project connection UI.
+- Use the resulting PostgreSQL URL as `DATABASE_URL` for `pg` and `@prisma/adapter-pg`.
+- For Prisma Postgres direct TCP, include `sslmode=require`.
+
+Typical direct TCP format:
+
+```env
+DATABASE_URL="postgres://identifier:key@db.prisma.io:5432/postgres?sslmode=require"
+```
+
+## Adapter choices
+
+- Standard Node.js apps: prefer `@prisma/adapter-pg` with the direct TCP URL above.
+- Edge/serverless runtimes: use `@prisma/adapter-ppg` with `@prisma/ppg` only when you specifically need the Prisma Postgres serverless driver.
+
+## References
+
+- [Prisma Postgres overview](https://www.prisma.io/docs/postgres/introduction/overview)
+- [Viewing data](https://www.prisma.io/docs/postgres/integrations/viewing-data)
+- [Direct connections](https://www.prisma.io/docs/postgres/database/direct-connections)

--- a/.agents/skills/prisma-postgres/references/create-db-cli.md
+++ b/.agents/skills/prisma-postgres/references/create-db-cli.md
@@ -1,0 +1,136 @@
+# create-db-cli
+
+Use `create-db` for instant Prisma Postgres provisioning from the terminal.
+
+## Priority
+
+CRITICAL
+
+## Why It Matters
+
+`create-db` is the fastest way to get a working Prisma Postgres instance for development, demos, and CI previews. It can also emit machine-readable output and write env variables directly.
+
+## Commands
+
+```bash
+npx create-db@latest
+npx create-db@latest create [options]
+npx create-db@latest regions
+```
+
+Aliases:
+
+```bash
+npx create-pg@latest
+npx create-postgres@latest
+```
+
+## Command discovery (`--help`)
+
+Always use `--help` first when integrating CLI commands:
+
+```bash
+npx create-db@latest --help
+npx create-db@latest create --help
+npx create-db@latest regions --help
+```
+
+Top-level commands currently exposed:
+
+- `create` (default) to provision a database
+- `regions` to list available regions
+
+## `create` options
+
+| Flag | Shorthand | Description |
+|---|---|---|
+| `--region [string]` | `-r` | Region choice: `ap-southeast-1`, `ap-northeast-1`, `eu-central-1`, `eu-west-3`, `us-east-1`, `us-west-1` |
+| `--interactive [boolean]` | `-i` | Open region selector |
+| `--json [boolean]` | `-j` | Output machine-readable JSON |
+| `--env [string]` | `-e` | Write `DATABASE_URL` and `CLAIM_URL` into a target `.env` |
+| `--ttl [string]` | `-t` | Auto-delete after a TTL like `30m` or `1h-24h` |
+| `--copy [boolean]` | `-c` | Copy the connection string to the clipboard |
+| `--quiet [boolean]` | `-q` | Only print the connection string |
+| `--open [boolean]` | `-o` | Open the claim URL in your browser |
+
+## Lifecycle and claim flow
+
+- Databases are temporary by default.
+- Unclaimed databases are auto-deleted after ~24 hours.
+- Claim the database using the URL shown in command output to keep it permanently.
+
+## Programmatic usage (library API)
+
+You can also use `create-db` programmatically in Node.js/Bun instead of shelling out to the CLI.
+
+Install:
+
+```bash
+npm install create-db
+# or
+bun add create-db
+```
+
+Create a database:
+
+```ts
+import { create, isDatabaseSuccess, isDatabaseError } from "create-db";
+
+const result = await create({
+  region: "us-east-1",
+  userAgent: "my-app/1.0.0",
+});
+
+if (isDatabaseSuccess(result)) {
+  console.log(result.connectionString);
+  console.log(result.claimUrl);
+  console.log(result.deletionDate);
+}
+
+if (isDatabaseError(result)) {
+  console.error(result.error, result.message);
+}
+```
+
+List regions programmatically:
+
+```ts
+import { regions } from "create-db";
+
+const available = await regions();
+console.log(available);
+```
+
+Programmatic `create()` defaults to `us-east-1` if no region is passed.
+
+## Common patterns
+
+```bash
+# quick database
+npx create-db@latest
+
+# region-specific database
+npx create-db@latest --region eu-central-1
+
+# interactive region selection
+npx create-db@latest --interactive
+
+# write env vars for app bootstrap
+npx create-db@latest --env .env
+
+# auto-delete sooner
+npx create-db@latest --ttl 2h
+
+# copy connection string to clipboard
+npx create-db@latest --copy
+
+# print only the connection string
+npx create-db@latest --quiet
+
+# CI-friendly output
+npx create-db@latest --json
+```
+
+## References
+
+- [npx create-db docs](https://www.prisma.io/docs/postgres/introduction/npx-create-db)

--- a/.agents/skills/prisma-postgres/references/create-db-cli.md
+++ b/.agents/skills/prisma-postgres/references/create-db-cli.md
@@ -42,16 +42,16 @@ Top-level commands currently exposed:
 
 ## `create` options
 
-| Flag | Shorthand | Description |
-|---|---|---|
-| `--region [string]` | `-r` | Region choice: `ap-southeast-1`, `ap-northeast-1`, `eu-central-1`, `eu-west-3`, `us-east-1`, `us-west-1` |
-| `--interactive [boolean]` | `-i` | Open region selector |
-| `--json [boolean]` | `-j` | Output machine-readable JSON |
-| `--env [string]` | `-e` | Write `DATABASE_URL` and `CLAIM_URL` into a target `.env` |
-| `--ttl [string]` | `-t` | Auto-delete after a TTL like `30m` or `1h-24h` |
-| `--copy [boolean]` | `-c` | Copy the connection string to the clipboard |
-| `--quiet [boolean]` | `-q` | Only print the connection string |
-| `--open [boolean]` | `-o` | Open the claim URL in your browser |
+| Flag                      | Shorthand | Description                                                                                              |
+| ------------------------- | --------- | -------------------------------------------------------------------------------------------------------- |
+| `--region [string]`       | `-r`      | Region choice: `ap-southeast-1`, `ap-northeast-1`, `eu-central-1`, `eu-west-3`, `us-east-1`, `us-west-1` |
+| `--interactive [boolean]` | `-i`      | Open region selector                                                                                     |
+| `--json [boolean]`        | `-j`      | Output machine-readable JSON                                                                             |
+| `--env [string]`          | `-e`      | Write `DATABASE_URL` and `CLAIM_URL` into a target `.env`                                                |
+| `--ttl [string]`          | `-t`      | Auto-delete after a TTL like `30m` or `1h-24h`                                                           |
+| `--copy [boolean]`        | `-c`      | Copy the connection string to the clipboard                                                              |
+| `--quiet [boolean]`       | `-q`      | Only print the connection string                                                                         |
+| `--open [boolean]`        | `-o`      | Open the claim URL in your browser                                                                       |
 
 ## Lifecycle and claim flow
 
@@ -74,31 +74,31 @@ bun add create-db
 Create a database:
 
 ```ts
-import { create, isDatabaseSuccess, isDatabaseError } from "create-db";
+import { create, isDatabaseSuccess, isDatabaseError } from 'create-db'
 
 const result = await create({
-  region: "us-east-1",
-  userAgent: "my-app/1.0.0",
-});
+    region: 'us-east-1',
+    userAgent: 'my-app/1.0.0',
+})
 
 if (isDatabaseSuccess(result)) {
-  console.log(result.connectionString);
-  console.log(result.claimUrl);
-  console.log(result.deletionDate);
+    console.log(result.connectionString)
+    console.log(result.claimUrl)
+    console.log(result.deletionDate)
 }
 
 if (isDatabaseError(result)) {
-  console.error(result.error, result.message);
+    console.error(result.error, result.message)
 }
 ```
 
 List regions programmatically:
 
 ```ts
-import { regions } from "create-db";
+import { regions } from 'create-db'
 
-const available = await regions();
-console.log(available);
+const available = await regions()
+console.log(available)
 ```
 
 Programmatic `create()` defaults to `us-east-1` if no region is passed.

--- a/.agents/skills/prisma-postgres/references/management-api-sdk.md
+++ b/.agents/skills/prisma-postgres/references/management-api-sdk.md
@@ -1,0 +1,56 @@
+# management-api-sdk
+
+Use `@prisma/management-api-sdk` for typed API integration with optional OAuth and token refresh.
+
+## Priority
+
+HIGH
+
+## Why It Matters
+
+The SDK provides typed endpoint methods and removes boilerplate around auth and refresh handling, which reduces errors in production provisioning flows.
+
+## Install
+
+```bash
+npm install @prisma/management-api-sdk
+```
+
+## Simple client (existing token)
+
+```typescript
+import { createManagementApiClient } from '@prisma/management-api-sdk'
+
+const client = createManagementApiClient({ token: process.env.PRISMA_SERVICE_TOKEN! })
+const { data: workspaces } = await client.GET('/v1/workspaces')
+```
+
+## Full SDK (OAuth + refresh)
+
+```typescript
+import { createManagementApiSdk, type TokenStorage } from '@prisma/management-api-sdk'
+
+const tokenStorage: TokenStorage = {
+  async getTokens() { return null },
+  async setTokens(tokens) {},
+  async clearTokens() {},
+}
+
+const api = createManagementApiSdk({
+  clientId: process.env.PRISMA_CLIENT_ID!,
+  redirectUri: 'https://your-app.com/auth/callback',
+  tokenStorage,
+})
+```
+
+## OAuth SDK flow
+
+1. Call `getLoginUrl()` and persist `state` + `verifier`.
+2. Redirect user to login URL.
+3. Handle callback with `handleCallback()`.
+4. Use `api.client` for typed endpoint calls.
+5. Call `logout()` when needed.
+
+## References
+
+- [Management API SDK docs](https://www.prisma.io/docs/postgres/introduction/management-api-sdk)

--- a/.agents/skills/prisma-postgres/references/management-api-sdk.md
+++ b/.agents/skills/prisma-postgres/references/management-api-sdk.md
@@ -21,25 +21,32 @@ npm install @prisma/management-api-sdk
 ```typescript
 import { createManagementApiClient } from '@prisma/management-api-sdk'
 
-const client = createManagementApiClient({ token: process.env.PRISMA_SERVICE_TOKEN! })
+const client = createManagementApiClient({
+    token: process.env.PRISMA_SERVICE_TOKEN!,
+})
 const { data: workspaces } = await client.GET('/v1/workspaces')
 ```
 
 ## Full SDK (OAuth + refresh)
 
 ```typescript
-import { createManagementApiSdk, type TokenStorage } from '@prisma/management-api-sdk'
+import {
+    createManagementApiSdk,
+    type TokenStorage,
+} from '@prisma/management-api-sdk'
 
 const tokenStorage: TokenStorage = {
-  async getTokens() { return null },
-  async setTokens(tokens) {},
-  async clearTokens() {},
+    async getTokens() {
+        return null
+    },
+    async setTokens(tokens) {},
+    async clearTokens() {},
 }
 
 const api = createManagementApiSdk({
-  clientId: process.env.PRISMA_CLIENT_ID!,
-  redirectUri: 'https://your-app.com/auth/callback',
-  tokenStorage,
+    clientId: process.env.PRISMA_CLIENT_ID!,
+    redirectUri: 'https://your-app.com/auth/callback',
+    tokenStorage,
 })
 ```
 

--- a/.agents/skills/prisma-postgres/references/management-api.md
+++ b/.agents/skills/prisma-postgres/references/management-api.md
@@ -1,0 +1,61 @@
+# management-api
+
+Use Prisma Management API for programmatic provisioning and workspace/project/database management.
+
+## Priority
+
+CRITICAL
+
+## Why It Matters
+
+When you need backend automation, multi-tenant onboarding flows, or controlled resource provisioning, the Management API is the source of truth and is more reliable than interactive workflows.
+
+## Base URL
+
+```text
+https://api.prisma.io/v1
+```
+
+## API exploration
+
+- OpenAPI docs: `https://api.prisma.io/v1/doc`
+- Swagger Editor: `https://api.prisma.io/v1/swagger-editor`
+
+## Authentication methods
+
+- Service token: best for server-to-server operations in your own workspace
+- OAuth 2.0: best for acting on behalf of users across workspaces
+
+## Service token flow
+
+1. Create token in Prisma Console workspace settings.
+2. Send token as Bearer auth:
+
+```text
+Authorization: Bearer $TOKEN
+```
+
+## OAuth flow summary
+
+1. Redirect user to `https://auth.prisma.io/authorize` with `client_id`, `redirect_uri`, `response_type=code`, and scopes.
+2. Receive `code` on callback.
+3. Exchange code at `https://auth.prisma.io/token`.
+4. Use returned access token in Management API requests.
+
+## Common endpoints
+
+- `GET /workspaces`
+- `GET /projects`
+- `POST /projects`
+- Database management endpoints under project/database paths
+
+## Notes
+
+- Management API responses may include direct connection credentials for databases.
+- Build PostgreSQL `DATABASE_URL` from direct connection values when needed.
+
+## References
+
+- [Management API docs](https://www.prisma.io/docs/postgres/introduction/management-api)
+- [OpenAPI docs](https://api.prisma.io/v1/doc)
+- [Swagger Editor](https://api.prisma.io/v1/swagger-editor)

--- a/.agents/skills/typescript-advanced-types/SKILL.md
+++ b/.agents/skills/typescript-advanced-types/SKILL.md
@@ -1,0 +1,717 @@
+---
+name: typescript-advanced-types
+description: Master TypeScript's advanced type system including generics, conditional types, mapped types, template literals, and utility types for building type-safe applications. Use when implementing complex type logic, creating reusable type utilities, or ensuring compile-time type safety in TypeScript projects.
+---
+
+# TypeScript Advanced Types
+
+Comprehensive guidance for mastering TypeScript's advanced type system including generics, conditional types, mapped types, template literal types, and utility types for building robust, type-safe applications.
+
+## When to Use This Skill
+
+- Building type-safe libraries or frameworks
+- Creating reusable generic components
+- Implementing complex type inference logic
+- Designing type-safe API clients
+- Building form validation systems
+- Creating strongly-typed configuration objects
+- Implementing type-safe state management
+- Migrating JavaScript codebases to TypeScript
+
+## Core Concepts
+
+### 1. Generics
+
+**Purpose:** Create reusable, type-flexible components while maintaining type safety.
+
+**Basic Generic Function:**
+
+```typescript
+function identity<T>(value: T): T {
+  return value;
+}
+
+const num = identity<number>(42); // Type: number
+const str = identity<string>("hello"); // Type: string
+const auto = identity(true); // Type inferred: boolean
+```
+
+**Generic Constraints:**
+
+```typescript
+interface HasLength {
+  length: number;
+}
+
+function logLength<T extends HasLength>(item: T): T {
+  console.log(item.length);
+  return item;
+}
+
+logLength("hello"); // OK: string has length
+logLength([1, 2, 3]); // OK: array has length
+logLength({ length: 10 }); // OK: object has length
+// logLength(42);             // Error: number has no length
+```
+
+**Multiple Type Parameters:**
+
+```typescript
+function merge<T, U>(obj1: T, obj2: U): T & U {
+  return { ...obj1, ...obj2 };
+}
+
+const merged = merge({ name: "John" }, { age: 30 });
+// Type: { name: string } & { age: number }
+```
+
+### 2. Conditional Types
+
+**Purpose:** Create types that depend on conditions, enabling sophisticated type logic.
+
+**Basic Conditional Type:**
+
+```typescript
+type IsString<T> = T extends string ? true : false;
+
+type A = IsString<string>; // true
+type B = IsString<number>; // false
+```
+
+**Extracting Return Types:**
+
+```typescript
+type ReturnType<T> = T extends (...args: any[]) => infer R ? R : never;
+
+function getUser() {
+  return { id: 1, name: "John" };
+}
+
+type User = ReturnType<typeof getUser>;
+// Type: { id: number; name: string; }
+```
+
+**Distributive Conditional Types:**
+
+```typescript
+type ToArray<T> = T extends any ? T[] : never;
+
+type StrOrNumArray = ToArray<string | number>;
+// Type: string[] | number[]
+```
+
+**Nested Conditions:**
+
+```typescript
+type TypeName<T> = T extends string
+  ? "string"
+  : T extends number
+    ? "number"
+    : T extends boolean
+      ? "boolean"
+      : T extends undefined
+        ? "undefined"
+        : T extends Function
+          ? "function"
+          : "object";
+
+type T1 = TypeName<string>; // "string"
+type T2 = TypeName<() => void>; // "function"
+```
+
+### 3. Mapped Types
+
+**Purpose:** Transform existing types by iterating over their properties.
+
+**Basic Mapped Type:**
+
+```typescript
+type Readonly<T> = {
+  readonly [P in keyof T]: T[P];
+};
+
+interface User {
+  id: number;
+  name: string;
+}
+
+type ReadonlyUser = Readonly<User>;
+// Type: { readonly id: number; readonly name: string; }
+```
+
+**Optional Properties:**
+
+```typescript
+type Partial<T> = {
+  [P in keyof T]?: T[P];
+};
+
+type PartialUser = Partial<User>;
+// Type: { id?: number; name?: string; }
+```
+
+**Key Remapping:**
+
+```typescript
+type Getters<T> = {
+  [K in keyof T as `get${Capitalize<string & K>}`]: () => T[K];
+};
+
+interface Person {
+  name: string;
+  age: number;
+}
+
+type PersonGetters = Getters<Person>;
+// Type: { getName: () => string; getAge: () => number; }
+```
+
+**Filtering Properties:**
+
+```typescript
+type PickByType<T, U> = {
+  [K in keyof T as T[K] extends U ? K : never]: T[K];
+};
+
+interface Mixed {
+  id: number;
+  name: string;
+  age: number;
+  active: boolean;
+}
+
+type OnlyNumbers = PickByType<Mixed, number>;
+// Type: { id: number; age: number; }
+```
+
+### 4. Template Literal Types
+
+**Purpose:** Create string-based types with pattern matching and transformation.
+
+**Basic Template Literal:**
+
+```typescript
+type EventName = "click" | "focus" | "blur";
+type EventHandler = `on${Capitalize<EventName>}`;
+// Type: "onClick" | "onFocus" | "onBlur"
+```
+
+**String Manipulation:**
+
+```typescript
+type UppercaseGreeting = Uppercase<"hello">; // "HELLO"
+type LowercaseGreeting = Lowercase<"HELLO">; // "hello"
+type CapitalizedName = Capitalize<"john">; // "John"
+type UncapitalizedName = Uncapitalize<"John">; // "john"
+```
+
+**Path Building:**
+
+```typescript
+type Path<T> = T extends object
+  ? {
+      [K in keyof T]: K extends string ? `${K}` | `${K}.${Path<T[K]>}` : never;
+    }[keyof T]
+  : never;
+
+interface Config {
+  server: {
+    host: string;
+    port: number;
+  };
+  database: {
+    url: string;
+  };
+}
+
+type ConfigPath = Path<Config>;
+// Type: "server" | "database" | "server.host" | "server.port" | "database.url"
+```
+
+### 5. Utility Types
+
+**Built-in Utility Types:**
+
+```typescript
+// Partial<T> - Make all properties optional
+type PartialUser = Partial<User>;
+
+// Required<T> - Make all properties required
+type RequiredUser = Required<PartialUser>;
+
+// Readonly<T> - Make all properties readonly
+type ReadonlyUser = Readonly<User>;
+
+// Pick<T, K> - Select specific properties
+type UserName = Pick<User, "name" | "email">;
+
+// Omit<T, K> - Remove specific properties
+type UserWithoutPassword = Omit<User, "password">;
+
+// Exclude<T, U> - Exclude types from union
+type T1 = Exclude<"a" | "b" | "c", "a">; // "b" | "c"
+
+// Extract<T, U> - Extract types from union
+type T2 = Extract<"a" | "b" | "c", "a" | "b">; // "a" | "b"
+
+// NonNullable<T> - Exclude null and undefined
+type T3 = NonNullable<string | null | undefined>; // string
+
+// Record<K, T> - Create object type with keys K and values T
+type PageInfo = Record<"home" | "about", { title: string }>;
+```
+
+## Advanced Patterns
+
+### Pattern 1: Type-Safe Event Emitter
+
+```typescript
+type EventMap = {
+  "user:created": { id: string; name: string };
+  "user:updated": { id: string };
+  "user:deleted": { id: string };
+};
+
+class TypedEventEmitter<T extends Record<string, any>> {
+  private listeners: {
+    [K in keyof T]?: Array<(data: T[K]) => void>;
+  } = {};
+
+  on<K extends keyof T>(event: K, callback: (data: T[K]) => void): void {
+    if (!this.listeners[event]) {
+      this.listeners[event] = [];
+    }
+    this.listeners[event]!.push(callback);
+  }
+
+  emit<K extends keyof T>(event: K, data: T[K]): void {
+    const callbacks = this.listeners[event];
+    if (callbacks) {
+      callbacks.forEach((callback) => callback(data));
+    }
+  }
+}
+
+const emitter = new TypedEventEmitter<EventMap>();
+
+emitter.on("user:created", (data) => {
+  console.log(data.id, data.name); // Type-safe!
+});
+
+emitter.emit("user:created", { id: "1", name: "John" });
+// emitter.emit("user:created", { id: "1" });  // Error: missing 'name'
+```
+
+### Pattern 2: Type-Safe API Client
+
+```typescript
+type HTTPMethod = "GET" | "POST" | "PUT" | "DELETE";
+
+type EndpointConfig = {
+  "/users": {
+    GET: { response: User[] };
+    POST: { body: { name: string; email: string }; response: User };
+  };
+  "/users/:id": {
+    GET: { params: { id: string }; response: User };
+    PUT: { params: { id: string }; body: Partial<User>; response: User };
+    DELETE: { params: { id: string }; response: void };
+  };
+};
+
+type ExtractParams<T> = T extends { params: infer P } ? P : never;
+type ExtractBody<T> = T extends { body: infer B } ? B : never;
+type ExtractResponse<T> = T extends { response: infer R } ? R : never;
+
+class APIClient<Config extends Record<string, Record<HTTPMethod, any>>> {
+  async request<Path extends keyof Config, Method extends keyof Config[Path]>(
+    path: Path,
+    method: Method,
+    ...[options]: ExtractParams<Config[Path][Method]> extends never
+      ? ExtractBody<Config[Path][Method]> extends never
+        ? []
+        : [{ body: ExtractBody<Config[Path][Method]> }]
+      : [
+          {
+            params: ExtractParams<Config[Path][Method]>;
+            body?: ExtractBody<Config[Path][Method]>;
+          },
+        ]
+  ): Promise<ExtractResponse<Config[Path][Method]>> {
+    // Implementation here
+    return {} as any;
+  }
+}
+
+const api = new APIClient<EndpointConfig>();
+
+// Type-safe API calls
+const users = await api.request("/users", "GET");
+// Type: User[]
+
+const newUser = await api.request("/users", "POST", {
+  body: { name: "John", email: "john@example.com" },
+});
+// Type: User
+
+const user = await api.request("/users/:id", "GET", {
+  params: { id: "123" },
+});
+// Type: User
+```
+
+### Pattern 3: Builder Pattern with Type Safety
+
+```typescript
+type BuilderState<T> = {
+  [K in keyof T]: T[K] | undefined;
+};
+
+type RequiredKeys<T> = {
+  [K in keyof T]-?: {} extends Pick<T, K> ? never : K;
+}[keyof T];
+
+type OptionalKeys<T> = {
+  [K in keyof T]-?: {} extends Pick<T, K> ? K : never;
+}[keyof T];
+
+type IsComplete<T, S> =
+  RequiredKeys<T> extends keyof S
+    ? S[RequiredKeys<T>] extends undefined
+      ? false
+      : true
+    : false;
+
+class Builder<T, S extends BuilderState<T> = {}> {
+  private state: S = {} as S;
+
+  set<K extends keyof T>(key: K, value: T[K]): Builder<T, S & Record<K, T[K]>> {
+    this.state[key] = value;
+    return this as any;
+  }
+
+  build(this: IsComplete<T, S> extends true ? this : never): T {
+    return this.state as T;
+  }
+}
+
+interface User {
+  id: string;
+  name: string;
+  email: string;
+  age?: number;
+}
+
+const builder = new Builder<User>();
+
+const user = builder
+  .set("id", "1")
+  .set("name", "John")
+  .set("email", "john@example.com")
+  .build(); // OK: all required fields set
+
+// const incomplete = builder
+//   .set("id", "1")
+//   .build();  // Error: missing required fields
+```
+
+### Pattern 4: Deep Readonly/Partial
+
+```typescript
+type DeepReadonly<T> = {
+  readonly [P in keyof T]: T[P] extends object
+    ? T[P] extends Function
+      ? T[P]
+      : DeepReadonly<T[P]>
+    : T[P];
+};
+
+type DeepPartial<T> = {
+  [P in keyof T]?: T[P] extends object
+    ? T[P] extends Array<infer U>
+      ? Array<DeepPartial<U>>
+      : DeepPartial<T[P]>
+    : T[P];
+};
+
+interface Config {
+  server: {
+    host: string;
+    port: number;
+    ssl: {
+      enabled: boolean;
+      cert: string;
+    };
+  };
+  database: {
+    url: string;
+    pool: {
+      min: number;
+      max: number;
+    };
+  };
+}
+
+type ReadonlyConfig = DeepReadonly<Config>;
+// All nested properties are readonly
+
+type PartialConfig = DeepPartial<Config>;
+// All nested properties are optional
+```
+
+### Pattern 5: Type-Safe Form Validation
+
+```typescript
+type ValidationRule<T> = {
+  validate: (value: T) => boolean;
+  message: string;
+};
+
+type FieldValidation<T> = {
+  [K in keyof T]?: ValidationRule<T[K]>[];
+};
+
+type ValidationErrors<T> = {
+  [K in keyof T]?: string[];
+};
+
+class FormValidator<T extends Record<string, any>> {
+  constructor(private rules: FieldValidation<T>) {}
+
+  validate(data: T): ValidationErrors<T> | null {
+    const errors: ValidationErrors<T> = {};
+    let hasErrors = false;
+
+    for (const key in this.rules) {
+      const fieldRules = this.rules[key];
+      const value = data[key];
+
+      if (fieldRules) {
+        const fieldErrors: string[] = [];
+
+        for (const rule of fieldRules) {
+          if (!rule.validate(value)) {
+            fieldErrors.push(rule.message);
+          }
+        }
+
+        if (fieldErrors.length > 0) {
+          errors[key] = fieldErrors;
+          hasErrors = true;
+        }
+      }
+    }
+
+    return hasErrors ? errors : null;
+  }
+}
+
+interface LoginForm {
+  email: string;
+  password: string;
+}
+
+const validator = new FormValidator<LoginForm>({
+  email: [
+    {
+      validate: (v) => v.includes("@"),
+      message: "Email must contain @",
+    },
+    {
+      validate: (v) => v.length > 0,
+      message: "Email is required",
+    },
+  ],
+  password: [
+    {
+      validate: (v) => v.length >= 8,
+      message: "Password must be at least 8 characters",
+    },
+  ],
+});
+
+const errors = validator.validate({
+  email: "invalid",
+  password: "short",
+});
+// Type: { email?: string[]; password?: string[]; } | null
+```
+
+### Pattern 6: Discriminated Unions
+
+```typescript
+type Success<T> = {
+  status: "success";
+  data: T;
+};
+
+type Error = {
+  status: "error";
+  error: string;
+};
+
+type Loading = {
+  status: "loading";
+};
+
+type AsyncState<T> = Success<T> | Error | Loading;
+
+function handleState<T>(state: AsyncState<T>): void {
+  switch (state.status) {
+    case "success":
+      console.log(state.data); // Type: T
+      break;
+    case "error":
+      console.log(state.error); // Type: string
+      break;
+    case "loading":
+      console.log("Loading...");
+      break;
+  }
+}
+
+// Type-safe state machine
+type State =
+  | { type: "idle" }
+  | { type: "fetching"; requestId: string }
+  | { type: "success"; data: any }
+  | { type: "error"; error: Error };
+
+type Event =
+  | { type: "FETCH"; requestId: string }
+  | { type: "SUCCESS"; data: any }
+  | { type: "ERROR"; error: Error }
+  | { type: "RESET" };
+
+function reducer(state: State, event: Event): State {
+  switch (state.type) {
+    case "idle":
+      return event.type === "FETCH"
+        ? { type: "fetching", requestId: event.requestId }
+        : state;
+    case "fetching":
+      if (event.type === "SUCCESS") {
+        return { type: "success", data: event.data };
+      }
+      if (event.type === "ERROR") {
+        return { type: "error", error: event.error };
+      }
+      return state;
+    case "success":
+    case "error":
+      return event.type === "RESET" ? { type: "idle" } : state;
+  }
+}
+```
+
+## Type Inference Techniques
+
+### 1. Infer Keyword
+
+```typescript
+// Extract array element type
+type ElementType<T> = T extends (infer U)[] ? U : never;
+
+type NumArray = number[];
+type Num = ElementType<NumArray>; // number
+
+// Extract promise type
+type PromiseType<T> = T extends Promise<infer U> ? U : never;
+
+type AsyncNum = PromiseType<Promise<number>>; // number
+
+// Extract function parameters
+type Parameters<T> = T extends (...args: infer P) => any ? P : never;
+
+function foo(a: string, b: number) {}
+type FooParams = Parameters<typeof foo>; // [string, number]
+```
+
+### 2. Type Guards
+
+```typescript
+function isString(value: unknown): value is string {
+  return typeof value === "string";
+}
+
+function isArrayOf<T>(
+  value: unknown,
+  guard: (item: unknown) => item is T,
+): value is T[] {
+  return Array.isArray(value) && value.every(guard);
+}
+
+const data: unknown = ["a", "b", "c"];
+
+if (isArrayOf(data, isString)) {
+  data.forEach((s) => s.toUpperCase()); // Type: string[]
+}
+```
+
+### 3. Assertion Functions
+
+```typescript
+function assertIsString(value: unknown): asserts value is string {
+  if (typeof value !== "string") {
+    throw new Error("Not a string");
+  }
+}
+
+function processValue(value: unknown) {
+  assertIsString(value);
+  // value is now typed as string
+  console.log(value.toUpperCase());
+}
+```
+
+## Best Practices
+
+1. **Use `unknown` over `any`**: Enforce type checking
+2. **Prefer `interface` for object shapes**: Better error messages
+3. **Use `type` for unions and complex types**: More flexible
+4. **Leverage type inference**: Let TypeScript infer when possible
+5. **Create helper types**: Build reusable type utilities
+6. **Use const assertions**: Preserve literal types
+7. **Avoid type assertions**: Use type guards instead
+8. **Document complex types**: Add JSDoc comments
+9. **Use strict mode**: Enable all strict compiler options
+10. **Test your types**: Use type tests to verify type behavior
+
+## Type Testing
+
+```typescript
+// Type assertion tests
+type AssertEqual<T, U> = [T] extends [U]
+  ? [U] extends [T]
+    ? true
+    : false
+  : false;
+
+type Test1 = AssertEqual<string, string>; // true
+type Test2 = AssertEqual<string, number>; // false
+type Test3 = AssertEqual<string | number, string>; // false
+
+// Expect error helper
+type ExpectError<T extends never> = T;
+
+// Example usage
+type ShouldError = ExpectError<AssertEqual<string, number>>;
+```
+
+## Common Pitfalls
+
+1. **Over-using `any`**: Defeats the purpose of TypeScript
+2. **Ignoring strict null checks**: Can lead to runtime errors
+3. **Too complex types**: Can slow down compilation
+4. **Not using discriminated unions**: Misses type narrowing opportunities
+5. **Forgetting readonly modifiers**: Allows unintended mutations
+6. **Circular type references**: Can cause compiler errors
+7. **Not handling edge cases**: Like empty arrays or null values
+
+## Performance Considerations
+
+- Avoid deeply nested conditional types
+- Use simple types when possible
+- Cache complex type computations
+- Limit recursion depth in recursive types
+- Use build tools to skip type checking in production

--- a/.agents/skills/typescript-advanced-types/SKILL.md
+++ b/.agents/skills/typescript-advanced-types/SKILL.md
@@ -28,29 +28,29 @@ Comprehensive guidance for mastering TypeScript's advanced type system including
 
 ```typescript
 function identity<T>(value: T): T {
-  return value;
+    return value
 }
 
-const num = identity<number>(42); // Type: number
-const str = identity<string>("hello"); // Type: string
-const auto = identity(true); // Type inferred: boolean
+const num = identity<number>(42) // Type: number
+const str = identity<string>('hello') // Type: string
+const auto = identity(true) // Type inferred: boolean
 ```
 
 **Generic Constraints:**
 
 ```typescript
 interface HasLength {
-  length: number;
+    length: number
 }
 
 function logLength<T extends HasLength>(item: T): T {
-  console.log(item.length);
-  return item;
+    console.log(item.length)
+    return item
 }
 
-logLength("hello"); // OK: string has length
-logLength([1, 2, 3]); // OK: array has length
-logLength({ length: 10 }); // OK: object has length
+logLength('hello') // OK: string has length
+logLength([1, 2, 3]) // OK: array has length
+logLength({ length: 10 }) // OK: object has length
 // logLength(42);             // Error: number has no length
 ```
 
@@ -58,10 +58,10 @@ logLength({ length: 10 }); // OK: object has length
 
 ```typescript
 function merge<T, U>(obj1: T, obj2: U): T & U {
-  return { ...obj1, ...obj2 };
+    return { ...obj1, ...obj2 }
 }
 
-const merged = merge({ name: "John" }, { age: 30 });
+const merged = merge({ name: 'John' }, { age: 30 })
 // Type: { name: string } & { age: number }
 ```
 
@@ -72,51 +72,47 @@ const merged = merge({ name: "John" }, { age: 30 });
 **Basic Conditional Type:**
 
 ```typescript
-type IsString<T> = T extends string ? true : false;
+type IsString<T> = T extends string ? true : false
 
-type A = IsString<string>; // true
-type B = IsString<number>; // false
+type A = IsString<string> // true
+type B = IsString<number> // false
 ```
 
 **Extracting Return Types:**
 
 ```typescript
-type ReturnType<T> = T extends (...args: any[]) => infer R ? R : never;
+type ReturnType<T> = T extends (...args: any[]) => infer R ? R : never
 
 function getUser() {
-  return { id: 1, name: "John" };
+    return { id: 1, name: 'John' }
 }
 
-type User = ReturnType<typeof getUser>;
+type User = ReturnType<typeof getUser>
 // Type: { id: number; name: string; }
 ```
 
 **Distributive Conditional Types:**
 
 ```typescript
-type ToArray<T> = T extends any ? T[] : never;
+type ToArray<T> = T extends any ? T[] : never
 
-type StrOrNumArray = ToArray<string | number>;
+type StrOrNumArray = ToArray<string | number>
 // Type: string[] | number[]
 ```
 
 **Nested Conditions:**
 
 ```typescript
-type TypeName<T> = T extends string
-  ? "string"
-  : T extends number
-    ? "number"
-    : T extends boolean
-      ? "boolean"
-      : T extends undefined
-        ? "undefined"
-        : T extends Function
-          ? "function"
-          : "object";
+type TypeName<T> =
+    T extends string ? 'string'
+    : T extends number ? 'number'
+    : T extends boolean ? 'boolean'
+    : T extends undefined ? 'undefined'
+    : T extends Function ? 'function'
+    : 'object'
 
-type T1 = TypeName<string>; // "string"
-type T2 = TypeName<() => void>; // "function"
+type T1 = TypeName<string> // "string"
+type T2 = TypeName<() => void> // "function"
 ```
 
 ### 3. Mapped Types
@@ -127,15 +123,15 @@ type T2 = TypeName<() => void>; // "function"
 
 ```typescript
 type Readonly<T> = {
-  readonly [P in keyof T]: T[P];
-};
-
-interface User {
-  id: number;
-  name: string;
+    readonly [P in keyof T]: T[P]
 }
 
-type ReadonlyUser = Readonly<User>;
+interface User {
+    id: number
+    name: string
+}
+
+type ReadonlyUser = Readonly<User>
 // Type: { readonly id: number; readonly name: string; }
 ```
 
@@ -143,10 +139,10 @@ type ReadonlyUser = Readonly<User>;
 
 ```typescript
 type Partial<T> = {
-  [P in keyof T]?: T[P];
-};
+    [P in keyof T]?: T[P]
+}
 
-type PartialUser = Partial<User>;
+type PartialUser = Partial<User>
 // Type: { id?: number; name?: string; }
 ```
 
@@ -154,15 +150,15 @@ type PartialUser = Partial<User>;
 
 ```typescript
 type Getters<T> = {
-  [K in keyof T as `get${Capitalize<string & K>}`]: () => T[K];
-};
-
-interface Person {
-  name: string;
-  age: number;
+    [K in keyof T as `get${Capitalize<string & K>}`]: () => T[K]
 }
 
-type PersonGetters = Getters<Person>;
+interface Person {
+    name: string
+    age: number
+}
+
+type PersonGetters = Getters<Person>
 // Type: { getName: () => string; getAge: () => number; }
 ```
 
@@ -170,17 +166,17 @@ type PersonGetters = Getters<Person>;
 
 ```typescript
 type PickByType<T, U> = {
-  [K in keyof T as T[K] extends U ? K : never]: T[K];
-};
-
-interface Mixed {
-  id: number;
-  name: string;
-  age: number;
-  active: boolean;
+    [K in keyof T as T[K] extends U ? K : never]: T[K]
 }
 
-type OnlyNumbers = PickByType<Mixed, number>;
+interface Mixed {
+    id: number
+    name: string
+    age: number
+    active: boolean
+}
+
+type OnlyNumbers = PickByType<Mixed, number>
 // Type: { id: number; age: number; }
 ```
 
@@ -191,40 +187,42 @@ type OnlyNumbers = PickByType<Mixed, number>;
 **Basic Template Literal:**
 
 ```typescript
-type EventName = "click" | "focus" | "blur";
-type EventHandler = `on${Capitalize<EventName>}`;
+type EventName = 'click' | 'focus' | 'blur'
+type EventHandler = `on${Capitalize<EventName>}`
 // Type: "onClick" | "onFocus" | "onBlur"
 ```
 
 **String Manipulation:**
 
 ```typescript
-type UppercaseGreeting = Uppercase<"hello">; // "HELLO"
-type LowercaseGreeting = Lowercase<"HELLO">; // "hello"
-type CapitalizedName = Capitalize<"john">; // "John"
-type UncapitalizedName = Uncapitalize<"John">; // "john"
+type UppercaseGreeting = Uppercase<'hello'> // "HELLO"
+type LowercaseGreeting = Lowercase<'HELLO'> // "hello"
+type CapitalizedName = Capitalize<'john'> // "John"
+type UncapitalizedName = Uncapitalize<'John'> // "john"
 ```
 
 **Path Building:**
 
 ```typescript
-type Path<T> = T extends object
-  ? {
-      [K in keyof T]: K extends string ? `${K}` | `${K}.${Path<T[K]>}` : never;
-    }[keyof T]
-  : never;
+type Path<T> =
+    T extends object ?
+        {
+            [K in keyof T]: K extends string ? `${K}` | `${K}.${Path<T[K]>}`
+            :   never
+        }[keyof T]
+    :   never
 
 interface Config {
-  server: {
-    host: string;
-    port: number;
-  };
-  database: {
-    url: string;
-  };
+    server: {
+        host: string
+        port: number
+    }
+    database: {
+        url: string
+    }
 }
 
-type ConfigPath = Path<Config>;
+type ConfigPath = Path<Config>
 // Type: "server" | "database" | "server.host" | "server.port" | "database.url"
 ```
 
@@ -234,31 +232,31 @@ type ConfigPath = Path<Config>;
 
 ```typescript
 // Partial<T> - Make all properties optional
-type PartialUser = Partial<User>;
+type PartialUser = Partial<User>
 
 // Required<T> - Make all properties required
-type RequiredUser = Required<PartialUser>;
+type RequiredUser = Required<PartialUser>
 
 // Readonly<T> - Make all properties readonly
-type ReadonlyUser = Readonly<User>;
+type ReadonlyUser = Readonly<User>
 
 // Pick<T, K> - Select specific properties
-type UserName = Pick<User, "name" | "email">;
+type UserName = Pick<User, 'name' | 'email'>
 
 // Omit<T, K> - Remove specific properties
-type UserWithoutPassword = Omit<User, "password">;
+type UserWithoutPassword = Omit<User, 'password'>
 
 // Exclude<T, U> - Exclude types from union
-type T1 = Exclude<"a" | "b" | "c", "a">; // "b" | "c"
+type T1 = Exclude<'a' | 'b' | 'c', 'a'> // "b" | "c"
 
 // Extract<T, U> - Extract types from union
-type T2 = Extract<"a" | "b" | "c", "a" | "b">; // "a" | "b"
+type T2 = Extract<'a' | 'b' | 'c', 'a' | 'b'> // "a" | "b"
 
 // NonNullable<T> - Exclude null and undefined
-type T3 = NonNullable<string | null | undefined>; // string
+type T3 = NonNullable<string | null | undefined> // string
 
 // Record<K, T> - Create object type with keys K and values T
-type PageInfo = Record<"home" | "about", { title: string }>;
+type PageInfo = Record<'home' | 'about', { title: string }>
 ```
 
 ## Advanced Patterns
@@ -267,96 +265,96 @@ type PageInfo = Record<"home" | "about", { title: string }>;
 
 ```typescript
 type EventMap = {
-  "user:created": { id: string; name: string };
-  "user:updated": { id: string };
-  "user:deleted": { id: string };
-};
-
-class TypedEventEmitter<T extends Record<string, any>> {
-  private listeners: {
-    [K in keyof T]?: Array<(data: T[K]) => void>;
-  } = {};
-
-  on<K extends keyof T>(event: K, callback: (data: T[K]) => void): void {
-    if (!this.listeners[event]) {
-      this.listeners[event] = [];
-    }
-    this.listeners[event]!.push(callback);
-  }
-
-  emit<K extends keyof T>(event: K, data: T[K]): void {
-    const callbacks = this.listeners[event];
-    if (callbacks) {
-      callbacks.forEach((callback) => callback(data));
-    }
-  }
+    'user:created': { id: string; name: string }
+    'user:updated': { id: string }
+    'user:deleted': { id: string }
 }
 
-const emitter = new TypedEventEmitter<EventMap>();
+class TypedEventEmitter<T extends Record<string, any>> {
+    private listeners: {
+        [K in keyof T]?: Array<(data: T[K]) => void>
+    } = {}
 
-emitter.on("user:created", (data) => {
-  console.log(data.id, data.name); // Type-safe!
-});
+    on<K extends keyof T>(event: K, callback: (data: T[K]) => void): void {
+        if (!this.listeners[event]) {
+            this.listeners[event] = []
+        }
+        this.listeners[event]!.push(callback)
+    }
 
-emitter.emit("user:created", { id: "1", name: "John" });
+    emit<K extends keyof T>(event: K, data: T[K]): void {
+        const callbacks = this.listeners[event]
+        if (callbacks) {
+            callbacks.forEach(callback => callback(data))
+        }
+    }
+}
+
+const emitter = new TypedEventEmitter<EventMap>()
+
+emitter.on('user:created', data => {
+    console.log(data.id, data.name) // Type-safe!
+})
+
+emitter.emit('user:created', { id: '1', name: 'John' })
 // emitter.emit("user:created", { id: "1" });  // Error: missing 'name'
 ```
 
 ### Pattern 2: Type-Safe API Client
 
 ```typescript
-type HTTPMethod = "GET" | "POST" | "PUT" | "DELETE";
+type HTTPMethod = 'GET' | 'POST' | 'PUT' | 'DELETE'
 
 type EndpointConfig = {
-  "/users": {
-    GET: { response: User[] };
-    POST: { body: { name: string; email: string }; response: User };
-  };
-  "/users/:id": {
-    GET: { params: { id: string }; response: User };
-    PUT: { params: { id: string }; body: Partial<User>; response: User };
-    DELETE: { params: { id: string }; response: void };
-  };
-};
-
-type ExtractParams<T> = T extends { params: infer P } ? P : never;
-type ExtractBody<T> = T extends { body: infer B } ? B : never;
-type ExtractResponse<T> = T extends { response: infer R } ? R : never;
-
-class APIClient<Config extends Record<string, Record<HTTPMethod, any>>> {
-  async request<Path extends keyof Config, Method extends keyof Config[Path]>(
-    path: Path,
-    method: Method,
-    ...[options]: ExtractParams<Config[Path][Method]> extends never
-      ? ExtractBody<Config[Path][Method]> extends never
-        ? []
-        : [{ body: ExtractBody<Config[Path][Method]> }]
-      : [
-          {
-            params: ExtractParams<Config[Path][Method]>;
-            body?: ExtractBody<Config[Path][Method]>;
-          },
-        ]
-  ): Promise<ExtractResponse<Config[Path][Method]>> {
-    // Implementation here
-    return {} as any;
-  }
+    '/users': {
+        GET: { response: User[] }
+        POST: { body: { name: string; email: string }; response: User }
+    }
+    '/users/:id': {
+        GET: { params: { id: string }; response: User }
+        PUT: { params: { id: string }; body: Partial<User>; response: User }
+        DELETE: { params: { id: string }; response: void }
+    }
 }
 
-const api = new APIClient<EndpointConfig>();
+type ExtractParams<T> = T extends { params: infer P } ? P : never
+type ExtractBody<T> = T extends { body: infer B } ? B : never
+type ExtractResponse<T> = T extends { response: infer R } ? R : never
+
+class APIClient<Config extends Record<string, Record<HTTPMethod, any>>> {
+    async request<Path extends keyof Config, Method extends keyof Config[Path]>(
+        path: Path,
+        method: Method,
+        ...[options]: ExtractParams<Config[Path][Method]> extends never ?
+            ExtractBody<Config[Path][Method]> extends never ?
+                []
+            :   [{ body: ExtractBody<Config[Path][Method]> }]
+        :   [
+                {
+                    params: ExtractParams<Config[Path][Method]>
+                    body?: ExtractBody<Config[Path][Method]>
+                },
+            ]
+    ): Promise<ExtractResponse<Config[Path][Method]>> {
+        // Implementation here
+        return {} as any
+    }
+}
+
+const api = new APIClient<EndpointConfig>()
 
 // Type-safe API calls
-const users = await api.request("/users", "GET");
+const users = await api.request('/users', 'GET')
 // Type: User[]
 
-const newUser = await api.request("/users", "POST", {
-  body: { name: "John", email: "john@example.com" },
-});
+const newUser = await api.request('/users', 'POST', {
+    body: { name: 'John', email: 'john@example.com' },
+})
 // Type: User
 
-const user = await api.request("/users/:id", "GET", {
-  params: { id: "123" },
-});
+const user = await api.request('/users/:id', 'GET', {
+    params: { id: '123' },
+})
 // Type: User
 ```
 
@@ -364,51 +362,54 @@ const user = await api.request("/users/:id", "GET", {
 
 ```typescript
 type BuilderState<T> = {
-  [K in keyof T]: T[K] | undefined;
-};
+    [K in keyof T]: T[K] | undefined
+}
 
 type RequiredKeys<T> = {
-  [K in keyof T]-?: {} extends Pick<T, K> ? never : K;
-}[keyof T];
+    [K in keyof T]-?: {} extends Pick<T, K> ? never : K
+}[keyof T]
 
 type OptionalKeys<T> = {
-  [K in keyof T]-?: {} extends Pick<T, K> ? K : never;
-}[keyof T];
+    [K in keyof T]-?: {} extends Pick<T, K> ? K : never
+}[keyof T]
 
 type IsComplete<T, S> =
-  RequiredKeys<T> extends keyof S
-    ? S[RequiredKeys<T>] extends undefined
-      ? false
-      : true
-    : false;
+    RequiredKeys<T> extends keyof S ?
+        S[RequiredKeys<T>] extends undefined ?
+            false
+        :   true
+    :   false
 
 class Builder<T, S extends BuilderState<T> = {}> {
-  private state: S = {} as S;
+    private state: S = {} as S
 
-  set<K extends keyof T>(key: K, value: T[K]): Builder<T, S & Record<K, T[K]>> {
-    this.state[key] = value;
-    return this as any;
-  }
+    set<K extends keyof T>(
+        key: K,
+        value: T[K],
+    ): Builder<T, S & Record<K, T[K]>> {
+        this.state[key] = value
+        return this as any
+    }
 
-  build(this: IsComplete<T, S> extends true ? this : never): T {
-    return this.state as T;
-  }
+    build(this: IsComplete<T, S> extends true ? this : never): T {
+        return this.state as T
+    }
 }
 
 interface User {
-  id: string;
-  name: string;
-  email: string;
-  age?: number;
+    id: string
+    name: string
+    email: string
+    age?: number
 }
 
-const builder = new Builder<User>();
+const builder = new Builder<User>()
 
 const user = builder
-  .set("id", "1")
-  .set("name", "John")
-  .set("email", "john@example.com")
-  .build(); // OK: all required fields set
+    .set('id', '1')
+    .set('name', 'John')
+    .set('email', 'john@example.com')
+    .build() // OK: all required fields set
 
 // const incomplete = builder
 //   .set("id", "1")
@@ -419,43 +420,43 @@ const user = builder
 
 ```typescript
 type DeepReadonly<T> = {
-  readonly [P in keyof T]: T[P] extends object
-    ? T[P] extends Function
-      ? T[P]
-      : DeepReadonly<T[P]>
-    : T[P];
-};
-
-type DeepPartial<T> = {
-  [P in keyof T]?: T[P] extends object
-    ? T[P] extends Array<infer U>
-      ? Array<DeepPartial<U>>
-      : DeepPartial<T[P]>
-    : T[P];
-};
-
-interface Config {
-  server: {
-    host: string;
-    port: number;
-    ssl: {
-      enabled: boolean;
-      cert: string;
-    };
-  };
-  database: {
-    url: string;
-    pool: {
-      min: number;
-      max: number;
-    };
-  };
+    readonly [P in keyof T]: T[P] extends object ?
+        T[P] extends Function ?
+            T[P]
+        :   DeepReadonly<T[P]>
+    :   T[P]
 }
 
-type ReadonlyConfig = DeepReadonly<Config>;
+type DeepPartial<T> = {
+    [P in keyof T]?: T[P] extends object ?
+        T[P] extends Array<infer U> ?
+            Array<DeepPartial<U>>
+        :   DeepPartial<T[P]>
+    :   T[P]
+}
+
+interface Config {
+    server: {
+        host: string
+        port: number
+        ssl: {
+            enabled: boolean
+            cert: string
+        }
+    }
+    database: {
+        url: string
+        pool: {
+            min: number
+            max: number
+        }
+    }
+}
+
+type ReadonlyConfig = DeepReadonly<Config>
 // All nested properties are readonly
 
-type PartialConfig = DeepPartial<Config>;
+type PartialConfig = DeepPartial<Config>
 // All nested properties are optional
 ```
 
@@ -463,77 +464,77 @@ type PartialConfig = DeepPartial<Config>;
 
 ```typescript
 type ValidationRule<T> = {
-  validate: (value: T) => boolean;
-  message: string;
-};
+    validate: (value: T) => boolean
+    message: string
+}
 
 type FieldValidation<T> = {
-  [K in keyof T]?: ValidationRule<T[K]>[];
-};
+    [K in keyof T]?: ValidationRule<T[K]>[]
+}
 
 type ValidationErrors<T> = {
-  [K in keyof T]?: string[];
-};
+    [K in keyof T]?: string[]
+}
 
 class FormValidator<T extends Record<string, any>> {
-  constructor(private rules: FieldValidation<T>) {}
+    constructor(private rules: FieldValidation<T>) {}
 
-  validate(data: T): ValidationErrors<T> | null {
-    const errors: ValidationErrors<T> = {};
-    let hasErrors = false;
+    validate(data: T): ValidationErrors<T> | null {
+        const errors: ValidationErrors<T> = {}
+        let hasErrors = false
 
-    for (const key in this.rules) {
-      const fieldRules = this.rules[key];
-      const value = data[key];
+        for (const key in this.rules) {
+            const fieldRules = this.rules[key]
+            const value = data[key]
 
-      if (fieldRules) {
-        const fieldErrors: string[] = [];
+            if (fieldRules) {
+                const fieldErrors: string[] = []
 
-        for (const rule of fieldRules) {
-          if (!rule.validate(value)) {
-            fieldErrors.push(rule.message);
-          }
+                for (const rule of fieldRules) {
+                    if (!rule.validate(value)) {
+                        fieldErrors.push(rule.message)
+                    }
+                }
+
+                if (fieldErrors.length > 0) {
+                    errors[key] = fieldErrors
+                    hasErrors = true
+                }
+            }
         }
 
-        if (fieldErrors.length > 0) {
-          errors[key] = fieldErrors;
-          hasErrors = true;
-        }
-      }
+        return hasErrors ? errors : null
     }
-
-    return hasErrors ? errors : null;
-  }
 }
 
 interface LoginForm {
-  email: string;
-  password: string;
+    email: string
+    password: string
 }
 
 const validator = new FormValidator<LoginForm>({
-  email: [
-    {
-      validate: (v) => v.includes("@"),
-      message: "Email must contain @",
-    },
-    {
-      validate: (v) => v.length > 0,
-      message: "Email is required",
-    },
-  ],
-  password: [
-    {
-      validate: (v) => v.length >= 8,
-      message: "Password must be at least 8 characters",
-    },
-  ],
-});
+    email: [
+        {
+            validate: v => v.includes('@'),
+            message: 'Email must contain @',
+        },
+        {
+            validate: v => v.length > 0,
+            message: 'Email is required',
+        },
+    ],
+    password: [
+        {
+            validate: v => v.length >= 8,
+            message: 'Password must be at least 8 characters',
+        },
+    ],
+})
 
 const errors = validator.validate({
-  email: "invalid",
-  password: "short",
-});
+    email: 'invalid',
+    password: 'short',
+})
 // Type: { email?: string[]; password?: string[]; } | null
 ```
 
@@ -541,66 +542,66 @@ const errors = validator.validate({
 
 ```typescript
 type Success<T> = {
-  status: "success";
-  data: T;
-};
+    status: 'success'
+    data: T
+}
 
 type Error = {
-  status: "error";
-  error: string;
-};
+    status: 'error'
+    error: string
+}
 
 type Loading = {
-  status: "loading";
-};
+    status: 'loading'
+}
 
-type AsyncState<T> = Success<T> | Error | Loading;
+type AsyncState<T> = Success<T> | Error | Loading
 
 function handleState<T>(state: AsyncState<T>): void {
-  switch (state.status) {
-    case "success":
-      console.log(state.data); // Type: T
-      break;
-    case "error":
-      console.log(state.error); // Type: string
-      break;
-    case "loading":
-      console.log("Loading...");
-      break;
-  }
+    switch (state.status) {
+        case 'success':
+            console.log(state.data) // Type: T
+            break
+        case 'error':
+            console.log(state.error) // Type: string
+            break
+        case 'loading':
+            console.log('Loading...')
+            break
+    }
 }
 
 // Type-safe state machine
 type State =
-  | { type: "idle" }
-  | { type: "fetching"; requestId: string }
-  | { type: "success"; data: any }
-  | { type: "error"; error: Error };
+    | { type: 'idle' }
+    | { type: 'fetching'; requestId: string }
+    | { type: 'success'; data: any }
+    | { type: 'error'; error: Error }
 
 type Event =
-  | { type: "FETCH"; requestId: string }
-  | { type: "SUCCESS"; data: any }
-  | { type: "ERROR"; error: Error }
-  | { type: "RESET" };
+    | { type: 'FETCH'; requestId: string }
+    | { type: 'SUCCESS'; data: any }
+    | { type: 'ERROR'; error: Error }
+    | { type: 'RESET' }
 
 function reducer(state: State, event: Event): State {
-  switch (state.type) {
-    case "idle":
-      return event.type === "FETCH"
-        ? { type: "fetching", requestId: event.requestId }
-        : state;
-    case "fetching":
-      if (event.type === "SUCCESS") {
-        return { type: "success", data: event.data };
-      }
-      if (event.type === "ERROR") {
-        return { type: "error", error: event.error };
-      }
-      return state;
-    case "success":
-    case "error":
-      return event.type === "RESET" ? { type: "idle" } : state;
-  }
+    switch (state.type) {
+        case 'idle':
+            return event.type === 'FETCH' ?
+                    { type: 'fetching', requestId: event.requestId }
+                :   state
+        case 'fetching':
+            if (event.type === 'SUCCESS') {
+                return { type: 'success', data: event.data }
+            }
+            if (event.type === 'ERROR') {
+                return { type: 'error', error: event.error }
+            }
+            return state
+        case 'success':
+        case 'error':
+            return event.type === 'RESET' ? { type: 'idle' } : state
+    }
 }
 ```
 
@@ -610,41 +611,41 @@ function reducer(state: State, event: Event): State {
 
 ```typescript
 // Extract array element type
-type ElementType<T> = T extends (infer U)[] ? U : never;
+type ElementType<T> = T extends (infer U)[] ? U : never
 
-type NumArray = number[];
-type Num = ElementType<NumArray>; // number
+type NumArray = number[]
+type Num = ElementType<NumArray> // number
 
 // Extract promise type
-type PromiseType<T> = T extends Promise<infer U> ? U : never;
+type PromiseType<T> = T extends Promise<infer U> ? U : never
 
-type AsyncNum = PromiseType<Promise<number>>; // number
+type AsyncNum = PromiseType<Promise<number>> // number
 
 // Extract function parameters
-type Parameters<T> = T extends (...args: infer P) => any ? P : never;
+type Parameters<T> = T extends (...args: infer P) => any ? P : never
 
 function foo(a: string, b: number) {}
-type FooParams = Parameters<typeof foo>; // [string, number]
+type FooParams = Parameters<typeof foo> // [string, number]
 ```
 
 ### 2. Type Guards
 
 ```typescript
 function isString(value: unknown): value is string {
-  return typeof value === "string";
+    return typeof value === 'string'
 }
 
 function isArrayOf<T>(
-  value: unknown,
-  guard: (item: unknown) => item is T,
+    value: unknown,
+    guard: (item: unknown) => item is T,
 ): value is T[] {
-  return Array.isArray(value) && value.every(guard);
+    return Array.isArray(value) && value.every(guard)
 }
 
-const data: unknown = ["a", "b", "c"];
+const data: unknown = ['a', 'b', 'c']
 
 if (isArrayOf(data, isString)) {
-  data.forEach((s) => s.toUpperCase()); // Type: string[]
+    data.forEach(s => s.toUpperCase()) // Type: string[]
 }
 ```
 
@@ -652,15 +653,15 @@ if (isArrayOf(data, isString)) {
 
 ```typescript
 function assertIsString(value: unknown): asserts value is string {
-  if (typeof value !== "string") {
-    throw new Error("Not a string");
-  }
+    if (typeof value !== 'string') {
+        throw new Error('Not a string')
+    }
 }
 
 function processValue(value: unknown) {
-  assertIsString(value);
-  // value is now typed as string
-  console.log(value.toUpperCase());
+    assertIsString(value)
+    // value is now typed as string
+    console.log(value.toUpperCase())
 }
 ```
 
@@ -681,21 +682,22 @@ function processValue(value: unknown) {
 
 ```typescript
 // Type assertion tests
-type AssertEqual<T, U> = [T] extends [U]
-  ? [U] extends [T]
-    ? true
-    : false
-  : false;
+type AssertEqual<T, U> =
+    [T] extends [U] ?
+        [U] extends [T] ?
+            true
+        :   false
+    :   false
 
-type Test1 = AssertEqual<string, string>; // true
-type Test2 = AssertEqual<string, number>; // false
-type Test3 = AssertEqual<string | number, string>; // false
+type Test1 = AssertEqual<string, string> // true
+type Test2 = AssertEqual<string, number> // false
+type Test3 = AssertEqual<string | number, string> // false
 
 // Expect error helper
-type ExpectError<T extends never> = T;
+type ExpectError<T extends never> = T
 
 // Example usage
-type ShouldError = ExpectError<AssertEqual<string, number>>;
+type ShouldError = ExpectError<AssertEqual<string, number>>
 ```
 
 ## Common Pitfalls

--- a/.agents/skills/zod/AGENTS.md
+++ b/.agents/skills/zod/AGENTS.md
@@ -1,0 +1,97 @@
+# Zod
+
+**Version 1.0.0**  
+community  
+January 2026
+
+> **Note:**  
+> This document is mainly for agents and LLMs to follow when maintaining,  
+> generating, or refactoring codebases. Humans may also find it useful,  
+> but guidance here is optimized for automation and consistency by AI-assisted workflows.
+
+---
+
+## Abstract
+
+Comprehensive schema validation guide for Zod in TypeScript applications, designed for AI agents and LLMs. Contains 43 rules across 8 categories, prioritized by impact from critical (schema definition, parsing) to incremental (performance, bundle optimization). Each rule includes detailed explanations, real-world examples comparing incorrect vs. correct implementations, and specific impact metrics to guide automated refactoring and code generation.
+
+---
+
+## Table of Contents
+
+1. [Schema Definition](references/_sections.md#1-schema-definition) — **CRITICAL**
+   - 1.1 [Apply String Validations at Schema Definition](references/schema-string-validations.md) — CRITICAL (Unvalidated strings allow SQL injection, XSS, and malformed data; validating at schema level catches issues at the boundary)
+   - 1.2 [Avoid Overusing Optional Fields](references/schema-avoid-optional-abuse.md) — CRITICAL (Excessive optional fields create schemas that accept almost anything; forces null checks throughout codebase)
+   - 1.3 [Use Coercion for Form and Query Data](references/schema-coercion-for-form-data.md) — CRITICAL (Form data and query params are always strings; without coercion, z.number() rejects "42" and z.boolean() rejects "true")
+   - 1.4 [Use Enums for Fixed String Values](references/schema-use-enums.md) — CRITICAL (Plain strings accept any value including typos; enums restrict to valid values and enable autocomplete)
+   - 1.5 [Use Primitive Schemas Correctly](references/schema-use-primitives-correctly.md) — CRITICAL (Incorrect primitive selection causes validation to pass on wrong types; using z.any() or z.unknown() loses all type safety)
+   - 1.6 [Use z.unknown() Instead of z.any()](references/schema-use-unknown-not-any.md) — CRITICAL (z.any() bypasses TypeScript's type system entirely; z.unknown() forces type narrowing before use)
+2. [Parsing & Validation](references/_sections.md#2-parsing-&-validation) — **CRITICAL**
+   - 2.1 [Avoid Double Validation](references/parse-avoid-double-validation.md) — HIGH (Parsing the same data twice wastes CPU cycles; in hot paths this adds measurable latency)
+   - 2.2 [Handle All Validation Issues Not Just First](references/parse-handle-all-issues.md) — CRITICAL (Showing only the first error forces users to fix-submit-fix repeatedly; collecting all errors improves UX dramatically)
+   - 2.3 [Never Trust JSON.parse Output](references/parse-never-trust-json.md) — CRITICAL (JSON.parse returns any type; unvalidated JSON allows type confusion attacks and runtime crashes)
+   - 2.4 [Use parseAsync for Async Refinements](references/parse-async-for-async-refinements.md) — CRITICAL (Using parse() with async refinements throws an error; async validation silently fails or crashes the application)
+   - 2.5 [Use safeParse() for User Input](references/parse-use-safeparse.md) — CRITICAL (parse() throws exceptions on invalid data; unhandled exceptions crash servers and expose stack traces to users)
+   - 2.6 [Validate at System Boundaries](references/parse-validate-early.md) — CRITICAL (Validating deep in business logic allows corrupt data to propagate; validating at boundaries catches issues before they spread)
+3. [Type Inference](references/_sections.md#3-type-inference) — **HIGH**
+   - 3.1 [Distinguish z.input from z.infer for Transforms](references/type-input-vs-output.md) — HIGH (Using wrong type with transforms causes TypeScript errors; z.input captures pre-transform shape, z.infer captures post-transform)
+   - 3.2 [Enable TypeScript Strict Mode](references/type-enable-strict-mode.md) — HIGH (Without strict mode, Zod's type inference is unreliable; undefined and null slip through, defeating the purpose of validation)
+   - 3.3 [Export Both Schemas and Inferred Types](references/type-export-schemas-and-types.md) — HIGH (Exporting only schemas forces consumers to derive types themselves; exporting both reduces boilerplate and improves DX)
+   - 3.4 [Use Branded Types for Domain Safety](references/type-branded-types.md) — HIGH (Plain string IDs are interchangeable, allowing userId where orderId is expected; branded types catch these bugs at compile time)
+   - 3.5 [Use z.infer Instead of Manual Types](references/type-use-z-infer.md) — HIGH (Manual type definitions drift from schemas over time; z.infer guarantees types match validation exactly)
+4. [Error Handling](references/_sections.md#4-error-handling) — **HIGH**
+   - 4.1 [Implement Internationalized Error Messages](references/error-i18n.md) — HIGH (Hardcoded English messages exclude non-English users; error maps enable localized messages for global applications)
+   - 4.2 [Provide Custom Error Messages](references/error-custom-messages.md) — HIGH (Default messages like "Expected string, received number" confuse users; custom messages like "Email is required" are actionable)
+   - 4.3 [Return False Instead of Throwing in Refine](references/error-avoid-throwing-in-refine.md) — HIGH (Throwing in refine stops validation early, hiding other errors; returning false allows Zod to collect all issues)
+   - 4.4 [Use flatten() for Form Error Display](references/error-use-flatten.md) — HIGH (Raw ZodError.issues requires manual path parsing; flatten() provides field-keyed errors ready for form display)
+   - 4.5 [Use issue.path for Nested Error Location](references/error-path-for-nested.md) — HIGH (Without path information, users can't identify which nested field failed; path provides exact location in complex objects)
+5. [Object Schemas](references/_sections.md#5-object-schemas) — **MEDIUM-HIGH**
+   - 5.1 [Choose strict() vs strip() for Unknown Keys](references/object-strict-vs-strip.md) — MEDIUM-HIGH (Default passthrough mode leaks unexpected data; strict() catches schema mismatches, strip() silently removes extras)
+   - 5.2 [Distinguish optional() from nullable()](references/object-optional-vs-nullable.md) — MEDIUM-HIGH (Confusing undefined and null semantics causes "property does not exist" vs "property is null" bugs; choose deliberately)
+   - 5.3 [Use Discriminated Unions for Type Narrowing](references/object-discriminated-unions.md) — MEDIUM-HIGH (Regular unions require manual type guards; discriminated unions enable TypeScript's automatic narrowing and Zod's optimized parsing)
+   - 5.4 [Use extend() for Adding Fields](references/object-extend-for-composition.md) — MEDIUM-HIGH (Merging objects manually loses type information; extend() preserves types and allows overriding fields safely)
+   - 5.5 [Use partial() for Update Schemas](references/object-partial-for-updates.md) — MEDIUM-HIGH (Creating separate update schemas duplicates definitions; partial() derives update schema from base, staying in sync)
+   - 5.6 [Use pick() and omit() for Schema Variants](references/object-pick-omit.md) — MEDIUM-HIGH (Copying fields between schemas creates duplication; pick/omit derive variants that stay in sync with base schema)
+6. [Schema Composition](references/_sections.md#6-schema-composition) — **MEDIUM**
+   - 6.1 [Extract Shared Schemas into Reusable Modules](references/compose-shared-schemas.md) — MEDIUM (Duplicating schemas across files leads to inconsistency; shared schemas ensure single source of truth)
+   - 6.2 [Use intersection() for Type Combinations](references/compose-intersection.md) — MEDIUM (Manual field combination loses type relationships; intersection creates proper TypeScript intersection types)
+   - 6.3 [Use pipe() for Multi-Stage Validation](references/compose-pipe.md) — MEDIUM (Chaining transforms loses intermediate type info; pipe() explicitly shows data flow through validation stages)
+   - 6.4 [Use preprocess() for Data Normalization](references/compose-preprocess.md) — MEDIUM (Validating before cleaning data causes false rejections; preprocess() normalizes input before schema validation runs)
+   - 6.5 [Use z.lazy() for Recursive Schemas](references/compose-lazy-recursive.md) — MEDIUM (Recursive types reference themselves before definition; z.lazy() defers evaluation to enable self-referential schemas)
+7. [Refinements & Transforms](references/_sections.md#7-refinements-&-transforms) — **MEDIUM**
+   - 7.1 [Add Path to Refinement Errors](references/refine-add-path.md) — MEDIUM (Errors without path show at object level; adding path highlights the specific field that failed)
+   - 7.2 [Choose refine() vs superRefine() Correctly](references/refine-vs-superrefine.md) — MEDIUM (refine() only reports one error; superRefine() enables multiple issues and custom error codes)
+   - 7.3 [Distinguish transform() from refine() and coerce()](references/refine-transform-coerce.md) — MEDIUM (Using wrong method causes validation to pass with wrong data; each method has distinct purpose)
+   - 7.4 [Use catch() for Fault-Tolerant Parsing](references/refine-catch.md) — MEDIUM (parse() fails on first invalid field; catch() provides fallback values, enabling partial success with degraded data)
+   - 7.5 [Use default() for Optional Fields with Defaults](references/refine-defaults.md) — MEDIUM (Manual default handling spreads logic across codebase; .default() centralizes defaults in schema)
+8. [Performance & Bundle](references/_sections.md#8-performance-&-bundle) — **LOW-MEDIUM**
+   - 8.1 [Avoid Dynamic Schema Creation in Hot Paths](references/perf-avoid-dynamic-creation.md) — LOW-MEDIUM (Zod 4's JIT compilation makes schema creation slower; creating schemas in loops adds ~0.15ms per creation)
+   - 8.2 [Cache Schema Instances](references/perf-cache-schemas.md) — LOW-MEDIUM (Creating schemas on every render/call wastes CPU; module-level or memoized schemas are created once)
+   - 8.3 [Lazy Load Large Schemas](references/perf-lazy-loading.md) — LOW-MEDIUM (Large schemas increase initial bundle and parse time; dynamic imports defer loading until needed)
+   - 8.4 [Optimize Large Array Validation](references/perf-arrays.md) — LOW-MEDIUM (Validating 10,000 items takes ~100ms; early exits, sampling, or batching reduce time for large datasets)
+   - 8.5 [Use Zod Mini for Bundle-Sensitive Applications](references/perf-zod-mini.md) — LOW-MEDIUM (Full Zod is ~17kb gzipped; Zod Mini is ~1.9kb - 85% smaller for frontend-critical bundles)
+
+---
+
+## References
+
+1. [https://zod.dev/](https://zod.dev/)
+2. [https://zod.dev/v4](https://zod.dev/v4)
+3. [https://github.com/colinhacks/zod](https://github.com/colinhacks/zod)
+4. [https://zod.dev/packages/mini](https://zod.dev/packages/mini)
+5. [https://www.totaltypescript.com/tutorials/zod](https://www.totaltypescript.com/tutorials/zod)
+6. [https://zod.dev/error-handling](https://zod.dev/error-handling)
+7. [https://zod.dev/api](https://zod.dev/api)
+
+---
+
+## Source Files
+
+This document was compiled from individual reference files. For detailed editing or extension:
+
+| File | Description |
+|------|-------------|
+| [references/_sections.md](references/_sections.md) | Category definitions and impact ordering |
+| [assets/templates/_template.md](assets/templates/_template.md) | Template for creating new rules |
+| [SKILL.md](SKILL.md) | Quick reference entry point |
+| [metadata.json](metadata.json) | Version and reference URLs |

--- a/.agents/skills/zod/AGENTS.md
+++ b/.agents/skills/zod/AGENTS.md
@@ -20,56 +20,56 @@ Comprehensive schema validation guide for Zod in TypeScript applications, design
 ## Table of Contents
 
 1. [Schema Definition](references/_sections.md#1-schema-definition) — **CRITICAL**
-   - 1.1 [Apply String Validations at Schema Definition](references/schema-string-validations.md) — CRITICAL (Unvalidated strings allow SQL injection, XSS, and malformed data; validating at schema level catches issues at the boundary)
-   - 1.2 [Avoid Overusing Optional Fields](references/schema-avoid-optional-abuse.md) — CRITICAL (Excessive optional fields create schemas that accept almost anything; forces null checks throughout codebase)
-   - 1.3 [Use Coercion for Form and Query Data](references/schema-coercion-for-form-data.md) — CRITICAL (Form data and query params are always strings; without coercion, z.number() rejects "42" and z.boolean() rejects "true")
-   - 1.4 [Use Enums for Fixed String Values](references/schema-use-enums.md) — CRITICAL (Plain strings accept any value including typos; enums restrict to valid values and enable autocomplete)
-   - 1.5 [Use Primitive Schemas Correctly](references/schema-use-primitives-correctly.md) — CRITICAL (Incorrect primitive selection causes validation to pass on wrong types; using z.any() or z.unknown() loses all type safety)
-   - 1.6 [Use z.unknown() Instead of z.any()](references/schema-use-unknown-not-any.md) — CRITICAL (z.any() bypasses TypeScript's type system entirely; z.unknown() forces type narrowing before use)
+    - 1.1 [Apply String Validations at Schema Definition](references/schema-string-validations.md) — CRITICAL (Unvalidated strings allow SQL injection, XSS, and malformed data; validating at schema level catches issues at the boundary)
+    - 1.2 [Avoid Overusing Optional Fields](references/schema-avoid-optional-abuse.md) — CRITICAL (Excessive optional fields create schemas that accept almost anything; forces null checks throughout codebase)
+    - 1.3 [Use Coercion for Form and Query Data](references/schema-coercion-for-form-data.md) — CRITICAL (Form data and query params are always strings; without coercion, z.number() rejects "42" and z.boolean() rejects "true")
+    - 1.4 [Use Enums for Fixed String Values](references/schema-use-enums.md) — CRITICAL (Plain strings accept any value including typos; enums restrict to valid values and enable autocomplete)
+    - 1.5 [Use Primitive Schemas Correctly](references/schema-use-primitives-correctly.md) — CRITICAL (Incorrect primitive selection causes validation to pass on wrong types; using z.any() or z.unknown() loses all type safety)
+    - 1.6 [Use z.unknown() Instead of z.any()](references/schema-use-unknown-not-any.md) — CRITICAL (z.any() bypasses TypeScript's type system entirely; z.unknown() forces type narrowing before use)
 2. [Parsing & Validation](references/_sections.md#2-parsing-&-validation) — **CRITICAL**
-   - 2.1 [Avoid Double Validation](references/parse-avoid-double-validation.md) — HIGH (Parsing the same data twice wastes CPU cycles; in hot paths this adds measurable latency)
-   - 2.2 [Handle All Validation Issues Not Just First](references/parse-handle-all-issues.md) — CRITICAL (Showing only the first error forces users to fix-submit-fix repeatedly; collecting all errors improves UX dramatically)
-   - 2.3 [Never Trust JSON.parse Output](references/parse-never-trust-json.md) — CRITICAL (JSON.parse returns any type; unvalidated JSON allows type confusion attacks and runtime crashes)
-   - 2.4 [Use parseAsync for Async Refinements](references/parse-async-for-async-refinements.md) — CRITICAL (Using parse() with async refinements throws an error; async validation silently fails or crashes the application)
-   - 2.5 [Use safeParse() for User Input](references/parse-use-safeparse.md) — CRITICAL (parse() throws exceptions on invalid data; unhandled exceptions crash servers and expose stack traces to users)
-   - 2.6 [Validate at System Boundaries](references/parse-validate-early.md) — CRITICAL (Validating deep in business logic allows corrupt data to propagate; validating at boundaries catches issues before they spread)
+    - 2.1 [Avoid Double Validation](references/parse-avoid-double-validation.md) — HIGH (Parsing the same data twice wastes CPU cycles; in hot paths this adds measurable latency)
+    - 2.2 [Handle All Validation Issues Not Just First](references/parse-handle-all-issues.md) — CRITICAL (Showing only the first error forces users to fix-submit-fix repeatedly; collecting all errors improves UX dramatically)
+    - 2.3 [Never Trust JSON.parse Output](references/parse-never-trust-json.md) — CRITICAL (JSON.parse returns any type; unvalidated JSON allows type confusion attacks and runtime crashes)
+    - 2.4 [Use parseAsync for Async Refinements](references/parse-async-for-async-refinements.md) — CRITICAL (Using parse() with async refinements throws an error; async validation silently fails or crashes the application)
+    - 2.5 [Use safeParse() for User Input](references/parse-use-safeparse.md) — CRITICAL (parse() throws exceptions on invalid data; unhandled exceptions crash servers and expose stack traces to users)
+    - 2.6 [Validate at System Boundaries](references/parse-validate-early.md) — CRITICAL (Validating deep in business logic allows corrupt data to propagate; validating at boundaries catches issues before they spread)
 3. [Type Inference](references/_sections.md#3-type-inference) — **HIGH**
-   - 3.1 [Distinguish z.input from z.infer for Transforms](references/type-input-vs-output.md) — HIGH (Using wrong type with transforms causes TypeScript errors; z.input captures pre-transform shape, z.infer captures post-transform)
-   - 3.2 [Enable TypeScript Strict Mode](references/type-enable-strict-mode.md) — HIGH (Without strict mode, Zod's type inference is unreliable; undefined and null slip through, defeating the purpose of validation)
-   - 3.3 [Export Both Schemas and Inferred Types](references/type-export-schemas-and-types.md) — HIGH (Exporting only schemas forces consumers to derive types themselves; exporting both reduces boilerplate and improves DX)
-   - 3.4 [Use Branded Types for Domain Safety](references/type-branded-types.md) — HIGH (Plain string IDs are interchangeable, allowing userId where orderId is expected; branded types catch these bugs at compile time)
-   - 3.5 [Use z.infer Instead of Manual Types](references/type-use-z-infer.md) — HIGH (Manual type definitions drift from schemas over time; z.infer guarantees types match validation exactly)
+    - 3.1 [Distinguish z.input from z.infer for Transforms](references/type-input-vs-output.md) — HIGH (Using wrong type with transforms causes TypeScript errors; z.input captures pre-transform shape, z.infer captures post-transform)
+    - 3.2 [Enable TypeScript Strict Mode](references/type-enable-strict-mode.md) — HIGH (Without strict mode, Zod's type inference is unreliable; undefined and null slip through, defeating the purpose of validation)
+    - 3.3 [Export Both Schemas and Inferred Types](references/type-export-schemas-and-types.md) — HIGH (Exporting only schemas forces consumers to derive types themselves; exporting both reduces boilerplate and improves DX)
+    - 3.4 [Use Branded Types for Domain Safety](references/type-branded-types.md) — HIGH (Plain string IDs are interchangeable, allowing userId where orderId is expected; branded types catch these bugs at compile time)
+    - 3.5 [Use z.infer Instead of Manual Types](references/type-use-z-infer.md) — HIGH (Manual type definitions drift from schemas over time; z.infer guarantees types match validation exactly)
 4. [Error Handling](references/_sections.md#4-error-handling) — **HIGH**
-   - 4.1 [Implement Internationalized Error Messages](references/error-i18n.md) — HIGH (Hardcoded English messages exclude non-English users; error maps enable localized messages for global applications)
-   - 4.2 [Provide Custom Error Messages](references/error-custom-messages.md) — HIGH (Default messages like "Expected string, received number" confuse users; custom messages like "Email is required" are actionable)
-   - 4.3 [Return False Instead of Throwing in Refine](references/error-avoid-throwing-in-refine.md) — HIGH (Throwing in refine stops validation early, hiding other errors; returning false allows Zod to collect all issues)
-   - 4.4 [Use flatten() for Form Error Display](references/error-use-flatten.md) — HIGH (Raw ZodError.issues requires manual path parsing; flatten() provides field-keyed errors ready for form display)
-   - 4.5 [Use issue.path for Nested Error Location](references/error-path-for-nested.md) — HIGH (Without path information, users can't identify which nested field failed; path provides exact location in complex objects)
+    - 4.1 [Implement Internationalized Error Messages](references/error-i18n.md) — HIGH (Hardcoded English messages exclude non-English users; error maps enable localized messages for global applications)
+    - 4.2 [Provide Custom Error Messages](references/error-custom-messages.md) — HIGH (Default messages like "Expected string, received number" confuse users; custom messages like "Email is required" are actionable)
+    - 4.3 [Return False Instead of Throwing in Refine](references/error-avoid-throwing-in-refine.md) — HIGH (Throwing in refine stops validation early, hiding other errors; returning false allows Zod to collect all issues)
+    - 4.4 [Use flatten() for Form Error Display](references/error-use-flatten.md) — HIGH (Raw ZodError.issues requires manual path parsing; flatten() provides field-keyed errors ready for form display)
+    - 4.5 [Use issue.path for Nested Error Location](references/error-path-for-nested.md) — HIGH (Without path information, users can't identify which nested field failed; path provides exact location in complex objects)
 5. [Object Schemas](references/_sections.md#5-object-schemas) — **MEDIUM-HIGH**
-   - 5.1 [Choose strict() vs strip() for Unknown Keys](references/object-strict-vs-strip.md) — MEDIUM-HIGH (Default passthrough mode leaks unexpected data; strict() catches schema mismatches, strip() silently removes extras)
-   - 5.2 [Distinguish optional() from nullable()](references/object-optional-vs-nullable.md) — MEDIUM-HIGH (Confusing undefined and null semantics causes "property does not exist" vs "property is null" bugs; choose deliberately)
-   - 5.3 [Use Discriminated Unions for Type Narrowing](references/object-discriminated-unions.md) — MEDIUM-HIGH (Regular unions require manual type guards; discriminated unions enable TypeScript's automatic narrowing and Zod's optimized parsing)
-   - 5.4 [Use extend() for Adding Fields](references/object-extend-for-composition.md) — MEDIUM-HIGH (Merging objects manually loses type information; extend() preserves types and allows overriding fields safely)
-   - 5.5 [Use partial() for Update Schemas](references/object-partial-for-updates.md) — MEDIUM-HIGH (Creating separate update schemas duplicates definitions; partial() derives update schema from base, staying in sync)
-   - 5.6 [Use pick() and omit() for Schema Variants](references/object-pick-omit.md) — MEDIUM-HIGH (Copying fields between schemas creates duplication; pick/omit derive variants that stay in sync with base schema)
+    - 5.1 [Choose strict() vs strip() for Unknown Keys](references/object-strict-vs-strip.md) — MEDIUM-HIGH (Default passthrough mode leaks unexpected data; strict() catches schema mismatches, strip() silently removes extras)
+    - 5.2 [Distinguish optional() from nullable()](references/object-optional-vs-nullable.md) — MEDIUM-HIGH (Confusing undefined and null semantics causes "property does not exist" vs "property is null" bugs; choose deliberately)
+    - 5.3 [Use Discriminated Unions for Type Narrowing](references/object-discriminated-unions.md) — MEDIUM-HIGH (Regular unions require manual type guards; discriminated unions enable TypeScript's automatic narrowing and Zod's optimized parsing)
+    - 5.4 [Use extend() for Adding Fields](references/object-extend-for-composition.md) — MEDIUM-HIGH (Merging objects manually loses type information; extend() preserves types and allows overriding fields safely)
+    - 5.5 [Use partial() for Update Schemas](references/object-partial-for-updates.md) — MEDIUM-HIGH (Creating separate update schemas duplicates definitions; partial() derives update schema from base, staying in sync)
+    - 5.6 [Use pick() and omit() for Schema Variants](references/object-pick-omit.md) — MEDIUM-HIGH (Copying fields between schemas creates duplication; pick/omit derive variants that stay in sync with base schema)
 6. [Schema Composition](references/_sections.md#6-schema-composition) — **MEDIUM**
-   - 6.1 [Extract Shared Schemas into Reusable Modules](references/compose-shared-schemas.md) — MEDIUM (Duplicating schemas across files leads to inconsistency; shared schemas ensure single source of truth)
-   - 6.2 [Use intersection() for Type Combinations](references/compose-intersection.md) — MEDIUM (Manual field combination loses type relationships; intersection creates proper TypeScript intersection types)
-   - 6.3 [Use pipe() for Multi-Stage Validation](references/compose-pipe.md) — MEDIUM (Chaining transforms loses intermediate type info; pipe() explicitly shows data flow through validation stages)
-   - 6.4 [Use preprocess() for Data Normalization](references/compose-preprocess.md) — MEDIUM (Validating before cleaning data causes false rejections; preprocess() normalizes input before schema validation runs)
-   - 6.5 [Use z.lazy() for Recursive Schemas](references/compose-lazy-recursive.md) — MEDIUM (Recursive types reference themselves before definition; z.lazy() defers evaluation to enable self-referential schemas)
+    - 6.1 [Extract Shared Schemas into Reusable Modules](references/compose-shared-schemas.md) — MEDIUM (Duplicating schemas across files leads to inconsistency; shared schemas ensure single source of truth)
+    - 6.2 [Use intersection() for Type Combinations](references/compose-intersection.md) — MEDIUM (Manual field combination loses type relationships; intersection creates proper TypeScript intersection types)
+    - 6.3 [Use pipe() for Multi-Stage Validation](references/compose-pipe.md) — MEDIUM (Chaining transforms loses intermediate type info; pipe() explicitly shows data flow through validation stages)
+    - 6.4 [Use preprocess() for Data Normalization](references/compose-preprocess.md) — MEDIUM (Validating before cleaning data causes false rejections; preprocess() normalizes input before schema validation runs)
+    - 6.5 [Use z.lazy() for Recursive Schemas](references/compose-lazy-recursive.md) — MEDIUM (Recursive types reference themselves before definition; z.lazy() defers evaluation to enable self-referential schemas)
 7. [Refinements & Transforms](references/_sections.md#7-refinements-&-transforms) — **MEDIUM**
-   - 7.1 [Add Path to Refinement Errors](references/refine-add-path.md) — MEDIUM (Errors without path show at object level; adding path highlights the specific field that failed)
-   - 7.2 [Choose refine() vs superRefine() Correctly](references/refine-vs-superrefine.md) — MEDIUM (refine() only reports one error; superRefine() enables multiple issues and custom error codes)
-   - 7.3 [Distinguish transform() from refine() and coerce()](references/refine-transform-coerce.md) — MEDIUM (Using wrong method causes validation to pass with wrong data; each method has distinct purpose)
-   - 7.4 [Use catch() for Fault-Tolerant Parsing](references/refine-catch.md) — MEDIUM (parse() fails on first invalid field; catch() provides fallback values, enabling partial success with degraded data)
-   - 7.5 [Use default() for Optional Fields with Defaults](references/refine-defaults.md) — MEDIUM (Manual default handling spreads logic across codebase; .default() centralizes defaults in schema)
+    - 7.1 [Add Path to Refinement Errors](references/refine-add-path.md) — MEDIUM (Errors without path show at object level; adding path highlights the specific field that failed)
+    - 7.2 [Choose refine() vs superRefine() Correctly](references/refine-vs-superrefine.md) — MEDIUM (refine() only reports one error; superRefine() enables multiple issues and custom error codes)
+    - 7.3 [Distinguish transform() from refine() and coerce()](references/refine-transform-coerce.md) — MEDIUM (Using wrong method causes validation to pass with wrong data; each method has distinct purpose)
+    - 7.4 [Use catch() for Fault-Tolerant Parsing](references/refine-catch.md) — MEDIUM (parse() fails on first invalid field; catch() provides fallback values, enabling partial success with degraded data)
+    - 7.5 [Use default() for Optional Fields with Defaults](references/refine-defaults.md) — MEDIUM (Manual default handling spreads logic across codebase; .default() centralizes defaults in schema)
 8. [Performance & Bundle](references/_sections.md#8-performance-&-bundle) — **LOW-MEDIUM**
-   - 8.1 [Avoid Dynamic Schema Creation in Hot Paths](references/perf-avoid-dynamic-creation.md) — LOW-MEDIUM (Zod 4's JIT compilation makes schema creation slower; creating schemas in loops adds ~0.15ms per creation)
-   - 8.2 [Cache Schema Instances](references/perf-cache-schemas.md) — LOW-MEDIUM (Creating schemas on every render/call wastes CPU; module-level or memoized schemas are created once)
-   - 8.3 [Lazy Load Large Schemas](references/perf-lazy-loading.md) — LOW-MEDIUM (Large schemas increase initial bundle and parse time; dynamic imports defer loading until needed)
-   - 8.4 [Optimize Large Array Validation](references/perf-arrays.md) — LOW-MEDIUM (Validating 10,000 items takes ~100ms; early exits, sampling, or batching reduce time for large datasets)
-   - 8.5 [Use Zod Mini for Bundle-Sensitive Applications](references/perf-zod-mini.md) — LOW-MEDIUM (Full Zod is ~17kb gzipped; Zod Mini is ~1.9kb - 85% smaller for frontend-critical bundles)
+    - 8.1 [Avoid Dynamic Schema Creation in Hot Paths](references/perf-avoid-dynamic-creation.md) — LOW-MEDIUM (Zod 4's JIT compilation makes schema creation slower; creating schemas in loops adds ~0.15ms per creation)
+    - 8.2 [Cache Schema Instances](references/perf-cache-schemas.md) — LOW-MEDIUM (Creating schemas on every render/call wastes CPU; module-level or memoized schemas are created once)
+    - 8.3 [Lazy Load Large Schemas](references/perf-lazy-loading.md) — LOW-MEDIUM (Large schemas increase initial bundle and parse time; dynamic imports defer loading until needed)
+    - 8.4 [Optimize Large Array Validation](references/perf-arrays.md) — LOW-MEDIUM (Validating 10,000 items takes ~100ms; early exits, sampling, or batching reduce time for large datasets)
+    - 8.5 [Use Zod Mini for Bundle-Sensitive Applications](references/perf-zod-mini.md) — LOW-MEDIUM (Full Zod is ~17kb gzipped; Zod Mini is ~1.9kb - 85% smaller for frontend-critical bundles)
 
 ---
 
@@ -89,9 +89,9 @@ Comprehensive schema validation guide for Zod in TypeScript applications, design
 
 This document was compiled from individual reference files. For detailed editing or extension:
 
-| File | Description |
-|------|-------------|
-| [references/_sections.md](references/_sections.md) | Category definitions and impact ordering |
-| [assets/templates/_template.md](assets/templates/_template.md) | Template for creating new rules |
-| [SKILL.md](SKILL.md) | Quick reference entry point |
-| [metadata.json](metadata.json) | Version and reference URLs |
+| File                                                            | Description                              |
+| --------------------------------------------------------------- | ---------------------------------------- |
+| [references/\_sections.md](references/_sections.md)             | Category definitions and impact ordering |
+| [assets/templates/\_template.md](assets/templates/_template.md) | Template for creating new rules          |
+| [SKILL.md](SKILL.md)                                            | Quick reference entry point              |
+| [metadata.json](metadata.json)                                  | Version and reference URLs               |

--- a/.agents/skills/zod/README.md
+++ b/.agents/skills/zod/README.md
@@ -1,0 +1,79 @@
+# Zod Best Practices Skill
+
+A comprehensive guide for using Zod effectively in TypeScript applications. This skill provides 42 rules across 8 categories, organized by impact to help AI agents and developers write better validation code.
+
+## Overview
+
+Zod is a TypeScript-first schema declaration and validation library. This skill covers best practices for:
+
+- **Schema Definition**: Choosing correct types, avoiding `z.any()`, proper string validations
+- **Parsing & Validation**: Using `safeParse()`, async validation, error handling
+- **Type Inference**: Leveraging `z.infer`, distinguishing input/output types
+- **Error Handling**: Custom messages, internationalization, form error display
+- **Object Schemas**: strict/strip modes, partial updates, discriminated unions
+- **Schema Composition**: Reusable schemas, intersections, recursive types
+- **Refinements & Transforms**: Custom validation, data transformation
+- **Performance**: Caching, Zod Mini, lazy loading, batch validation
+
+## Usage
+
+### For Claude Code / AI Agents
+
+The skill is automatically loaded when working with Zod code. Reference specific rules:
+
+```
+See rules/parse-use-safeparse.md for safeParse best practices
+```
+
+### For Developers
+
+Read `SKILL.md` for a quick reference, or `AGENTS.md` for the full compiled guide.
+
+## File Structure
+
+```
+zod/
+├── SKILL.md          # Quick reference with rule index
+├── AGENTS.md         # Full compiled guide (all rules)
+├── metadata.json     # Version, categories, references
+├── README.md         # This file
+└── rules/
+    ├── _sections.md  # Category definitions
+    ├── _template.md  # Rule template
+    ├── schema-*.md   # Schema definition rules
+    ├── parse-*.md    # Parsing rules
+    ├── type-*.md     # Type inference rules
+    ├── error-*.md    # Error handling rules
+    ├── object-*.md   # Object schema rules
+    ├── compose-*.md  # Composition rules
+    ├── refine-*.md   # Refinement rules
+    └── perf-*.md     # Performance rules
+```
+
+## Rule Categories
+
+| Priority | Category | Rules | Impact |
+|----------|----------|-------|--------|
+| 1 | Schema Definition | 6 | CRITICAL |
+| 2 | Parsing & Validation | 6 | CRITICAL |
+| 3 | Type Inference | 5 | HIGH |
+| 4 | Error Handling | 5 | HIGH |
+| 5 | Object Schemas | 6 | MEDIUM-HIGH |
+| 6 | Schema Composition | 5 | MEDIUM |
+| 7 | Refinements & Transforms | 5 | MEDIUM |
+| 8 | Performance & Bundle | 5 | LOW-MEDIUM |
+
+## Key Principles
+
+1. **Type Safety First**: Always use `z.infer`, never duplicate types manually
+2. **Validate at Boundaries**: Parse external data immediately at entry points
+3. **User-Friendly Errors**: Provide custom messages, collect all issues
+4. **Single Source of Truth**: Schema defines validation AND TypeScript types
+5. **Composition Over Duplication**: Use extend, pick, omit, partial
+
+## References
+
+- [Zod Official Documentation](https://zod.dev/)
+- [Zod v4 Release Notes](https://zod.dev/v4)
+- [Zod GitHub](https://github.com/colinhacks/zod)
+- [Zod Mini](https://zod.dev/packages/mini)

--- a/.agents/skills/zod/README.md
+++ b/.agents/skills/zod/README.md
@@ -52,16 +52,16 @@ zod/
 
 ## Rule Categories
 
-| Priority | Category | Rules | Impact |
-|----------|----------|-------|--------|
-| 1 | Schema Definition | 6 | CRITICAL |
-| 2 | Parsing & Validation | 6 | CRITICAL |
-| 3 | Type Inference | 5 | HIGH |
-| 4 | Error Handling | 5 | HIGH |
-| 5 | Object Schemas | 6 | MEDIUM-HIGH |
-| 6 | Schema Composition | 5 | MEDIUM |
-| 7 | Refinements & Transforms | 5 | MEDIUM |
-| 8 | Performance & Bundle | 5 | LOW-MEDIUM |
+| Priority | Category                 | Rules | Impact      |
+| -------- | ------------------------ | ----- | ----------- |
+| 1        | Schema Definition        | 6     | CRITICAL    |
+| 2        | Parsing & Validation     | 6     | CRITICAL    |
+| 3        | Type Inference           | 5     | HIGH        |
+| 4        | Error Handling           | 5     | HIGH        |
+| 5        | Object Schemas           | 6     | MEDIUM-HIGH |
+| 6        | Schema Composition       | 5     | MEDIUM      |
+| 7        | Refinements & Transforms | 5     | MEDIUM      |
+| 8        | Performance & Bundle     | 5     | LOW-MEDIUM  |
 
 ## Key Principles
 

--- a/.agents/skills/zod/SKILL.md
+++ b/.agents/skills/zod/SKILL.md
@@ -1,0 +1,127 @@
+---
+name: zod
+description: Zod schema validation best practices for type safety, parsing, and error handling. This skill should be used when defining z.object schemas, using z.string validations, safeParse, or z.infer. This skill does NOT cover React Hook Form integration patterns (use react-hook-form skill) or OpenAPI client generation (use orval skill).
+---
+
+# Zod Best Practices
+
+Comprehensive schema validation guide for Zod in TypeScript applications. Contains 43 rules across 8 categories, prioritized by impact to guide automated refactoring and code generation.
+
+## When to Apply
+
+Reference these guidelines when:
+- Writing new Zod schemas
+- Choosing between parse() and safeParse()
+- Implementing type inference with z.infer
+- Handling validation errors for user feedback
+- Composing complex object schemas
+- Using refinements and transforms
+- Optimizing bundle size and validation performance
+- Reviewing Zod code for best practices
+
+## Rule Categories by Priority
+
+| Priority | Category | Impact | Prefix |
+|----------|----------|--------|--------|
+| 1 | Schema Definition | CRITICAL | `schema-` |
+| 2 | Parsing & Validation | CRITICAL | `parse-` |
+| 3 | Type Inference | HIGH | `type-` |
+| 4 | Error Handling | HIGH | `error-` |
+| 5 | Object Schemas | MEDIUM-HIGH | `object-` |
+| 6 | Schema Composition | MEDIUM | `compose-` |
+| 7 | Refinements & Transforms | MEDIUM | `refine-` |
+| 8 | Performance & Bundle | LOW-MEDIUM | `perf-` |
+
+## Quick Reference
+
+### 1. Schema Definition (CRITICAL)
+
+- `schema-use-primitives-correctly` - Use correct primitive schemas for each type
+- `schema-use-unknown-not-any` - Use z.unknown() instead of z.any() for type safety
+- `schema-avoid-optional-abuse` - Avoid overusing optional fields
+- `schema-string-validations` - Apply string validations at schema definition
+- `schema-use-enums` - Use enums for fixed string values
+- `schema-coercion-for-form-data` - Use coercion for form and query data
+
+### 2. Parsing & Validation (CRITICAL)
+
+- `parse-use-safeparse` - Use safeParse() for user input
+- `parse-async-for-async-refinements` - Use parseAsync for async refinements
+- `parse-handle-all-issues` - Handle all validation issues not just first
+- `parse-validate-early` - Validate at system boundaries
+- `parse-avoid-double-validation` - Avoid validating same data twice
+- `parse-never-trust-json` - Never trust JSON.parse output
+
+### 3. Type Inference (HIGH)
+
+- `type-use-z-infer` - Use z.infer instead of manual types
+- `type-input-vs-output` - Distinguish z.input from z.infer for transforms
+- `type-export-schemas-and-types` - Export both schemas and inferred types
+- `type-branded-types` - Use branded types for domain safety
+- `type-enable-strict-mode` - Enable TypeScript strict mode
+
+### 4. Error Handling (HIGH)
+
+- `error-custom-messages` - Provide custom error messages
+- `error-use-flatten` - Use flatten() for form error display
+- `error-path-for-nested` - Use issue.path for nested error location
+- `error-i18n` - Implement internationalized error messages
+- `error-avoid-throwing-in-refine` - Return false instead of throwing in refine
+
+### 5. Object Schemas (MEDIUM-HIGH)
+
+- `object-strict-vs-strip` - Choose strict() vs strip() for unknown keys
+- `object-partial-for-updates` - Use partial() for update schemas
+- `object-pick-omit` - Use pick() and omit() for schema variants
+- `object-extend-for-composition` - Use extend() for adding fields
+- `object-optional-vs-nullable` - Distinguish optional() from nullable()
+- `object-discriminated-unions` - Use discriminated unions for type narrowing
+
+### 6. Schema Composition (MEDIUM)
+
+- `compose-shared-schemas` - Extract shared schemas into reusable modules
+- `compose-intersection` - Use intersection() for type combinations
+- `compose-lazy-recursive` - Use z.lazy() for recursive schemas
+- `compose-preprocess` - Use preprocess() for data normalization
+- `compose-pipe` - Use pipe() for multi-stage validation
+
+### 7. Refinements & Transforms (MEDIUM)
+
+- `refine-vs-superrefine` - Choose refine() vs superRefine() correctly
+- `refine-transform-coerce` - Distinguish transform() from refine() and coerce()
+- `refine-add-path` - Add path to refinement errors
+- `refine-defaults` - Use default() for optional fields with defaults
+- `refine-catch` - Use catch() for fault-tolerant parsing
+
+### 8. Performance & Bundle (LOW-MEDIUM)
+
+- `perf-cache-schemas` - Cache schema instances
+- `perf-zod-mini` - Use Zod Mini for bundle-sensitive applications
+- `perf-avoid-dynamic-creation` - Avoid dynamic schema creation in hot paths
+- `perf-lazy-loading` - Lazy load large schemas
+- `perf-arrays` - Optimize large array validation
+
+## How to Use
+
+Read individual reference files for detailed explanations and code examples:
+
+- [Section definitions](references/_sections.md) - Category structure and impact levels
+- [Rule template](assets/templates/_template.md) - Template for adding new rules
+- Individual rules: `references/{prefix}-{slug}.md`
+
+## Full Compiled Document
+
+For the complete guide with all rules expanded: `AGENTS.md`
+
+## Related Skills
+
+- For React Hook Form integration, see `react-hook-form` skill
+- For API client generation, see `orval` skill
+
+## Sources
+
+- [Zod Official Documentation](https://zod.dev/)
+- [Zod v4 Release Notes](https://zod.dev/v4)
+- [Zod GitHub Repository](https://github.com/colinhacks/zod)
+- [Zod Mini](https://zod.dev/packages/mini)
+- [Total TypeScript Zod Tutorial](https://www.totaltypescript.com/tutorials/zod)

--- a/.agents/skills/zod/SKILL.md
+++ b/.agents/skills/zod/SKILL.md
@@ -10,6 +10,7 @@ Comprehensive schema validation guide for Zod in TypeScript applications. Contai
 ## When to Apply
 
 Reference these guidelines when:
+
 - Writing new Zod schemas
 - Choosing between parse() and safeParse()
 - Implementing type inference with z.infer
@@ -21,16 +22,16 @@ Reference these guidelines when:
 
 ## Rule Categories by Priority
 
-| Priority | Category | Impact | Prefix |
-|----------|----------|--------|--------|
-| 1 | Schema Definition | CRITICAL | `schema-` |
-| 2 | Parsing & Validation | CRITICAL | `parse-` |
-| 3 | Type Inference | HIGH | `type-` |
-| 4 | Error Handling | HIGH | `error-` |
-| 5 | Object Schemas | MEDIUM-HIGH | `object-` |
-| 6 | Schema Composition | MEDIUM | `compose-` |
-| 7 | Refinements & Transforms | MEDIUM | `refine-` |
-| 8 | Performance & Bundle | LOW-MEDIUM | `perf-` |
+| Priority | Category                 | Impact      | Prefix     |
+| -------- | ------------------------ | ----------- | ---------- |
+| 1        | Schema Definition        | CRITICAL    | `schema-`  |
+| 2        | Parsing & Validation     | CRITICAL    | `parse-`   |
+| 3        | Type Inference           | HIGH        | `type-`    |
+| 4        | Error Handling           | HIGH        | `error-`   |
+| 5        | Object Schemas           | MEDIUM-HIGH | `object-`  |
+| 6        | Schema Composition       | MEDIUM      | `compose-` |
+| 7        | Refinements & Transforms | MEDIUM      | `refine-`  |
+| 8        | Performance & Bundle     | LOW-MEDIUM  | `perf-`    |
 
 ## Quick Reference
 

--- a/.agents/skills/zod/assets/templates/_template.md
+++ b/.agents/skills/zod/assets/templates/_template.md
@@ -1,0 +1,30 @@
+---
+title: Rule Title Here
+impact: CRITICAL|HIGH|MEDIUM-HIGH|MEDIUM|LOW-MEDIUM|LOW
+impactDescription: Quantified impact (e.g., "2-10× improvement", "prevents runtime crashes")
+tags: section-prefix, technique, tool, related-concepts
+---
+
+## Rule Title Here
+
+1-3 sentences explaining WHY this matters. Focus on validation implications and cascade effects.
+
+**Incorrect (what's wrong):**
+
+```typescript
+// Bad code example - production-realistic, not strawman
+// Comments explaining the cost
+```
+
+**Correct (what's right):**
+
+```typescript
+// Good code example - minimal diff from incorrect
+// Comments explaining the benefit
+```
+
+**When NOT to use this pattern:**
+- Exception 1
+- Exception 2
+
+Reference: [Reference Title](URL)

--- a/.agents/skills/zod/assets/templates/_template.md
+++ b/.agents/skills/zod/assets/templates/_template.md
@@ -24,6 +24,7 @@ tags: section-prefix, technique, tool, related-concepts
 ```
 
 **When NOT to use this pattern:**
+
 - Exception 1
 - Exception 2
 

--- a/.agents/skills/zod/metadata.json
+++ b/.agents/skills/zod/metadata.json
@@ -1,0 +1,69 @@
+{
+  "version": "1.1.1",
+  "organization": "community",
+  "technology": "Zod",
+  "date": "January 2026",
+  "abstract": "Comprehensive schema validation guide for Zod in TypeScript applications, designed for AI agents and LLMs. Contains 43 rules across 8 categories, prioritized by impact from critical (schema definition, parsing) to incremental (performance, bundle optimization). Each rule includes detailed explanations, real-world examples comparing incorrect vs. correct implementations, and specific impact metrics to guide automated refactoring and code generation.",
+  "references": [
+    "https://zod.dev/",
+    "https://zod.dev/v4",
+    "https://github.com/colinhacks/zod",
+    "https://zod.dev/packages/mini",
+    "https://www.totaltypescript.com/tutorials/zod",
+    "https://zod.dev/error-handling",
+    "https://zod.dev/api"
+  ],
+  "categories": [
+    {
+      "name": "Schema Definition",
+      "prefix": "schema",
+      "impact": "CRITICAL",
+      "ruleCount": 6
+    },
+    {
+      "name": "Parsing & Validation",
+      "prefix": "parse",
+      "impact": "CRITICAL",
+      "ruleCount": 6
+    },
+    {
+      "name": "Type Inference",
+      "prefix": "type",
+      "impact": "HIGH",
+      "ruleCount": 5
+    },
+    {
+      "name": "Error Handling",
+      "prefix": "error",
+      "impact": "HIGH",
+      "ruleCount": 5
+    },
+    {
+      "name": "Object Schemas",
+      "prefix": "object",
+      "impact": "MEDIUM-HIGH",
+      "ruleCount": 6
+    },
+    {
+      "name": "Schema Composition",
+      "prefix": "compose",
+      "impact": "MEDIUM",
+      "ruleCount": 5
+    },
+    {
+      "name": "Refinements & Transforms",
+      "prefix": "refine",
+      "impact": "MEDIUM",
+      "ruleCount": 5
+    },
+    {
+      "name": "Performance & Bundle",
+      "prefix": "perf",
+      "impact": "LOW-MEDIUM",
+      "ruleCount": 5
+    }
+  ],
+  "totalRules": 43,
+  "zodVersion": "4.x",
+  "category": "API"
+}

--- a/.agents/skills/zod/metadata.json
+++ b/.agents/skills/zod/metadata.json
@@ -1,69 +1,69 @@
 {
-  "version": "1.1.1",
-  "organization": "community",
-  "technology": "Zod",
-  "date": "January 2026",
-  "abstract": "Comprehensive schema validation guide for Zod in TypeScript applications, designed for AI agents and LLMs. Contains 43 rules across 8 categories, prioritized by impact from critical (schema definition, parsing) to incremental (performance, bundle optimization). Each rule includes detailed explanations, real-world examples comparing incorrect vs. correct implementations, and specific impact metrics to guide automated refactoring and code generation.",
-  "references": [
-    "https://zod.dev/",
-    "https://zod.dev/v4",
-    "https://github.com/colinhacks/zod",
-    "https://zod.dev/packages/mini",
-    "https://www.totaltypescript.com/tutorials/zod",
-    "https://zod.dev/error-handling",
-    "https://zod.dev/api"
-  ],
-  "categories": [
-    {
-      "name": "Schema Definition",
-      "prefix": "schema",
-      "impact": "CRITICAL",
-      "ruleCount": 6
-    },
-    {
-      "name": "Parsing & Validation",
-      "prefix": "parse",
-      "impact": "CRITICAL",
-      "ruleCount": 6
-    },
-    {
-      "name": "Type Inference",
-      "prefix": "type",
-      "impact": "HIGH",
-      "ruleCount": 5
-    },
-    {
-      "name": "Error Handling",
-      "prefix": "error",
-      "impact": "HIGH",
-      "ruleCount": 5
-    },
-    {
-      "name": "Object Schemas",
-      "prefix": "object",
-      "impact": "MEDIUM-HIGH",
-      "ruleCount": 6
-    },
-    {
-      "name": "Schema Composition",
-      "prefix": "compose",
-      "impact": "MEDIUM",
-      "ruleCount": 5
-    },
-    {
-      "name": "Refinements & Transforms",
-      "prefix": "refine",
-      "impact": "MEDIUM",
-      "ruleCount": 5
-    },
-    {
-      "name": "Performance & Bundle",
-      "prefix": "perf",
-      "impact": "LOW-MEDIUM",
-      "ruleCount": 5
-    }
-  ],
-  "totalRules": 43,
-  "zodVersion": "4.x",
-  "category": "API"
+    "version": "1.1.1",
+    "organization": "community",
+    "technology": "Zod",
+    "date": "January 2026",
+    "abstract": "Comprehensive schema validation guide for Zod in TypeScript applications, designed for AI agents and LLMs. Contains 43 rules across 8 categories, prioritized by impact from critical (schema definition, parsing) to incremental (performance, bundle optimization). Each rule includes detailed explanations, real-world examples comparing incorrect vs. correct implementations, and specific impact metrics to guide automated refactoring and code generation.",
+    "references": [
+        "https://zod.dev/",
+        "https://zod.dev/v4",
+        "https://github.com/colinhacks/zod",
+        "https://zod.dev/packages/mini",
+        "https://www.totaltypescript.com/tutorials/zod",
+        "https://zod.dev/error-handling",
+        "https://zod.dev/api"
+    ],
+    "categories": [
+        {
+            "name": "Schema Definition",
+            "prefix": "schema",
+            "impact": "CRITICAL",
+            "ruleCount": 6
+        },
+        {
+            "name": "Parsing & Validation",
+            "prefix": "parse",
+            "impact": "CRITICAL",
+            "ruleCount": 6
+        },
+        {
+            "name": "Type Inference",
+            "prefix": "type",
+            "impact": "HIGH",
+            "ruleCount": 5
+        },
+        {
+            "name": "Error Handling",
+            "prefix": "error",
+            "impact": "HIGH",
+            "ruleCount": 5
+        },
+        {
+            "name": "Object Schemas",
+            "prefix": "object",
+            "impact": "MEDIUM-HIGH",
+            "ruleCount": 6
+        },
+        {
+            "name": "Schema Composition",
+            "prefix": "compose",
+            "impact": "MEDIUM",
+            "ruleCount": 5
+        },
+        {
+            "name": "Refinements & Transforms",
+            "prefix": "refine",
+            "impact": "MEDIUM",
+            "ruleCount": 5
+        },
+        {
+            "name": "Performance & Bundle",
+            "prefix": "perf",
+            "impact": "LOW-MEDIUM",
+            "ruleCount": 5
+        }
+    ],
+    "totalRules": 43,
+    "zodVersion": "4.x",
+    "category": "API"
 }

--- a/.agents/skills/zod/references/_sections.md
+++ b/.agents/skills/zod/references/_sections.md
@@ -1,0 +1,46 @@
+# Sections
+
+This file defines all sections, their ordering, impact levels, and descriptions.
+The section ID (in parentheses) is the filename prefix used to group rules.
+
+---
+
+## 1. Schema Definition (schema)
+
+**Impact:** CRITICAL
+**Description:** Schema definition is the foundation of all Zod validation; incorrect or overly permissive schemas cascade errors through your entire application, allowing invalid data to corrupt downstream logic.
+
+## 2. Parsing & Validation (parse)
+
+**Impact:** CRITICAL
+**Description:** Parsing is the core Zod operation; using `parse()` vs `safeParse()` incorrectly causes either unhandled exceptions crashing your app or silent failures that let invalid data through.
+
+## 3. Type Inference (type)
+
+**Impact:** HIGH
+**Description:** Zod's TypeScript integration eliminates duplicate type definitions; poor inference practices force manual type declarations that drift from schemas, losing the core benefit of Zod.
+
+## 4. Error Handling (error)
+
+**Impact:** HIGH
+**Description:** Error handling determines user experience; poorly structured error handling produces cryptic messages that harm UX and make debugging validation failures nearly impossible.
+
+## 5. Object Schemas (object)
+
+**Impact:** MEDIUM-HIGH
+**Description:** Objects are the most common schema type; misconfiguring strict/passthrough/strip modes either leaks unexpected data to clients or fails validation on legitimate requests.
+
+## 6. Schema Composition (compose)
+
+**Impact:** MEDIUM
+**Description:** Schema composition enables reuse and maintainability; poor composition patterns lead to duplicated schemas that drift apart or deeply nested structures that are impossible to maintain.
+
+## 7. Refinements & Transforms (refine)
+
+**Impact:** MEDIUM
+**Description:** Refinements and transforms handle custom validation and data coercion; choosing the wrong method causes performance issues, incorrect error aggregation, or async parsing failures.
+
+## 8. Performance & Bundle (perf)
+
+**Impact:** LOW-MEDIUM
+**Description:** Zod's performance and bundle size affect application startup and validation throughput; understanding when to use Zod Mini or cache schemas prevents unnecessary overhead in performance-critical paths.

--- a/.agents/skills/zod/references/compose-intersection.md
+++ b/.agents/skills/zod/references/compose-intersection.md
@@ -1,0 +1,144 @@
+---
+title: Use intersection() for Type Combinations
+impact: MEDIUM
+impactDescription: Manual field combination loses type relationships; intersection creates proper TypeScript intersection types
+tags: compose, intersection, and, combination
+---
+
+## Use intersection() for Type Combinations
+
+When you need an object that satisfies multiple schemas simultaneously (like combining a base type with mixins), use `.and()` or `z.intersection()`. This creates proper TypeScript intersection types and validates against all schemas.
+
+**Incorrect (manual combination):**
+
+```typescript
+import { z } from 'zod'
+
+const timestampsSchema = z.object({
+  createdAt: z.date(),
+  updatedAt: z.date(),
+})
+
+const softDeleteSchema = z.object({
+  deletedAt: z.date().nullable(),
+  deletedBy: z.string().nullable(),
+})
+
+const userSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  email: z.string().email(),
+})
+
+// Manual combination - verbose and error-prone
+const fullUserSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  email: z.string().email(),
+  createdAt: z.date(),
+  updatedAt: z.date(),
+  deletedAt: z.date().nullable(),
+  deletedBy: z.string().nullable(),
+})
+```
+
+**Correct (using intersection):**
+
+```typescript
+import { z } from 'zod'
+
+const timestampsSchema = z.object({
+  createdAt: z.date(),
+  updatedAt: z.date(),
+})
+
+const softDeleteSchema = z.object({
+  deletedAt: z.date().nullable(),
+  deletedBy: z.string().nullable(),
+})
+
+const userSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  email: z.string().email(),
+})
+
+// Using .and() for intersection
+const fullUserSchema = userSchema
+  .and(timestampsSchema)
+  .and(softDeleteSchema)
+
+// Or using z.intersection()
+const fullUserSchema2 = z.intersection(
+  z.intersection(userSchema, timestampsSchema),
+  softDeleteSchema
+)
+
+type FullUser = z.infer<typeof fullUserSchema>
+// {
+//   id: string;
+//   name: string;
+//   email: string;
+//   createdAt: Date;
+//   updatedAt: Date;
+//   deletedAt: Date | null;
+//   deletedBy: string | null;
+// }
+```
+
+**Creating mixins:**
+
+```typescript
+// Reusable mixins
+const auditable = z.object({
+  createdBy: z.string(),
+  updatedBy: z.string(),
+})
+
+const versioned = z.object({
+  version: z.number().int().positive(),
+})
+
+const tagged = z.object({
+  tags: z.array(z.string()),
+})
+
+// Apply mixins to any schema
+function withAudit<T extends z.ZodRawShape>(schema: z.ZodObject<T>) {
+  return schema.and(auditable).and(timestampsSchema)
+}
+
+function withVersioning<T extends z.ZodRawShape>(schema: z.ZodObject<T>) {
+  return schema.and(versioned)
+}
+
+// Usage
+const documentSchema = z.object({
+  id: z.string(),
+  title: z.string(),
+  content: z.string(),
+})
+
+const fullDocumentSchema = withAudit(withVersioning(documentSchema))
+```
+
+**Intersection vs Merge:**
+
+```typescript
+// .merge() - replaces fields from first with second
+const a = z.object({ x: z.string(), y: z.number() })
+const b = z.object({ y: z.string() })  // y is string, not number
+
+a.merge(b)  // { x: string, y: string } - b's y wins
+
+// .and() - requires fields to be compatible
+// If both have y with different types, intersection fails at runtime
+a.and(b)  // Validation will fail - y can't be both number and string
+```
+
+**When NOT to use this pattern:**
+- When schemas have overlapping fields with different types (use merge)
+- When you need to override fields (use extend)
+- Simple cases where extend works fine
+
+Reference: [Zod API - intersection](https://zod.dev/api#intersection)

--- a/.agents/skills/zod/references/compose-intersection.md
+++ b/.agents/skills/zod/references/compose-intersection.md
@@ -15,30 +15,30 @@ When you need an object that satisfies multiple schemas simultaneously (like com
 import { z } from 'zod'
 
 const timestampsSchema = z.object({
-  createdAt: z.date(),
-  updatedAt: z.date(),
+    createdAt: z.date(),
+    updatedAt: z.date(),
 })
 
 const softDeleteSchema = z.object({
-  deletedAt: z.date().nullable(),
-  deletedBy: z.string().nullable(),
+    deletedAt: z.date().nullable(),
+    deletedBy: z.string().nullable(),
 })
 
 const userSchema = z.object({
-  id: z.string(),
-  name: z.string(),
-  email: z.string().email(),
+    id: z.string(),
+    name: z.string(),
+    email: z.string().email(),
 })
 
 // Manual combination - verbose and error-prone
 const fullUserSchema = z.object({
-  id: z.string(),
-  name: z.string(),
-  email: z.string().email(),
-  createdAt: z.date(),
-  updatedAt: z.date(),
-  deletedAt: z.date().nullable(),
-  deletedBy: z.string().nullable(),
+    id: z.string(),
+    name: z.string(),
+    email: z.string().email(),
+    createdAt: z.date(),
+    updatedAt: z.date(),
+    deletedAt: z.date().nullable(),
+    deletedBy: z.string().nullable(),
 })
 ```
 
@@ -48,30 +48,28 @@ const fullUserSchema = z.object({
 import { z } from 'zod'
 
 const timestampsSchema = z.object({
-  createdAt: z.date(),
-  updatedAt: z.date(),
+    createdAt: z.date(),
+    updatedAt: z.date(),
 })
 
 const softDeleteSchema = z.object({
-  deletedAt: z.date().nullable(),
-  deletedBy: z.string().nullable(),
+    deletedAt: z.date().nullable(),
+    deletedBy: z.string().nullable(),
 })
 
 const userSchema = z.object({
-  id: z.string(),
-  name: z.string(),
-  email: z.string().email(),
+    id: z.string(),
+    name: z.string(),
+    email: z.string().email(),
 })
 
 // Using .and() for intersection
-const fullUserSchema = userSchema
-  .and(timestampsSchema)
-  .and(softDeleteSchema)
+const fullUserSchema = userSchema.and(timestampsSchema).and(softDeleteSchema)
 
 // Or using z.intersection()
 const fullUserSchema2 = z.intersection(
-  z.intersection(userSchema, timestampsSchema),
-  softDeleteSchema
+    z.intersection(userSchema, timestampsSchema),
+    softDeleteSchema,
 )
 
 type FullUser = z.infer<typeof fullUserSchema>
@@ -91,32 +89,32 @@ type FullUser = z.infer<typeof fullUserSchema>
 ```typescript
 // Reusable mixins
 const auditable = z.object({
-  createdBy: z.string(),
-  updatedBy: z.string(),
+    createdBy: z.string(),
+    updatedBy: z.string(),
 })
 
 const versioned = z.object({
-  version: z.number().int().positive(),
+    version: z.number().int().positive(),
 })
 
 const tagged = z.object({
-  tags: z.array(z.string()),
+    tags: z.array(z.string()),
 })
 
 // Apply mixins to any schema
 function withAudit<T extends z.ZodRawShape>(schema: z.ZodObject<T>) {
-  return schema.and(auditable).and(timestampsSchema)
+    return schema.and(auditable).and(timestampsSchema)
 }
 
 function withVersioning<T extends z.ZodRawShape>(schema: z.ZodObject<T>) {
-  return schema.and(versioned)
+    return schema.and(versioned)
 }
 
 // Usage
 const documentSchema = z.object({
-  id: z.string(),
-  title: z.string(),
-  content: z.string(),
+    id: z.string(),
+    title: z.string(),
+    content: z.string(),
 })
 
 const fullDocumentSchema = withAudit(withVersioning(documentSchema))
@@ -127,16 +125,17 @@ const fullDocumentSchema = withAudit(withVersioning(documentSchema))
 ```typescript
 // .merge() - replaces fields from first with second
 const a = z.object({ x: z.string(), y: z.number() })
-const b = z.object({ y: z.string() })  // y is string, not number
+const b = z.object({ y: z.string() }) // y is string, not number
 
-a.merge(b)  // { x: string, y: string } - b's y wins
+a.merge(b) // { x: string, y: string } - b's y wins
 
 // .and() - requires fields to be compatible
 // If both have y with different types, intersection fails at runtime
-a.and(b)  // Validation will fail - y can't be both number and string
+a.and(b) // Validation will fail - y can't be both number and string
 ```
 
 **When NOT to use this pattern:**
+
 - When schemas have overlapping fields with different types (use merge)
 - When you need to override fields (use extend)
 - Simple cases where extend works fine

--- a/.agents/skills/zod/references/compose-lazy-recursive.md
+++ b/.agents/skills/zod/references/compose-lazy-recursive.md
@@ -1,0 +1,143 @@
+---
+title: Use z.lazy() for Recursive Schemas
+impact: MEDIUM
+impactDescription: Recursive types reference themselves before definition; z.lazy() defers evaluation to enable self-referential schemas
+tags: compose, lazy, recursive, trees
+---
+
+## Use z.lazy() for Recursive Schemas
+
+TypeScript can't infer recursive Zod schema types automatically. Use `z.lazy()` to defer schema evaluation and manually provide the type annotation. This enables tree structures, nested comments, and other self-referential data.
+
+**Incorrect (direct self-reference):**
+
+```typescript
+import { z } from 'zod'
+
+// This fails - categorySchema used before it's defined
+const categorySchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  children: z.array(categorySchema),  // Error: Block-scoped variable used before declaration
+})
+```
+
+**Correct (using z.lazy with type annotation):**
+
+```typescript
+import { z } from 'zod'
+
+// Define the type manually
+interface Category {
+  id: string
+  name: string
+  children: Category[]
+}
+
+// Use z.lazy() to defer schema reference
+const categorySchema: z.ZodType<Category> = z.object({
+  id: z.string(),
+  name: z.string(),
+  children: z.lazy(() => z.array(categorySchema)),
+})
+
+// Now it works
+const tree = categorySchema.parse({
+  id: '1',
+  name: 'Electronics',
+  children: [
+    {
+      id: '2',
+      name: 'Phones',
+      children: [
+        { id: '3', name: 'iPhones', children: [] },
+        { id: '4', name: 'Android', children: [] },
+      ],
+    },
+  ],
+})
+```
+
+**Common recursive patterns:**
+
+```typescript
+// Comments with replies
+interface Comment {
+  id: string
+  content: string
+  author: string
+  replies: Comment[]
+}
+
+const commentSchema: z.ZodType<Comment> = z.object({
+  id: z.string(),
+  content: z.string(),
+  author: z.string(),
+  replies: z.lazy(() => z.array(commentSchema)),
+})
+
+// Binary tree
+interface TreeNode {
+  value: number
+  left: TreeNode | null
+  right: TreeNode | null
+}
+
+const treeNodeSchema: z.ZodType<TreeNode> = z.object({
+  value: z.number(),
+  left: z.lazy(() => treeNodeSchema.nullable()),
+  right: z.lazy(() => treeNodeSchema.nullable()),
+})
+
+// Nested menu structure
+interface MenuItem {
+  label: string
+  href?: string
+  children?: MenuItem[]
+}
+
+const menuItemSchema: z.ZodType<MenuItem> = z.object({
+  label: z.string(),
+  href: z.string().url().optional(),
+  children: z.lazy(() => z.array(menuItemSchema)).optional(),
+})
+```
+
+**JSON Schema (any valid JSON):**
+
+```typescript
+type JSONValue =
+  | string
+  | number
+  | boolean
+  | null
+  | JSONValue[]
+  | { [key: string]: JSONValue }
+
+const jsonValueSchema: z.ZodType<JSONValue> = z.lazy(() =>
+  z.union([
+    z.string(),
+    z.number(),
+    z.boolean(),
+    z.null(),
+    z.array(jsonValueSchema),
+    z.record(jsonValueSchema),
+  ])
+)
+```
+
+**Performance consideration:**
+
+```typescript
+// z.lazy() has minimal overhead - the function is called once
+// and the schema is cached. Safe to use in hot paths.
+
+// If validating many recursive structures, the schema itself
+// is only built once. Validation performance depends on data depth.
+```
+
+**When NOT to use this pattern:**
+- Non-recursive schemas (lazy adds unnecessary indirection)
+- When you can flatten the structure instead
+
+Reference: [Zod API - Recursive Types](https://zod.dev/api#recursive-types)

--- a/.agents/skills/zod/references/compose-lazy-recursive.md
+++ b/.agents/skills/zod/references/compose-lazy-recursive.md
@@ -16,9 +16,9 @@ import { z } from 'zod'
 
 // This fails - categorySchema used before it's defined
 const categorySchema = z.object({
-  id: z.string(),
-  name: z.string(),
-  children: z.array(categorySchema),  // Error: Block-scoped variable used before declaration
+    id: z.string(),
+    name: z.string(),
+    children: z.array(categorySchema), // Error: Block-scoped variable used before declaration
 })
 ```
 
@@ -29,32 +29,32 @@ import { z } from 'zod'
 
 // Define the type manually
 interface Category {
-  id: string
-  name: string
-  children: Category[]
+    id: string
+    name: string
+    children: Category[]
 }
 
 // Use z.lazy() to defer schema reference
 const categorySchema: z.ZodType<Category> = z.object({
-  id: z.string(),
-  name: z.string(),
-  children: z.lazy(() => z.array(categorySchema)),
+    id: z.string(),
+    name: z.string(),
+    children: z.lazy(() => z.array(categorySchema)),
 })
 
 // Now it works
 const tree = categorySchema.parse({
-  id: '1',
-  name: 'Electronics',
-  children: [
-    {
-      id: '2',
-      name: 'Phones',
-      children: [
-        { id: '3', name: 'iPhones', children: [] },
-        { id: '4', name: 'Android', children: [] },
-      ],
-    },
-  ],
+    id: '1',
+    name: 'Electronics',
+    children: [
+        {
+            id: '2',
+            name: 'Phones',
+            children: [
+                { id: '3', name: 'iPhones', children: [] },
+                { id: '4', name: 'Android', children: [] },
+            ],
+        },
+    ],
 })
 ```
 
@@ -63,43 +63,43 @@ const tree = categorySchema.parse({
 ```typescript
 // Comments with replies
 interface Comment {
-  id: string
-  content: string
-  author: string
-  replies: Comment[]
+    id: string
+    content: string
+    author: string
+    replies: Comment[]
 }
 
 const commentSchema: z.ZodType<Comment> = z.object({
-  id: z.string(),
-  content: z.string(),
-  author: z.string(),
-  replies: z.lazy(() => z.array(commentSchema)),
+    id: z.string(),
+    content: z.string(),
+    author: z.string(),
+    replies: z.lazy(() => z.array(commentSchema)),
 })
 
 // Binary tree
 interface TreeNode {
-  value: number
-  left: TreeNode | null
-  right: TreeNode | null
+    value: number
+    left: TreeNode | null
+    right: TreeNode | null
 }
 
 const treeNodeSchema: z.ZodType<TreeNode> = z.object({
-  value: z.number(),
-  left: z.lazy(() => treeNodeSchema.nullable()),
-  right: z.lazy(() => treeNodeSchema.nullable()),
+    value: z.number(),
+    left: z.lazy(() => treeNodeSchema.nullable()),
+    right: z.lazy(() => treeNodeSchema.nullable()),
 })
 
 // Nested menu structure
 interface MenuItem {
-  label: string
-  href?: string
-  children?: MenuItem[]
+    label: string
+    href?: string
+    children?: MenuItem[]
 }
 
 const menuItemSchema: z.ZodType<MenuItem> = z.object({
-  label: z.string(),
-  href: z.string().url().optional(),
-  children: z.lazy(() => z.array(menuItemSchema)).optional(),
+    label: z.string(),
+    href: z.string().url().optional(),
+    children: z.lazy(() => z.array(menuItemSchema)).optional(),
 })
 ```
 
@@ -107,22 +107,22 @@ const menuItemSchema: z.ZodType<MenuItem> = z.object({
 
 ```typescript
 type JSONValue =
-  | string
-  | number
-  | boolean
-  | null
-  | JSONValue[]
-  | { [key: string]: JSONValue }
+    | string
+    | number
+    | boolean
+    | null
+    | JSONValue[]
+    | { [key: string]: JSONValue }
 
 const jsonValueSchema: z.ZodType<JSONValue> = z.lazy(() =>
-  z.union([
-    z.string(),
-    z.number(),
-    z.boolean(),
-    z.null(),
-    z.array(jsonValueSchema),
-    z.record(jsonValueSchema),
-  ])
+    z.union([
+        z.string(),
+        z.number(),
+        z.boolean(),
+        z.null(),
+        z.array(jsonValueSchema),
+        z.record(jsonValueSchema),
+    ]),
 )
 ```
 
@@ -137,6 +137,7 @@ const jsonValueSchema: z.ZodType<JSONValue> = z.lazy(() =>
 ```
 
 **When NOT to use this pattern:**
+
 - Non-recursive schemas (lazy adds unnecessary indirection)
 - When you can flatten the structure instead
 

--- a/.agents/skills/zod/references/compose-pipe.md
+++ b/.agents/skills/zod/references/compose-pipe.md
@@ -1,0 +1,113 @@
+---
+title: Use pipe() for Multi-Stage Validation
+impact: MEDIUM
+impactDescription: Chaining transforms loses intermediate type info; pipe() explicitly shows data flow through validation stages
+tags: compose, pipe, pipeline, transform
+---
+
+## Use pipe() for Multi-Stage Validation
+
+When data needs to pass through multiple validation stages (coerce string to number, then validate range, then transform to currency), use `.pipe()` to chain schemas. This makes the data transformation pipeline explicit and each stage's type clear.
+
+**Incorrect (unclear transformation chain):**
+
+```typescript
+import { z } from 'zod'
+
+// All transforms in one long chain - hard to understand stages
+const priceSchema = z
+  .string()
+  .transform((s) => parseFloat(s.replace(/[$,]/g, '')))
+  .refine((n) => !isNaN(n), 'Invalid number')
+  .refine((n) => n >= 0, 'Must be positive')
+  .refine((n) => n <= 1000000, 'Too large')
+  .transform((n) => Math.round(n * 100))
+
+// What type is n at each stage? Hard to tell
+```
+
+**Correct (using pipe for clear stages):**
+
+```typescript
+import { z } from 'zod'
+
+// Stage 1: Coerce string to number
+const parsePrice = z.string().transform((s) => {
+  const cleaned = s.replace(/[$,]/g, '')
+  const parsed = parseFloat(cleaned)
+  if (isNaN(parsed)) throw new Error('Invalid number')
+  return parsed
+})
+
+// Stage 2: Validate number constraints
+const validPrice = z.number().min(0, 'Must be positive').max(1000000, 'Too large')
+
+// Stage 3: Transform to cents
+const centsPrice = z.number().transform((n) => Math.round(n * 100))
+
+// Pipe them together - clear data flow
+const priceSchema = parsePrice.pipe(validPrice).pipe(centsPrice)
+
+// Type at each stage is clear:
+// string -> number (parsePrice)
+// number -> number (validPrice)
+// number -> number (centsPrice, but semantically cents)
+```
+
+**Coercion with validation:**
+
+```typescript
+// Without pipe - validation runs on raw input
+const schema1 = z.coerce.number().min(1)
+schema1.parse('')  // Passes! Empty string coerces to 0, but then... wait, 0 < 1
+
+// With pipe - validation runs on coerced value
+const schema2 = z.coerce.number().pipe(z.number().min(1))
+schema2.parse('')  // Fails correctly: 0 is less than 1
+```
+
+**Complex data transformation:**
+
+```typescript
+// Input: CSV string of emails
+// Output: Array of normalized, validated email objects
+
+const emailArraySchema = z
+  .string()
+  // Stage 1: Split CSV
+  .transform((s) => s.split(',').map((e) => e.trim()))
+  // Stage 2: Validate as email array
+  .pipe(z.array(z.string().email()))
+  // Stage 3: Transform to objects
+  .pipe(
+    z.array(z.string()).transform((emails) =>
+      emails.map((email) => ({
+        address: email.toLowerCase(),
+        domain: email.split('@')[1],
+      }))
+    )
+  )
+
+emailArraySchema.parse('John@Example.com, jane@test.com')
+// [
+//   { address: 'john@example.com', domain: 'Example.com' },
+//   { address: 'jane@test.com', domain: 'test.com' }
+// ]
+```
+
+**Type inference with pipe:**
+
+```typescript
+const schema = z.string().pipe(z.coerce.number()).pipe(z.number().positive())
+
+type Input = z.input<typeof schema>  // string
+type Output = z.output<typeof schema>  // number
+
+// Each pipe stage has clear input/output types
+```
+
+**When NOT to use this pattern:**
+- Simple single-stage validation (adds unnecessary complexity)
+- When `.refine()` chain is sufficient and readable
+
+Reference: [Zod API - pipe](https://zod.dev/api#pipe)

--- a/.agents/skills/zod/references/compose-pipe.md
+++ b/.agents/skills/zod/references/compose-pipe.md
@@ -16,12 +16,12 @@ import { z } from 'zod'
 
 // All transforms in one long chain - hard to understand stages
 const priceSchema = z
-  .string()
-  .transform((s) => parseFloat(s.replace(/[$,]/g, '')))
-  .refine((n) => !isNaN(n), 'Invalid number')
-  .refine((n) => n >= 0, 'Must be positive')
-  .refine((n) => n <= 1000000, 'Too large')
-  .transform((n) => Math.round(n * 100))
+    .string()
+    .transform(s => parseFloat(s.replace(/[$,]/g, '')))
+    .refine(n => !isNaN(n), 'Invalid number')
+    .refine(n => n >= 0, 'Must be positive')
+    .refine(n => n <= 1000000, 'Too large')
+    .transform(n => Math.round(n * 100))
 
 // What type is n at each stage? Hard to tell
 ```
@@ -32,18 +32,21 @@ const priceSchema = z
 import { z } from 'zod'
 
 // Stage 1: Coerce string to number
-const parsePrice = z.string().transform((s) => {
-  const cleaned = s.replace(/[$,]/g, '')
-  const parsed = parseFloat(cleaned)
-  if (isNaN(parsed)) throw new Error('Invalid number')
-  return parsed
+const parsePrice = z.string().transform(s => {
+    const cleaned = s.replace(/[$,]/g, '')
+    const parsed = parseFloat(cleaned)
+    if (isNaN(parsed)) throw new Error('Invalid number')
+    return parsed
 })
 
 // Stage 2: Validate number constraints
-const validPrice = z.number().min(0, 'Must be positive').max(1000000, 'Too large')
+const validPrice = z
+    .number()
+    .min(0, 'Must be positive')
+    .max(1000000, 'Too large')
 
 // Stage 3: Transform to cents
-const centsPrice = z.number().transform((n) => Math.round(n * 100))
+const centsPrice = z.number().transform(n => Math.round(n * 100))
 
 // Pipe them together - clear data flow
 const priceSchema = parsePrice.pipe(validPrice).pipe(centsPrice)
@@ -59,11 +62,11 @@ const priceSchema = parsePrice.pipe(validPrice).pipe(centsPrice)
 ```typescript
 // Without pipe - validation runs on raw input
 const schema1 = z.coerce.number().min(1)
-schema1.parse('')  // Passes! Empty string coerces to 0, but then... wait, 0 < 1
+schema1.parse('') // Passes! Empty string coerces to 0, but then... wait, 0 < 1
 
 // With pipe - validation runs on coerced value
 const schema2 = z.coerce.number().pipe(z.number().min(1))
-schema2.parse('')  // Fails correctly: 0 is less than 1
+schema2.parse('') // Fails correctly: 0 is less than 1
 ```
 
 **Complex data transformation:**
@@ -73,20 +76,20 @@ schema2.parse('')  // Fails correctly: 0 is less than 1
 // Output: Array of normalized, validated email objects
 
 const emailArraySchema = z
-  .string()
-  // Stage 1: Split CSV
-  .transform((s) => s.split(',').map((e) => e.trim()))
-  // Stage 2: Validate as email array
-  .pipe(z.array(z.string().email()))
-  // Stage 3: Transform to objects
-  .pipe(
-    z.array(z.string()).transform((emails) =>
-      emails.map((email) => ({
-        address: email.toLowerCase(),
-        domain: email.split('@')[1],
-      }))
+    .string()
+    // Stage 1: Split CSV
+    .transform(s => s.split(',').map(e => e.trim()))
+    // Stage 2: Validate as email array
+    .pipe(z.array(z.string().email()))
+    // Stage 3: Transform to objects
+    .pipe(
+        z.array(z.string()).transform(emails =>
+            emails.map(email => ({
+                address: email.toLowerCase(),
+                domain: email.split('@')[1],
+            })),
+        ),
     )
-  )
 
 emailArraySchema.parse('John@Example.com, jane@test.com')
 // [
@@ -100,13 +103,14 @@ emailArraySchema.parse('John@Example.com, jane@test.com')
 ```typescript
 const schema = z.string().pipe(z.coerce.number()).pipe(z.number().positive())
 
-type Input = z.input<typeof schema>  // string
-type Output = z.output<typeof schema>  // number
+type Input = z.input<typeof schema> // string
+type Output = z.output<typeof schema> // number
 
 // Each pipe stage has clear input/output types
 ```
 
 **When NOT to use this pattern:**
+
 - Simple single-stage validation (adds unnecessary complexity)
 - When `.refine()` chain is sufficient and readable
 

--- a/.agents/skills/zod/references/compose-preprocess.md
+++ b/.agents/skills/zod/references/compose-preprocess.md
@@ -1,0 +1,142 @@
+---
+title: Use preprocess() for Data Normalization
+impact: MEDIUM
+impactDescription: Validating before cleaning data causes false rejections; preprocess() normalizes input before schema validation runs
+tags: compose, preprocess, normalize, cleaning
+---
+
+## Use preprocess() for Data Normalization
+
+When incoming data needs normalization before validation (trimming whitespace, parsing JSON strings, converting formats), use `z.preprocess()`. This runs a function on the raw input before Zod's type checking, allowing you to clean data that would otherwise fail validation.
+
+**Incorrect (validation fails on unnormalized data):**
+
+```typescript
+import { z } from 'zod'
+
+const userSchema = z.object({
+  name: z.string().min(1),
+  email: z.string().email(),
+  config: z.object({
+    theme: z.string(),
+  }),
+})
+
+// Raw form data
+const formData = {
+  name: '  John Doe  ',  // Has whitespace
+  email: 'JOHN@EXAMPLE.COM',  // Uppercase
+  config: '{"theme": "dark"}',  // JSON string, not object
+}
+
+userSchema.parse(formData)
+// ZodError: Expected object, received string at "config"
+```
+
+**Correct (using preprocess):**
+
+```typescript
+import { z } from 'zod'
+
+// Preprocess normalizes before validation
+const trimmedString = z.preprocess(
+  (val) => (typeof val === 'string' ? val.trim() : val),
+  z.string()
+)
+
+const lowercaseEmail = z.preprocess(
+  (val) => (typeof val === 'string' ? val.toLowerCase().trim() : val),
+  z.string().email()
+)
+
+const jsonObject = z.preprocess(
+  (val) => {
+    if (typeof val === 'string') {
+      try {
+        return JSON.parse(val)
+      } catch {
+        return val  // Let Zod report the error
+      }
+    }
+    return val
+  },
+  z.object({ theme: z.string() })
+)
+
+const userSchema = z.object({
+  name: trimmedString.pipe(z.string().min(1)),
+  email: lowercaseEmail,
+  config: jsonObject,
+})
+
+const formData = {
+  name: '  John Doe  ',
+  email: 'JOHN@EXAMPLE.COM',
+  config: '{"theme": "dark"}',
+}
+
+const user = userSchema.parse(formData)
+// { name: 'John Doe', email: 'john@example.com', config: { theme: 'dark' } }
+```
+
+**Common preprocessing patterns:**
+
+```typescript
+// Trim all strings
+const trimmedString = z.preprocess(
+  (val) => (typeof val === 'string' ? val.trim() : val),
+  z.string()
+)
+
+// Parse numeric strings
+const numericString = z.preprocess(
+  (val) => (typeof val === 'string' ? Number(val) : val),
+  z.number()
+)
+
+// Parse boolean-like values
+const booleanLike = z.preprocess(
+  (val) => {
+    if (val === 'true' || val === '1' || val === 1) return true
+    if (val === 'false' || val === '0' || val === 0) return false
+    return val
+  },
+  z.boolean()
+)
+
+// Parse date strings
+const dateString = z.preprocess(
+  (val) => (typeof val === 'string' ? new Date(val) : val),
+  z.date()
+)
+
+// Split comma-separated strings into arrays
+const csvArray = z.preprocess(
+  (val) => (typeof val === 'string' ? val.split(',').map(s => s.trim()) : val),
+  z.array(z.string())
+)
+```
+
+**Preprocess vs Transform:**
+
+```typescript
+// preprocess() runs BEFORE type checking
+// Use for: Normalizing input format before validation
+z.preprocess(val => String(val).trim(), z.string().min(1))
+
+// transform() runs AFTER type checking
+// Use for: Converting validated data to different format
+z.string().transform(s => s.toUpperCase())
+
+// Order of operations:
+// 1. preprocess receives raw unknown input
+// 2. Zod validates the preprocessed value
+// 3. transform converts the validated value
+```
+
+**When NOT to use this pattern:**
+- When `.coerce` methods handle the conversion (simpler)
+- When transformation should happen after validation (use transform)
+- When normalization could hide validation errors
+
+Reference: [Zod API - preprocess](https://zod.dev/api#preprocess)

--- a/.agents/skills/zod/references/compose-preprocess.md
+++ b/.agents/skills/zod/references/compose-preprocess.md
@@ -15,18 +15,18 @@ When incoming data needs normalization before validation (trimming whitespace, p
 import { z } from 'zod'
 
 const userSchema = z.object({
-  name: z.string().min(1),
-  email: z.string().email(),
-  config: z.object({
-    theme: z.string(),
-  }),
+    name: z.string().min(1),
+    email: z.string().email(),
+    config: z.object({
+        theme: z.string(),
+    }),
 })
 
 // Raw form data
 const formData = {
-  name: '  John Doe  ',  // Has whitespace
-  email: 'JOHN@EXAMPLE.COM',  // Uppercase
-  config: '{"theme": "dark"}',  // JSON string, not object
+    name: '  John Doe  ', // Has whitespace
+    email: 'JOHN@EXAMPLE.COM', // Uppercase
+    config: '{"theme": "dark"}', // JSON string, not object
 }
 
 userSchema.parse(formData)
@@ -40,39 +40,39 @@ import { z } from 'zod'
 
 // Preprocess normalizes before validation
 const trimmedString = z.preprocess(
-  (val) => (typeof val === 'string' ? val.trim() : val),
-  z.string()
+    val => (typeof val === 'string' ? val.trim() : val),
+    z.string(),
 )
 
 const lowercaseEmail = z.preprocess(
-  (val) => (typeof val === 'string' ? val.toLowerCase().trim() : val),
-  z.string().email()
+    val => (typeof val === 'string' ? val.toLowerCase().trim() : val),
+    z.string().email(),
 )
 
 const jsonObject = z.preprocess(
-  (val) => {
-    if (typeof val === 'string') {
-      try {
-        return JSON.parse(val)
-      } catch {
-        return val  // Let Zod report the error
-      }
-    }
-    return val
-  },
-  z.object({ theme: z.string() })
+    val => {
+        if (typeof val === 'string') {
+            try {
+                return JSON.parse(val)
+            } catch {
+                return val // Let Zod report the error
+            }
+        }
+        return val
+    },
+    z.object({ theme: z.string() }),
 )
 
 const userSchema = z.object({
-  name: trimmedString.pipe(z.string().min(1)),
-  email: lowercaseEmail,
-  config: jsonObject,
+    name: trimmedString.pipe(z.string().min(1)),
+    email: lowercaseEmail,
+    config: jsonObject,
 })
 
 const formData = {
-  name: '  John Doe  ',
-  email: 'JOHN@EXAMPLE.COM',
-  config: '{"theme": "dark"}',
+    name: '  John Doe  ',
+    email: 'JOHN@EXAMPLE.COM',
+    config: '{"theme": "dark"}',
 }
 
 const user = userSchema.parse(formData)
@@ -84,36 +84,33 @@ const user = userSchema.parse(formData)
 ```typescript
 // Trim all strings
 const trimmedString = z.preprocess(
-  (val) => (typeof val === 'string' ? val.trim() : val),
-  z.string()
+    val => (typeof val === 'string' ? val.trim() : val),
+    z.string(),
 )
 
 // Parse numeric strings
 const numericString = z.preprocess(
-  (val) => (typeof val === 'string' ? Number(val) : val),
-  z.number()
+    val => (typeof val === 'string' ? Number(val) : val),
+    z.number(),
 )
 
 // Parse boolean-like values
-const booleanLike = z.preprocess(
-  (val) => {
+const booleanLike = z.preprocess(val => {
     if (val === 'true' || val === '1' || val === 1) return true
     if (val === 'false' || val === '0' || val === 0) return false
     return val
-  },
-  z.boolean()
-)
+}, z.boolean())
 
 // Parse date strings
 const dateString = z.preprocess(
-  (val) => (typeof val === 'string' ? new Date(val) : val),
-  z.date()
+    val => (typeof val === 'string' ? new Date(val) : val),
+    z.date(),
 )
 
 // Split comma-separated strings into arrays
 const csvArray = z.preprocess(
-  (val) => (typeof val === 'string' ? val.split(',').map(s => s.trim()) : val),
-  z.array(z.string())
+    val => (typeof val === 'string' ? val.split(',').map(s => s.trim()) : val),
+    z.array(z.string()),
 )
 ```
 
@@ -135,6 +132,7 @@ z.string().transform(s => s.toUpperCase())
 ```
 
 **When NOT to use this pattern:**
+
 - When `.coerce` methods handle the conversion (simpler)
 - When transformation should happen after validation (use transform)
 - When normalization could hide validation errors

--- a/.agents/skills/zod/references/compose-shared-schemas.md
+++ b/.agents/skills/zod/references/compose-shared-schemas.md
@@ -1,0 +1,137 @@
+---
+title: Extract Shared Schemas into Reusable Modules
+impact: MEDIUM
+impactDescription: Duplicating schemas across files leads to inconsistency; shared schemas ensure single source of truth
+tags: compose, reuse, modules, organization
+---
+
+## Extract Shared Schemas into Reusable Modules
+
+When the same schema pattern appears in multiple places, extract it into a shared module. This ensures consistency, reduces duplication, and makes changes propagate automatically across your codebase.
+
+**Incorrect (duplicating schemas):**
+
+```typescript
+// api/users.ts
+import { z } from 'zod'
+
+const userSchema = z.object({
+  id: z.string().uuid(),
+  email: z.string().email(),
+  name: z.string().min(1),
+  createdAt: z.date(),
+})
+
+// api/orders.ts
+import { z } from 'zod'
+
+const orderSchema = z.object({
+  id: z.string().uuid(),  // Duplicated
+  userId: z.string().uuid(),  // Same pattern
+  items: z.array(z.object({
+    productId: z.string().uuid(),  // Duplicated
+    quantity: z.number().int().positive(),
+  })),
+  createdAt: z.date(),  // Duplicated
+})
+
+// api/comments.ts
+import { z } from 'zod'
+
+const commentSchema = z.object({
+  id: z.string().uuid(),  // Same duplication
+  userId: z.string().uuid(),
+  content: z.string().min(1),
+  createdAt: z.date(),  // Inconsistency risk
+})
+```
+
+**Correct (shared schema modules):**
+
+```typescript
+// schemas/common.ts
+import { z } from 'zod'
+
+// Reusable ID types
+export const uuid = z.string().uuid()
+export type UUID = z.infer<typeof uuid>
+
+// Timestamps
+export const timestamps = z.object({
+  createdAt: z.date(),
+  updatedAt: z.date(),
+})
+
+// Base entity with ID
+export const baseEntity = z.object({
+  id: uuid,
+}).merge(timestamps)
+
+export type BaseEntity = z.infer<typeof baseEntity>
+
+// Pagination
+export const paginationParams = z.object({
+  page: z.coerce.number().int().positive().default(1),
+  limit: z.coerce.number().int().min(1).max(100).default(20),
+})
+```
+
+```typescript
+// schemas/user.ts
+import { z } from 'zod'
+import { baseEntity, uuid } from './common'
+
+export const userSchema = baseEntity.extend({
+  email: z.string().email(),
+  name: z.string().min(1),
+})
+
+export type User = z.infer<typeof userSchema>
+```
+
+```typescript
+// schemas/order.ts
+import { z } from 'zod'
+import { baseEntity, uuid } from './common'
+
+const orderItemSchema = z.object({
+  productId: uuid,
+  quantity: z.number().int().positive(),
+})
+
+export const orderSchema = baseEntity.extend({
+  userId: uuid,
+  items: z.array(orderItemSchema).min(1),
+  total: z.number().positive(),
+})
+
+export type Order = z.infer<typeof orderSchema>
+```
+
+**Organizing schema modules:**
+
+```
+schemas/
+├── common.ts       # Shared primitives and base schemas
+├── user.ts         # User-related schemas
+├── order.ts        # Order-related schemas
+├── product.ts      # Product-related schemas
+└── index.ts        # Re-exports for convenience
+```
+
+```typescript
+// schemas/index.ts
+export * from './common'
+export * from './user'
+export * from './order'
+export * from './product'
+
+// Usage
+import { userSchema, orderSchema, uuid, type User } from '@/schemas'
+```
+
+**When NOT to use this pattern:**
+- One-off schemas used only in a single file
+- When schemas look similar but have different semantics (don't over-abstract)
+
+Reference: [Zod - Type Inference](https://zod.dev/api#type-inference)

--- a/.agents/skills/zod/references/compose-shared-schemas.md
+++ b/.agents/skills/zod/references/compose-shared-schemas.md
@@ -16,33 +16,35 @@ When the same schema pattern appears in multiple places, extract it into a share
 import { z } from 'zod'
 
 const userSchema = z.object({
-  id: z.string().uuid(),
-  email: z.string().email(),
-  name: z.string().min(1),
-  createdAt: z.date(),
+    id: z.string().uuid(),
+    email: z.string().email(),
+    name: z.string().min(1),
+    createdAt: z.date(),
 })
 
 // api/orders.ts
 import { z } from 'zod'
 
 const orderSchema = z.object({
-  id: z.string().uuid(),  // Duplicated
-  userId: z.string().uuid(),  // Same pattern
-  items: z.array(z.object({
-    productId: z.string().uuid(),  // Duplicated
-    quantity: z.number().int().positive(),
-  })),
-  createdAt: z.date(),  // Duplicated
+    id: z.string().uuid(), // Duplicated
+    userId: z.string().uuid(), // Same pattern
+    items: z.array(
+        z.object({
+            productId: z.string().uuid(), // Duplicated
+            quantity: z.number().int().positive(),
+        }),
+    ),
+    createdAt: z.date(), // Duplicated
 })
 
 // api/comments.ts
 import { z } from 'zod'
 
 const commentSchema = z.object({
-  id: z.string().uuid(),  // Same duplication
-  userId: z.string().uuid(),
-  content: z.string().min(1),
-  createdAt: z.date(),  // Inconsistency risk
+    id: z.string().uuid(), // Same duplication
+    userId: z.string().uuid(),
+    content: z.string().min(1),
+    createdAt: z.date(), // Inconsistency risk
 })
 ```
 
@@ -58,21 +60,23 @@ export type UUID = z.infer<typeof uuid>
 
 // Timestamps
 export const timestamps = z.object({
-  createdAt: z.date(),
-  updatedAt: z.date(),
+    createdAt: z.date(),
+    updatedAt: z.date(),
 })
 
 // Base entity with ID
-export const baseEntity = z.object({
-  id: uuid,
-}).merge(timestamps)
+export const baseEntity = z
+    .object({
+        id: uuid,
+    })
+    .merge(timestamps)
 
 export type BaseEntity = z.infer<typeof baseEntity>
 
 // Pagination
 export const paginationParams = z.object({
-  page: z.coerce.number().int().positive().default(1),
-  limit: z.coerce.number().int().min(1).max(100).default(20),
+    page: z.coerce.number().int().positive().default(1),
+    limit: z.coerce.number().int().min(1).max(100).default(20),
 })
 ```
 
@@ -82,8 +86,8 @@ import { z } from 'zod'
 import { baseEntity, uuid } from './common'
 
 export const userSchema = baseEntity.extend({
-  email: z.string().email(),
-  name: z.string().min(1),
+    email: z.string().email(),
+    name: z.string().min(1),
 })
 
 export type User = z.infer<typeof userSchema>
@@ -95,14 +99,14 @@ import { z } from 'zod'
 import { baseEntity, uuid } from './common'
 
 const orderItemSchema = z.object({
-  productId: uuid,
-  quantity: z.number().int().positive(),
+    productId: uuid,
+    quantity: z.number().int().positive(),
 })
 
 export const orderSchema = baseEntity.extend({
-  userId: uuid,
-  items: z.array(orderItemSchema).min(1),
-  total: z.number().positive(),
+    userId: uuid,
+    items: z.array(orderItemSchema).min(1),
+    total: z.number().positive(),
 })
 
 export type Order = z.infer<typeof orderSchema>
@@ -131,6 +135,7 @@ import { userSchema, orderSchema, uuid, type User } from '@/schemas'
 ```
 
 **When NOT to use this pattern:**
+
 - One-off schemas used only in a single file
 - When schemas look similar but have different semantics (don't over-abstract)
 

--- a/.agents/skills/zod/references/error-avoid-throwing-in-refine.md
+++ b/.agents/skills/zod/references/error-avoid-throwing-in-refine.md
@@ -1,0 +1,127 @@
+---
+title: Return False Instead of Throwing in Refine
+impact: HIGH
+impactDescription: Throwing in refine stops validation early, hiding other errors; returning false allows Zod to collect all issues
+tags: error, refine, validation, best-practices
+---
+
+## Return False Instead of Throwing in Refine
+
+When using `.refine()` for custom validation, return `false` for invalid data instead of throwing an error. Throwing stops validation immediately, preventing Zod from collecting other validation errors. This results in poor UX where users fix one error only to discover another.
+
+**Incorrect (throwing in refine):**
+
+```typescript
+import { z } from 'zod'
+
+const passwordSchema = z.object({
+  password: z.string().min(8),
+  confirmPassword: z.string(),
+}).refine((data) => {
+  if (data.password !== data.confirmPassword) {
+    // Throwing stops all further validation
+    throw new Error('Passwords do not match')
+  }
+  return true
+})
+
+const formSchema = z.object({
+  email: z.string().email(),
+  passwords: passwordSchema,
+  terms: z.boolean().refine((v) => v === true, 'Must accept terms'),
+})
+
+// If passwords don't match, user never learns about other errors
+formSchema.safeParse({
+  email: 'bad-email',
+  passwords: { password: '12345678', confirmPassword: 'different' },
+  terms: false,
+})
+// Only shows: "Passwords do not match"
+// Hidden: "Invalid email", "Must accept terms"
+```
+
+**Correct (returning false in refine):**
+
+```typescript
+import { z } from 'zod'
+
+const passwordSchema = z.object({
+  password: z.string().min(8),
+  confirmPassword: z.string(),
+}).refine(
+  (data) => data.password === data.confirmPassword,
+  { message: 'Passwords do not match', path: ['confirmPassword'] }
+)
+
+const formSchema = z.object({
+  email: z.string().email(),
+  passwords: passwordSchema,
+  terms: z.boolean().refine((v) => v === true, 'Must accept terms'),
+})
+
+// All errors are collected
+formSchema.safeParse({
+  email: 'bad-email',
+  passwords: { password: '12345678', confirmPassword: 'different' },
+  terms: false,
+})
+// Shows all errors:
+// - "Invalid email"
+// - "Passwords do not match"
+// - "Must accept terms"
+```
+
+**For multiple validation rules, use superRefine:**
+
+```typescript
+const passwordSchema = z.string().superRefine((password, ctx) => {
+  // Check multiple rules, report all failures
+  if (password.length < 8) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: 'Password must be at least 8 characters',
+    })
+  }
+
+  if (!/[A-Z]/.test(password)) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: 'Password must contain an uppercase letter',
+    })
+  }
+
+  if (!/[0-9]/.test(password)) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: 'Password must contain a number',
+    })
+  }
+
+  // Don't return anything - issues are added via ctx
+})
+
+passwordSchema.safeParse('weak')
+// All three errors reported at once
+```
+
+**Correct pattern for async validation:**
+
+```typescript
+const schema = z.object({
+  email: z.string().email(),
+}).refine(
+  async (data) => {
+    // Return boolean, don't throw
+    const exists = await checkEmailExists(data.email)
+    return !exists
+  },
+  { message: 'Email already registered', path: ['email'] }
+)
+```
+
+**When NOT to use this pattern:**
+- When you need to abort validation entirely (security issues)
+- When subsequent validations depend on current check passing
+
+Reference: [Zod API - Refine](https://zod.dev/api#refine)

--- a/.agents/skills/zod/references/error-avoid-throwing-in-refine.md
+++ b/.agents/skills/zod/references/error-avoid-throwing-in-refine.md
@@ -14,28 +14,30 @@ When using `.refine()` for custom validation, return `false` for invalid data in
 ```typescript
 import { z } from 'zod'
 
-const passwordSchema = z.object({
-  password: z.string().min(8),
-  confirmPassword: z.string(),
-}).refine((data) => {
-  if (data.password !== data.confirmPassword) {
-    // Throwing stops all further validation
-    throw new Error('Passwords do not match')
-  }
-  return true
-})
+const passwordSchema = z
+    .object({
+        password: z.string().min(8),
+        confirmPassword: z.string(),
+    })
+    .refine(data => {
+        if (data.password !== data.confirmPassword) {
+            // Throwing stops all further validation
+            throw new Error('Passwords do not match')
+        }
+        return true
+    })
 
 const formSchema = z.object({
-  email: z.string().email(),
-  passwords: passwordSchema,
-  terms: z.boolean().refine((v) => v === true, 'Must accept terms'),
+    email: z.string().email(),
+    passwords: passwordSchema,
+    terms: z.boolean().refine(v => v === true, 'Must accept terms'),
 })
 
 // If passwords don't match, user never learns about other errors
 formSchema.safeParse({
-  email: 'bad-email',
-  passwords: { password: '12345678', confirmPassword: 'different' },
-  terms: false,
+    email: 'bad-email',
+    passwords: { password: '12345678', confirmPassword: 'different' },
+    terms: false,
 })
 // Only shows: "Passwords do not match"
 // Hidden: "Invalid email", "Must accept terms"
@@ -46,25 +48,27 @@ formSchema.safeParse({
 ```typescript
 import { z } from 'zod'
 
-const passwordSchema = z.object({
-  password: z.string().min(8),
-  confirmPassword: z.string(),
-}).refine(
-  (data) => data.password === data.confirmPassword,
-  { message: 'Passwords do not match', path: ['confirmPassword'] }
-)
+const passwordSchema = z
+    .object({
+        password: z.string().min(8),
+        confirmPassword: z.string(),
+    })
+    .refine(data => data.password === data.confirmPassword, {
+        message: 'Passwords do not match',
+        path: ['confirmPassword'],
+    })
 
 const formSchema = z.object({
-  email: z.string().email(),
-  passwords: passwordSchema,
-  terms: z.boolean().refine((v) => v === true, 'Must accept terms'),
+    email: z.string().email(),
+    passwords: passwordSchema,
+    terms: z.boolean().refine(v => v === true, 'Must accept terms'),
 })
 
 // All errors are collected
 formSchema.safeParse({
-  email: 'bad-email',
-  passwords: { password: '12345678', confirmPassword: 'different' },
-  terms: false,
+    email: 'bad-email',
+    passwords: { password: '12345678', confirmPassword: 'different' },
+    terms: false,
 })
 // Shows all errors:
 // - "Invalid email"
@@ -76,29 +80,29 @@ formSchema.safeParse({
 
 ```typescript
 const passwordSchema = z.string().superRefine((password, ctx) => {
-  // Check multiple rules, report all failures
-  if (password.length < 8) {
-    ctx.addIssue({
-      code: z.ZodIssueCode.custom,
-      message: 'Password must be at least 8 characters',
-    })
-  }
+    // Check multiple rules, report all failures
+    if (password.length < 8) {
+        ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: 'Password must be at least 8 characters',
+        })
+    }
 
-  if (!/[A-Z]/.test(password)) {
-    ctx.addIssue({
-      code: z.ZodIssueCode.custom,
-      message: 'Password must contain an uppercase letter',
-    })
-  }
+    if (!/[A-Z]/.test(password)) {
+        ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: 'Password must contain an uppercase letter',
+        })
+    }
 
-  if (!/[0-9]/.test(password)) {
-    ctx.addIssue({
-      code: z.ZodIssueCode.custom,
-      message: 'Password must contain a number',
-    })
-  }
+    if (!/[0-9]/.test(password)) {
+        ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: 'Password must contain a number',
+        })
+    }
 
-  // Don't return anything - issues are added via ctx
+    // Don't return anything - issues are added via ctx
 })
 
 passwordSchema.safeParse('weak')
@@ -108,19 +112,22 @@ passwordSchema.safeParse('weak')
 **Correct pattern for async validation:**
 
 ```typescript
-const schema = z.object({
-  email: z.string().email(),
-}).refine(
-  async (data) => {
-    // Return boolean, don't throw
-    const exists = await checkEmailExists(data.email)
-    return !exists
-  },
-  { message: 'Email already registered', path: ['email'] }
-)
+const schema = z
+    .object({
+        email: z.string().email(),
+    })
+    .refine(
+        async data => {
+            // Return boolean, don't throw
+            const exists = await checkEmailExists(data.email)
+            return !exists
+        },
+        { message: 'Email already registered', path: ['email'] },
+    )
 ```
 
 **When NOT to use this pattern:**
+
 - When you need to abort validation entirely (security issues)
 - When subsequent validations depend on current check passing
 

--- a/.agents/skills/zod/references/error-custom-messages.md
+++ b/.agents/skills/zod/references/error-custom-messages.md
@@ -1,0 +1,118 @@
+---
+title: Provide Custom Error Messages
+impact: HIGH
+impactDescription: Default messages like "Expected string, received number" confuse users; custom messages like "Email is required" are actionable
+tags: error, messages, user-experience, validation
+---
+
+## Provide Custom Error Messages
+
+Zod's default error messages are technical and confusing for end users. Provide custom messages that are clear, specific, and actionable. This dramatically improves user experience when validation fails.
+
+**Incorrect (default error messages):**
+
+```typescript
+import { z } from 'zod'
+
+const signupSchema = z.object({
+  email: z.string().email(),
+  password: z.string().min(8),
+  age: z.number().min(18),
+})
+
+signupSchema.parse({ email: 'bad', password: '123', age: 15 })
+// ZodError issues:
+// - "Invalid email"
+// - "String must contain at least 8 character(s)"
+// - "Number must be greater than or equal to 18"
+// Users see: "String must contain at least 8 character(s)" - what string?
+```
+
+**Correct (custom error messages):**
+
+```typescript
+import { z } from 'zod'
+
+const signupSchema = z.object({
+  email: z.string({
+    required_error: 'Email is required',
+    invalid_type_error: 'Email must be text',
+  }).email('Please enter a valid email address'),
+
+  password: z.string({
+    required_error: 'Password is required',
+  }).min(8, 'Password must be at least 8 characters'),
+
+  age: z.number({
+    required_error: 'Age is required',
+    invalid_type_error: 'Age must be a number',
+  }).min(18, 'You must be at least 18 years old'),
+})
+
+signupSchema.parse({ email: 'bad', password: '123', age: 15 })
+// ZodError issues:
+// - "Please enter a valid email address"
+// - "Password must be at least 8 characters"
+// - "You must be at least 18 years old"
+```
+
+**Message types and when they trigger:**
+
+```typescript
+const schema = z.string({
+  // When field is undefined
+  required_error: 'This field is required',
+
+  // When field is wrong type (e.g., number instead of string)
+  invalid_type_error: 'This field must be text',
+
+  // Fallback for any other error
+  message: 'Invalid value',
+})
+.min(1, 'Cannot be empty')  // When length < 1
+.max(100, 'Too long')  // When length > 100
+.email('Invalid email format')  // When format fails
+```
+
+**Using error maps for consistent messaging:**
+
+```typescript
+const customErrorMap: z.ZodErrorMap = (issue, ctx) => {
+  // Customize messages by error code
+  if (issue.code === z.ZodIssueCode.too_small) {
+    if (issue.type === 'string') {
+      return { message: `Must be at least ${issue.minimum} characters` }
+    }
+    if (issue.type === 'number') {
+      return { message: `Must be at least ${issue.minimum}` }
+    }
+  }
+
+  if (issue.code === z.ZodIssueCode.invalid_type) {
+    if (issue.expected === 'string') {
+      return { message: 'Must be text' }
+    }
+  }
+
+  // Default to Zod's message
+  return { message: ctx.defaultError }
+}
+
+// Apply globally
+z.setErrorMap(customErrorMap)
+
+// Or per-schema
+schema.parse(data, { errorMap: customErrorMap })
+```
+
+**Good error message principles:**
+- Say what's wrong: "Password too short" not "Invalid password"
+- Say how to fix it: "at least 8 characters" not just "too short"
+- Use user's language: "email" not "string field at path .email"
+- Be specific: "Must be a positive number" not "Invalid"
+
+**When NOT to use this pattern:**
+- Internal development scripts where technical errors are fine
+- When you'll map errors to user-facing messages in the UI layer
+
+Reference: [Zod Error Customization](https://zod.dev/error-customization)

--- a/.agents/skills/zod/references/error-custom-messages.md
+++ b/.agents/skills/zod/references/error-custom-messages.md
@@ -15,9 +15,9 @@ Zod's default error messages are technical and confusing for end users. Provide 
 import { z } from 'zod'
 
 const signupSchema = z.object({
-  email: z.string().email(),
-  password: z.string().min(8),
-  age: z.number().min(18),
+    email: z.string().email(),
+    password: z.string().min(8),
+    age: z.number().min(18),
 })
 
 signupSchema.parse({ email: 'bad', password: '123', age: 15 })
@@ -34,19 +34,25 @@ signupSchema.parse({ email: 'bad', password: '123', age: 15 })
 import { z } from 'zod'
 
 const signupSchema = z.object({
-  email: z.string({
-    required_error: 'Email is required',
-    invalid_type_error: 'Email must be text',
-  }).email('Please enter a valid email address'),
+    email: z
+        .string({
+            required_error: 'Email is required',
+            invalid_type_error: 'Email must be text',
+        })
+        .email('Please enter a valid email address'),
 
-  password: z.string({
-    required_error: 'Password is required',
-  }).min(8, 'Password must be at least 8 characters'),
+    password: z
+        .string({
+            required_error: 'Password is required',
+        })
+        .min(8, 'Password must be at least 8 characters'),
 
-  age: z.number({
-    required_error: 'Age is required',
-    invalid_type_error: 'Age must be a number',
-  }).min(18, 'You must be at least 18 years old'),
+    age: z
+        .number({
+            required_error: 'Age is required',
+            invalid_type_error: 'Age must be a number',
+        })
+        .min(18, 'You must be at least 18 years old'),
 })
 
 signupSchema.parse({ email: 'bad', password: '123', age: 15 })
@@ -59,43 +65,44 @@ signupSchema.parse({ email: 'bad', password: '123', age: 15 })
 **Message types and when they trigger:**
 
 ```typescript
-const schema = z.string({
-  // When field is undefined
-  required_error: 'This field is required',
+const schema = z
+    .string({
+        // When field is undefined
+        required_error: 'This field is required',
 
-  // When field is wrong type (e.g., number instead of string)
-  invalid_type_error: 'This field must be text',
+        // When field is wrong type (e.g., number instead of string)
+        invalid_type_error: 'This field must be text',
 
-  // Fallback for any other error
-  message: 'Invalid value',
-})
-.min(1, 'Cannot be empty')  // When length < 1
-.max(100, 'Too long')  // When length > 100
-.email('Invalid email format')  // When format fails
+        // Fallback for any other error
+        message: 'Invalid value',
+    })
+    .min(1, 'Cannot be empty') // When length < 1
+    .max(100, 'Too long') // When length > 100
+    .email('Invalid email format') // When format fails
 ```
 
 **Using error maps for consistent messaging:**
 
 ```typescript
 const customErrorMap: z.ZodErrorMap = (issue, ctx) => {
-  // Customize messages by error code
-  if (issue.code === z.ZodIssueCode.too_small) {
-    if (issue.type === 'string') {
-      return { message: `Must be at least ${issue.minimum} characters` }
+    // Customize messages by error code
+    if (issue.code === z.ZodIssueCode.too_small) {
+        if (issue.type === 'string') {
+            return { message: `Must be at least ${issue.minimum} characters` }
+        }
+        if (issue.type === 'number') {
+            return { message: `Must be at least ${issue.minimum}` }
+        }
     }
-    if (issue.type === 'number') {
-      return { message: `Must be at least ${issue.minimum}` }
-    }
-  }
 
-  if (issue.code === z.ZodIssueCode.invalid_type) {
-    if (issue.expected === 'string') {
-      return { message: 'Must be text' }
+    if (issue.code === z.ZodIssueCode.invalid_type) {
+        if (issue.expected === 'string') {
+            return { message: 'Must be text' }
+        }
     }
-  }
 
-  // Default to Zod's message
-  return { message: ctx.defaultError }
+    // Default to Zod's message
+    return { message: ctx.defaultError }
 }
 
 // Apply globally
@@ -106,12 +113,14 @@ schema.parse(data, { errorMap: customErrorMap })
 ```
 
 **Good error message principles:**
+
 - Say what's wrong: "Password too short" not "Invalid password"
 - Say how to fix it: "at least 8 characters" not just "too short"
 - Use user's language: "email" not "string field at path .email"
 - Be specific: "Must be a positive number" not "Invalid"
 
 **When NOT to use this pattern:**
+
 - Internal development scripts where technical errors are fine
 - When you'll map errors to user-facing messages in the UI layer
 

--- a/.agents/skills/zod/references/error-i18n.md
+++ b/.agents/skills/zod/references/error-i18n.md
@@ -1,0 +1,145 @@
+---
+title: Implement Internationalized Error Messages
+impact: HIGH
+impactDescription: Hardcoded English messages exclude non-English users; error maps enable localized messages for global applications
+tags: error, i18n, localization, internationalization
+---
+
+## Implement Internationalized Error Messages
+
+Hardcoded error messages in English exclude users who speak other languages. Use Zod's error map feature to provide localized messages based on user locale, making your application accessible globally.
+
+**Incorrect (hardcoded English messages):**
+
+```typescript
+import { z } from 'zod'
+
+const userSchema = z.object({
+  name: z.string().min(1, 'Name is required'),
+  email: z.string().email('Invalid email address'),
+  age: z.number().min(18, 'You must be at least 18 years old'),
+})
+
+// French users see English errors - poor UX
+```
+
+**Correct (localized error messages):**
+
+```typescript
+import { z } from 'zod'
+
+// Translation dictionaries
+const translations = {
+  en: {
+    required: 'This field is required',
+    invalidEmail: 'Please enter a valid email address',
+    tooShort: (min: number) => `Must be at least ${min} characters`,
+    tooYoung: (min: number) => `You must be at least ${min} years old`,
+  },
+  fr: {
+    required: 'Ce champ est obligatoire',
+    invalidEmail: 'Veuillez entrer une adresse email valide',
+    tooShort: (min: number) => `Doit contenir au moins ${min} caractères`,
+    tooYoung: (min: number) => `Vous devez avoir au moins ${min} ans`,
+  },
+  es: {
+    required: 'Este campo es requerido',
+    invalidEmail: 'Por favor ingrese un correo electrónico válido',
+    tooShort: (min: number) => `Debe tener al menos ${min} caracteres`,
+    tooYoung: (min: number) => `Debes tener al menos ${min} años`,
+  },
+} as const
+
+type Locale = keyof typeof translations
+
+function createErrorMap(locale: Locale): z.ZodErrorMap {
+  const t = translations[locale]
+
+  return (issue, ctx) => {
+    switch (issue.code) {
+      case z.ZodIssueCode.invalid_type:
+        if (issue.received === 'undefined') {
+          return { message: t.required }
+        }
+        break
+
+      case z.ZodIssueCode.invalid_string:
+        if (issue.validation === 'email') {
+          return { message: t.invalidEmail }
+        }
+        break
+
+      case z.ZodIssueCode.too_small:
+        if (issue.type === 'string') {
+          return { message: t.tooShort(issue.minimum as number) }
+        }
+        if (issue.type === 'number') {
+          return { message: t.tooYoung(issue.minimum as number) }
+        }
+        break
+    }
+
+    return { message: ctx.defaultError }
+  }
+}
+
+// Usage with user's locale
+const userLocale: Locale = 'fr'
+const errorMap = createErrorMap(userLocale)
+
+const userSchema = z.object({
+  name: z.string().min(1),
+  email: z.string().email(),
+  age: z.number().min(18),
+})
+
+const result = userSchema.safeParse(
+  { name: '', email: 'bad', age: 15 },
+  { errorMap }
+)
+
+// French error messages:
+// - "Ce champ est obligatoire"
+// - "Veuillez entrer une adresse email valide"
+// - "Vous devez avoir au moins 18 ans"
+```
+
+**Setting error map globally:**
+
+```typescript
+// At application startup
+const userLocale = getUserLocale()  // From cookie, header, etc.
+z.setErrorMap(createErrorMap(userLocale))
+
+// All schemas now use localized messages
+```
+
+**With i18n libraries (react-intl, i18next):**
+
+```typescript
+import { useIntl } from 'react-intl'
+
+function useZodErrorMap() {
+  const intl = useIntl()
+
+  return (issue: z.ZodIssue, ctx: z.ErrorMapCtx) => {
+    switch (issue.code) {
+      case z.ZodIssueCode.too_small:
+        return {
+          message: intl.formatMessage(
+            { id: 'validation.tooShort' },
+            { min: issue.minimum }
+          )
+        }
+      // ...
+    }
+    return { message: ctx.defaultError }
+  }
+}
+```
+
+**When NOT to use this pattern:**
+- Internal tools used only by your team
+- Single-language applications
+
+Reference: [Zod Error Customization - Internationalization](https://zod.dev/error-customization#internationalization)

--- a/.agents/skills/zod/references/error-i18n.md
+++ b/.agents/skills/zod/references/error-i18n.md
@@ -15,9 +15,9 @@ Hardcoded error messages in English exclude users who speak other languages. Use
 import { z } from 'zod'
 
 const userSchema = z.object({
-  name: z.string().min(1, 'Name is required'),
-  email: z.string().email('Invalid email address'),
-  age: z.number().min(18, 'You must be at least 18 years old'),
+    name: z.string().min(1, 'Name is required'),
+    email: z.string().email('Invalid email address'),
+    age: z.number().min(18, 'You must be at least 18 years old'),
 })
 
 // French users see English errors - poor UX
@@ -30,57 +30,57 @@ import { z } from 'zod'
 
 // Translation dictionaries
 const translations = {
-  en: {
-    required: 'This field is required',
-    invalidEmail: 'Please enter a valid email address',
-    tooShort: (min: number) => `Must be at least ${min} characters`,
-    tooYoung: (min: number) => `You must be at least ${min} years old`,
-  },
-  fr: {
-    required: 'Ce champ est obligatoire',
-    invalidEmail: 'Veuillez entrer une adresse email valide',
-    tooShort: (min: number) => `Doit contenir au moins ${min} caractères`,
-    tooYoung: (min: number) => `Vous devez avoir au moins ${min} ans`,
-  },
-  es: {
-    required: 'Este campo es requerido',
-    invalidEmail: 'Por favor ingrese un correo electrónico válido',
-    tooShort: (min: number) => `Debe tener al menos ${min} caracteres`,
-    tooYoung: (min: number) => `Debes tener al menos ${min} años`,
-  },
+    en: {
+        required: 'This field is required',
+        invalidEmail: 'Please enter a valid email address',
+        tooShort: (min: number) => `Must be at least ${min} characters`,
+        tooYoung: (min: number) => `You must be at least ${min} years old`,
+    },
+    fr: {
+        required: 'Ce champ est obligatoire',
+        invalidEmail: 'Veuillez entrer une adresse email valide',
+        tooShort: (min: number) => `Doit contenir au moins ${min} caractères`,
+        tooYoung: (min: number) => `Vous devez avoir au moins ${min} ans`,
+    },
+    es: {
+        required: 'Este campo es requerido',
+        invalidEmail: 'Por favor ingrese un correo electrónico válido',
+        tooShort: (min: number) => `Debe tener al menos ${min} caracteres`,
+        tooYoung: (min: number) => `Debes tener al menos ${min} años`,
+    },
 } as const
 
 type Locale = keyof typeof translations
 
 function createErrorMap(locale: Locale): z.ZodErrorMap {
-  const t = translations[locale]
+    const t = translations[locale]
 
-  return (issue, ctx) => {
-    switch (issue.code) {
-      case z.ZodIssueCode.invalid_type:
-        if (issue.received === 'undefined') {
-          return { message: t.required }
-        }
-        break
+    return (issue, ctx) => {
+        switch (issue.code) {
+            case z.ZodIssueCode.invalid_type:
+                if (issue.received === 'undefined') {
+                    return { message: t.required }
+                }
+                break
 
-      case z.ZodIssueCode.invalid_string:
-        if (issue.validation === 'email') {
-          return { message: t.invalidEmail }
-        }
-        break
+            case z.ZodIssueCode.invalid_string:
+                if (issue.validation === 'email') {
+                    return { message: t.invalidEmail }
+                }
+                break
 
-      case z.ZodIssueCode.too_small:
-        if (issue.type === 'string') {
-          return { message: t.tooShort(issue.minimum as number) }
+            case z.ZodIssueCode.too_small:
+                if (issue.type === 'string') {
+                    return { message: t.tooShort(issue.minimum as number) }
+                }
+                if (issue.type === 'number') {
+                    return { message: t.tooYoung(issue.minimum as number) }
+                }
+                break
         }
-        if (issue.type === 'number') {
-          return { message: t.tooYoung(issue.minimum as number) }
-        }
-        break
+
+        return { message: ctx.defaultError }
     }
-
-    return { message: ctx.defaultError }
-  }
 }
 
 // Usage with user's locale
@@ -88,14 +88,14 @@ const userLocale: Locale = 'fr'
 const errorMap = createErrorMap(userLocale)
 
 const userSchema = z.object({
-  name: z.string().min(1),
-  email: z.string().email(),
-  age: z.number().min(18),
+    name: z.string().min(1),
+    email: z.string().email(),
+    age: z.number().min(18),
 })
 
 const result = userSchema.safeParse(
-  { name: '', email: 'bad', age: 15 },
-  { errorMap }
+    { name: '', email: 'bad', age: 15 },
+    { errorMap },
 )
 
 // French error messages:
@@ -108,7 +108,7 @@ const result = userSchema.safeParse(
 
 ```typescript
 // At application startup
-const userLocale = getUserLocale()  // From cookie, header, etc.
+const userLocale = getUserLocale() // From cookie, header, etc.
 z.setErrorMap(createErrorMap(userLocale))
 
 // All schemas now use localized messages
@@ -120,25 +120,26 @@ z.setErrorMap(createErrorMap(userLocale))
 import { useIntl } from 'react-intl'
 
 function useZodErrorMap() {
-  const intl = useIntl()
+    const intl = useIntl()
 
-  return (issue: z.ZodIssue, ctx: z.ErrorMapCtx) => {
-    switch (issue.code) {
-      case z.ZodIssueCode.too_small:
-        return {
-          message: intl.formatMessage(
-            { id: 'validation.tooShort' },
-            { min: issue.minimum }
-          )
+    return (issue: z.ZodIssue, ctx: z.ErrorMapCtx) => {
+        switch (issue.code) {
+            case z.ZodIssueCode.too_small:
+                return {
+                    message: intl.formatMessage(
+                        { id: 'validation.tooShort' },
+                        { min: issue.minimum },
+                    ),
+                }
+            // ...
         }
-      // ...
+        return { message: ctx.defaultError }
     }
-    return { message: ctx.defaultError }
-  }
 }
 ```
 
 **When NOT to use this pattern:**
+
 - Internal tools used only by your team
 - Single-language applications
 

--- a/.agents/skills/zod/references/error-path-for-nested.md
+++ b/.agents/skills/zod/references/error-path-for-nested.md
@@ -1,0 +1,130 @@
+---
+title: Use issue.path for Nested Error Location
+impact: HIGH
+impactDescription: Without path information, users can't identify which nested field failed; path provides exact location in complex objects
+tags: error, path, nested, debugging
+---
+
+## Use issue.path for Nested Error Location
+
+When validating nested objects or arrays, `issue.path` tells you exactly where the error occurred. This is essential for highlighting the correct form field or providing precise error messages in complex data structures.
+
+**Incorrect (ignoring path information):**
+
+```typescript
+import { z } from 'zod'
+
+const orderSchema = z.object({
+  customer: z.object({
+    name: z.string().min(1, 'Name required'),
+    address: z.object({
+      street: z.string().min(1, 'Street required'),
+      city: z.string().min(1, 'City required'),
+    }),
+  }),
+  items: z.array(z.object({
+    productId: z.string(),
+    quantity: z.number().positive('Quantity must be positive'),
+  })),
+})
+
+const result = orderSchema.safeParse({
+  customer: { name: '', address: { street: '', city: '' } },
+  items: [{ productId: 'abc', quantity: -1 }],
+})
+
+if (!result.success) {
+  // Only showing message, not WHERE the error is
+  result.error.issues.forEach(issue => {
+    console.log(issue.message)  // 'Name required', 'Street required', 'Quantity must be positive'
+    // User: "Which quantity? Which field?"
+  })
+}
+```
+
+**Correct (using path information):**
+
+```typescript
+import { z } from 'zod'
+
+const orderSchema = z.object({
+  customer: z.object({
+    name: z.string().min(1, 'Name required'),
+    address: z.object({
+      street: z.string().min(1, 'Street required'),
+      city: z.string().min(1, 'City required'),
+    }),
+  }),
+  items: z.array(z.object({
+    productId: z.string(),
+    quantity: z.number().positive('Quantity must be positive'),
+  })),
+})
+
+const result = orderSchema.safeParse({
+  customer: { name: '', address: { street: '', city: '' } },
+  items: [{ productId: 'abc', quantity: -1 }],
+})
+
+if (!result.success) {
+  result.error.issues.forEach(issue => {
+    // path is an array of keys/indices
+    console.log(`${issue.path.join('.')}: ${issue.message}`)
+    // 'customer.name: Name required'
+    // 'customer.address.street: Street required'
+    // 'customer.address.city: City required'
+    // 'items.0.quantity: Quantity must be positive'
+  })
+}
+```
+
+**Building field-specific error mapping:**
+
+```typescript
+function mapErrorsToFields(error: z.ZodError) {
+  const fieldErrors: Map<string, string[]> = new Map()
+
+  for (const issue of error.issues) {
+    const fieldPath = issue.path.join('.')
+    const existing = fieldErrors.get(fieldPath) ?? []
+    fieldErrors.set(fieldPath, [...existing, issue.message])
+  }
+
+  return fieldErrors
+}
+
+// Usage
+const errors = mapErrorsToFields(result.error)
+errors.get('customer.name')  // ['Name required']
+errors.get('items.0.quantity')  // ['Quantity must be positive']
+```
+
+**For array items, get index from path:**
+
+```typescript
+const itemsWithErrors: Set<number> = new Set()
+
+result.error.issues.forEach(issue => {
+  if (issue.path[0] === 'items' && typeof issue.path[1] === 'number') {
+    itemsWithErrors.add(issue.path[1])
+  }
+})
+
+// Highlight items at indices: Set { 0 }
+```
+
+**Using path with format():**
+
+```typescript
+const formatted = result.error.format()
+
+// Access errors at any path level
+formatted.customer?.address?.city?._errors  // ['City required']
+formatted.items?.[0]?.quantity?._errors  // ['Quantity must be positive']
+```
+
+**When NOT to use this pattern:**
+- Flat objects where field name is obvious
+- When using form libraries that handle path mapping
+
+Reference: [Zod Error Handling](https://zod.dev/error-handling)

--- a/.agents/skills/zod/references/error-path-for-nested.md
+++ b/.agents/skills/zod/references/error-path-for-nested.md
@@ -15,30 +15,32 @@ When validating nested objects or arrays, `issue.path` tells you exactly where t
 import { z } from 'zod'
 
 const orderSchema = z.object({
-  customer: z.object({
-    name: z.string().min(1, 'Name required'),
-    address: z.object({
-      street: z.string().min(1, 'Street required'),
-      city: z.string().min(1, 'City required'),
+    customer: z.object({
+        name: z.string().min(1, 'Name required'),
+        address: z.object({
+            street: z.string().min(1, 'Street required'),
+            city: z.string().min(1, 'City required'),
+        }),
     }),
-  }),
-  items: z.array(z.object({
-    productId: z.string(),
-    quantity: z.number().positive('Quantity must be positive'),
-  })),
+    items: z.array(
+        z.object({
+            productId: z.string(),
+            quantity: z.number().positive('Quantity must be positive'),
+        }),
+    ),
 })
 
 const result = orderSchema.safeParse({
-  customer: { name: '', address: { street: '', city: '' } },
-  items: [{ productId: 'abc', quantity: -1 }],
+    customer: { name: '', address: { street: '', city: '' } },
+    items: [{ productId: 'abc', quantity: -1 }],
 })
 
 if (!result.success) {
-  // Only showing message, not WHERE the error is
-  result.error.issues.forEach(issue => {
-    console.log(issue.message)  // 'Name required', 'Street required', 'Quantity must be positive'
-    // User: "Which quantity? Which field?"
-  })
+    // Only showing message, not WHERE the error is
+    result.error.issues.forEach(issue => {
+        console.log(issue.message) // 'Name required', 'Street required', 'Quantity must be positive'
+        // User: "Which quantity? Which field?"
+    })
 }
 ```
 
@@ -48,33 +50,35 @@ if (!result.success) {
 import { z } from 'zod'
 
 const orderSchema = z.object({
-  customer: z.object({
-    name: z.string().min(1, 'Name required'),
-    address: z.object({
-      street: z.string().min(1, 'Street required'),
-      city: z.string().min(1, 'City required'),
+    customer: z.object({
+        name: z.string().min(1, 'Name required'),
+        address: z.object({
+            street: z.string().min(1, 'Street required'),
+            city: z.string().min(1, 'City required'),
+        }),
     }),
-  }),
-  items: z.array(z.object({
-    productId: z.string(),
-    quantity: z.number().positive('Quantity must be positive'),
-  })),
+    items: z.array(
+        z.object({
+            productId: z.string(),
+            quantity: z.number().positive('Quantity must be positive'),
+        }),
+    ),
 })
 
 const result = orderSchema.safeParse({
-  customer: { name: '', address: { street: '', city: '' } },
-  items: [{ productId: 'abc', quantity: -1 }],
+    customer: { name: '', address: { street: '', city: '' } },
+    items: [{ productId: 'abc', quantity: -1 }],
 })
 
 if (!result.success) {
-  result.error.issues.forEach(issue => {
-    // path is an array of keys/indices
-    console.log(`${issue.path.join('.')}: ${issue.message}`)
-    // 'customer.name: Name required'
-    // 'customer.address.street: Street required'
-    // 'customer.address.city: City required'
-    // 'items.0.quantity: Quantity must be positive'
-  })
+    result.error.issues.forEach(issue => {
+        // path is an array of keys/indices
+        console.log(`${issue.path.join('.')}: ${issue.message}`)
+        // 'customer.name: Name required'
+        // 'customer.address.street: Street required'
+        // 'customer.address.city: City required'
+        // 'items.0.quantity: Quantity must be positive'
+    })
 }
 ```
 
@@ -82,21 +86,21 @@ if (!result.success) {
 
 ```typescript
 function mapErrorsToFields(error: z.ZodError) {
-  const fieldErrors: Map<string, string[]> = new Map()
+    const fieldErrors: Map<string, string[]> = new Map()
 
-  for (const issue of error.issues) {
-    const fieldPath = issue.path.join('.')
-    const existing = fieldErrors.get(fieldPath) ?? []
-    fieldErrors.set(fieldPath, [...existing, issue.message])
-  }
+    for (const issue of error.issues) {
+        const fieldPath = issue.path.join('.')
+        const existing = fieldErrors.get(fieldPath) ?? []
+        fieldErrors.set(fieldPath, [...existing, issue.message])
+    }
 
-  return fieldErrors
+    return fieldErrors
 }
 
 // Usage
 const errors = mapErrorsToFields(result.error)
-errors.get('customer.name')  // ['Name required']
-errors.get('items.0.quantity')  // ['Quantity must be positive']
+errors.get('customer.name') // ['Name required']
+errors.get('items.0.quantity') // ['Quantity must be positive']
 ```
 
 **For array items, get index from path:**
@@ -105,9 +109,9 @@ errors.get('items.0.quantity')  // ['Quantity must be positive']
 const itemsWithErrors: Set<number> = new Set()
 
 result.error.issues.forEach(issue => {
-  if (issue.path[0] === 'items' && typeof issue.path[1] === 'number') {
-    itemsWithErrors.add(issue.path[1])
-  }
+    if (issue.path[0] === 'items' && typeof issue.path[1] === 'number') {
+        itemsWithErrors.add(issue.path[1])
+    }
 })
 
 // Highlight items at indices: Set { 0 }
@@ -119,11 +123,12 @@ result.error.issues.forEach(issue => {
 const formatted = result.error.format()
 
 // Access errors at any path level
-formatted.customer?.address?.city?._errors  // ['City required']
-formatted.items?.[0]?.quantity?._errors  // ['Quantity must be positive']
+formatted.customer?.address?.city?._errors // ['City required']
+formatted.items?.[0]?.quantity?._errors // ['Quantity must be positive']
 ```
 
 **When NOT to use this pattern:**
+
 - Flat objects where field name is obvious
 - When using form libraries that handle path mapping
 

--- a/.agents/skills/zod/references/error-use-flatten.md
+++ b/.agents/skills/zod/references/error-use-flatten.md
@@ -1,0 +1,131 @@
+---
+title: Use flatten() for Form Error Display
+impact: HIGH
+impactDescription: Raw ZodError.issues requires manual path parsing; flatten() provides field-keyed errors ready for form display
+tags: error, flatten, forms, user-experience
+---
+
+## Use flatten() for Form Error Display
+
+`ZodError.issues` is an array that requires manual processing to map errors to form fields. `ZodError.flatten()` returns an object with `fieldErrors` keyed by field name, ready for form libraries and UI display.
+
+**Incorrect (manual issue processing):**
+
+```typescript
+import { z } from 'zod'
+
+const formSchema = z.object({
+  email: z.string().email('Invalid email'),
+  password: z.string().min(8, 'Password too short'),
+  profile: z.object({
+    name: z.string().min(1, 'Name required'),
+  }),
+})
+
+function getFieldErrors(error: z.ZodError) {
+  const errors: Record<string, string> = {}
+
+  for (const issue of error.issues) {
+    // Manual path joining - error prone
+    const field = issue.path.join('.')
+    if (!errors[field]) {
+      errors[field] = issue.message
+    }
+  }
+
+  return errors
+}
+
+const result = formSchema.safeParse(data)
+if (!result.success) {
+  const errors = getFieldErrors(result.error)
+  // { email: 'Invalid email', 'profile.name': 'Name required' }
+}
+```
+
+**Correct (using flatten):**
+
+```typescript
+import { z } from 'zod'
+
+const formSchema = z.object({
+  email: z.string().email('Invalid email'),
+  password: z.string().min(8, 'Password too short'),
+  profile: z.object({
+    name: z.string().min(1, 'Name required'),
+  }),
+})
+
+const result = formSchema.safeParse(data)
+
+if (!result.success) {
+  const { formErrors, fieldErrors } = result.error.flatten()
+
+  // formErrors: string[] - top-level errors (from .refine on the object)
+  // fieldErrors: { [key]: string[] } - errors by field
+
+  // Ready for form display
+  console.log(fieldErrors)
+  // {
+  //   email: ['Invalid email'],
+  //   password: ['Password too short'],
+  //   'profile.name': ['Name required']
+  // }
+}
+```
+
+**With React Hook Form:**
+
+```typescript
+import { zodResolver } from '@hookform/resolvers/zod'
+import { useForm } from 'react-hook-form'
+
+const { register, formState: { errors } } = useForm({
+  resolver: zodResolver(formSchema),
+})
+
+// errors are already flattened by the resolver
+// <input {...register('email')} />
+// {errors.email && <span>{errors.email.message}</span>}
+```
+
+**Customizing flatten output:**
+
+```typescript
+const flattened = result.error.flatten((issue) => ({
+  message: issue.message,
+  code: issue.code,
+}))
+
+// fieldErrors now contains custom objects
+// {
+//   email: [{ message: 'Invalid email', code: 'invalid_string' }],
+// }
+```
+
+**For deeply nested objects, use format():**
+
+```typescript
+const result = formSchema.safeParse(data)
+
+if (!result.success) {
+  const formatted = result.error.format()
+  // {
+  //   _errors: [],
+  //   email: { _errors: ['Invalid email'] },
+  //   profile: {
+  //     _errors: [],
+  //     name: { _errors: ['Name required'] }
+  //   }
+  // }
+
+  // Access nested errors naturally
+  formatted.profile?.name?._errors  // ['Name required']
+}
+```
+
+**When NOT to use this pattern:**
+- When you need access to full issue metadata (code, path as array)
+- When using a form library that expects different error format
+
+Reference: [Zod Error Handling](https://zod.dev/error-handling)

--- a/.agents/skills/zod/references/error-use-flatten.md
+++ b/.agents/skills/zod/references/error-use-flatten.md
@@ -15,31 +15,31 @@ tags: error, flatten, forms, user-experience
 import { z } from 'zod'
 
 const formSchema = z.object({
-  email: z.string().email('Invalid email'),
-  password: z.string().min(8, 'Password too short'),
-  profile: z.object({
-    name: z.string().min(1, 'Name required'),
-  }),
+    email: z.string().email('Invalid email'),
+    password: z.string().min(8, 'Password too short'),
+    profile: z.object({
+        name: z.string().min(1, 'Name required'),
+    }),
 })
 
 function getFieldErrors(error: z.ZodError) {
-  const errors: Record<string, string> = {}
+    const errors: Record<string, string> = {}
 
-  for (const issue of error.issues) {
-    // Manual path joining - error prone
-    const field = issue.path.join('.')
-    if (!errors[field]) {
-      errors[field] = issue.message
+    for (const issue of error.issues) {
+        // Manual path joining - error prone
+        const field = issue.path.join('.')
+        if (!errors[field]) {
+            errors[field] = issue.message
+        }
     }
-  }
 
-  return errors
+    return errors
 }
 
 const result = formSchema.safeParse(data)
 if (!result.success) {
-  const errors = getFieldErrors(result.error)
-  // { email: 'Invalid email', 'profile.name': 'Name required' }
+    const errors = getFieldErrors(result.error)
+    // { email: 'Invalid email', 'profile.name': 'Name required' }
 }
 ```
 
@@ -49,28 +49,28 @@ if (!result.success) {
 import { z } from 'zod'
 
 const formSchema = z.object({
-  email: z.string().email('Invalid email'),
-  password: z.string().min(8, 'Password too short'),
-  profile: z.object({
-    name: z.string().min(1, 'Name required'),
-  }),
+    email: z.string().email('Invalid email'),
+    password: z.string().min(8, 'Password too short'),
+    profile: z.object({
+        name: z.string().min(1, 'Name required'),
+    }),
 })
 
 const result = formSchema.safeParse(data)
 
 if (!result.success) {
-  const { formErrors, fieldErrors } = result.error.flatten()
+    const { formErrors, fieldErrors } = result.error.flatten()
 
-  // formErrors: string[] - top-level errors (from .refine on the object)
-  // fieldErrors: { [key]: string[] } - errors by field
+    // formErrors: string[] - top-level errors (from .refine on the object)
+    // fieldErrors: { [key]: string[] } - errors by field
 
-  // Ready for form display
-  console.log(fieldErrors)
-  // {
-  //   email: ['Invalid email'],
-  //   password: ['Password too short'],
-  //   'profile.name': ['Name required']
-  // }
+    // Ready for form display
+    console.log(fieldErrors)
+    // {
+    //   email: ['Invalid email'],
+    //   password: ['Password too short'],
+    //   'profile.name': ['Name required']
+    // }
 }
 ```
 
@@ -80,8 +80,11 @@ if (!result.success) {
 import { zodResolver } from '@hookform/resolvers/zod'
 import { useForm } from 'react-hook-form'
 
-const { register, formState: { errors } } = useForm({
-  resolver: zodResolver(formSchema),
+const {
+    register,
+    formState: { errors },
+} = useForm({
+    resolver: zodResolver(formSchema),
 })
 
 // errors are already flattened by the resolver
@@ -92,9 +95,9 @@ const { register, formState: { errors } } = useForm({
 **Customizing flatten output:**
 
 ```typescript
-const flattened = result.error.flatten((issue) => ({
-  message: issue.message,
-  code: issue.code,
+const flattened = result.error.flatten(issue => ({
+    message: issue.message,
+    code: issue.code,
 }))
 
 // fieldErrors now contains custom objects
@@ -109,22 +112,23 @@ const flattened = result.error.flatten((issue) => ({
 const result = formSchema.safeParse(data)
 
 if (!result.success) {
-  const formatted = result.error.format()
-  // {
-  //   _errors: [],
-  //   email: { _errors: ['Invalid email'] },
-  //   profile: {
-  //     _errors: [],
-  //     name: { _errors: ['Name required'] }
-  //   }
-  // }
+    const formatted = result.error.format()
+    // {
+    //   _errors: [],
+    //   email: { _errors: ['Invalid email'] },
+    //   profile: {
+    //     _errors: [],
+    //     name: { _errors: ['Name required'] }
+    //   }
+    // }
 
-  // Access nested errors naturally
-  formatted.profile?.name?._errors  // ['Name required']
+    // Access nested errors naturally
+    formatted.profile?.name?._errors // ['Name required']
 }
 ```
 
 **When NOT to use this pattern:**
+
 - When you need access to full issue metadata (code, path as array)
 - When using a form library that expects different error format
 

--- a/.agents/skills/zod/references/object-discriminated-unions.md
+++ b/.agents/skills/zod/references/object-discriminated-unions.md
@@ -1,0 +1,138 @@
+---
+title: Use Discriminated Unions for Type Narrowing
+impact: MEDIUM-HIGH
+impactDescription: Regular unions require manual type guards; discriminated unions enable TypeScript's automatic narrowing and Zod's optimized parsing
+tags: object, discriminatedUnion, narrowing, typescript
+---
+
+## Use Discriminated Unions for Type Narrowing
+
+When a field's type depends on another field's value (e.g., `type: 'success'` means `data` exists, `type: 'error'` means `error` exists), use `z.discriminatedUnion()`. This enables TypeScript's automatic type narrowing and Zod's optimized O(1) parsing instead of trying each variant.
+
+**Incorrect (regular union - no automatic narrowing):**
+
+```typescript
+import { z } from 'zod'
+
+const successSchema = z.object({
+  type: z.literal('success'),
+  data: z.object({ id: z.string() }),
+})
+
+const errorSchema = z.object({
+  type: z.literal('error'),
+  message: z.string(),
+})
+
+// Regular union - Zod tries each option in order
+const responseSchema = z.union([successSchema, errorSchema])
+
+type Response = z.infer<typeof responseSchema>
+
+function handleResponse(response: Response) {
+  // TypeScript doesn't narrow automatically
+  if (response.type === 'success') {
+    response.data  // Error: Property 'data' does not exist on type 'Response'
+    // Must cast or use type guards
+  }
+}
+```
+
+**Correct (discriminated union):**
+
+```typescript
+import { z } from 'zod'
+
+const successSchema = z.object({
+  type: z.literal('success'),
+  data: z.object({ id: z.string() }),
+})
+
+const errorSchema = z.object({
+  type: z.literal('error'),
+  message: z.string(),
+})
+
+// Discriminated union - Zod uses 'type' field for O(1) dispatch
+const responseSchema = z.discriminatedUnion('type', [
+  successSchema,
+  errorSchema,
+])
+
+type Response = z.infer<typeof responseSchema>
+
+function handleResponse(response: Response) {
+  // TypeScript narrows automatically!
+  if (response.type === 'success') {
+    response.data.id  // Works - TypeScript knows data exists
+  } else {
+    response.message  // Works - TypeScript knows message exists
+  }
+}
+```
+
+**Common use cases:**
+
+```typescript
+// API responses
+const apiResponse = z.discriminatedUnion('status', [
+  z.object({ status: z.literal('success'), data: z.unknown() }),
+  z.object({ status: z.literal('error'), error: z.string(), code: z.number() }),
+  z.object({ status: z.literal('loading') }),
+])
+
+// Event types
+const event = z.discriminatedUnion('type', [
+  z.object({ type: z.literal('click'), x: z.number(), y: z.number() }),
+  z.object({ type: z.literal('keypress'), key: z.string() }),
+  z.object({ type: z.literal('scroll'), delta: z.number() }),
+])
+
+// Database records with polymorphic types
+const notification = z.discriminatedUnion('channel', [
+  z.object({ channel: z.literal('email'), address: z.string().email() }),
+  z.object({ channel: z.literal('sms'), phoneNumber: z.string() }),
+  z.object({ channel: z.literal('push'), deviceToken: z.string() }),
+])
+```
+
+**Type-safe handling:**
+
+```typescript
+const paymentSchema = z.discriminatedUnion('method', [
+  z.object({
+    method: z.literal('card'),
+    cardNumber: z.string(),
+    expiryDate: z.string(),
+  }),
+  z.object({
+    method: z.literal('bank'),
+    accountNumber: z.string(),
+    routingNumber: z.string(),
+  }),
+  z.object({
+    method: z.literal('crypto'),
+    walletAddress: z.string(),
+  }),
+])
+
+type Payment = z.infer<typeof paymentSchema>
+
+function processPayment(payment: Payment) {
+  switch (payment.method) {
+    case 'card':
+      return chargeCard(payment.cardNumber, payment.expiryDate)
+    case 'bank':
+      return initiateBankTransfer(payment.accountNumber, payment.routingNumber)
+    case 'crypto':
+      return sendCrypto(payment.walletAddress)
+    // TypeScript exhaustiveness check - no default needed
+  }
+}
+```
+
+**When NOT to use this pattern:**
+- When variants don't share a common discriminator field
+- When the discriminator isn't a literal type (use regular union)
+
+Reference: [Zod API - Discriminated Unions](https://zod.dev/api#discriminated-unions)

--- a/.agents/skills/zod/references/object-discriminated-unions.md
+++ b/.agents/skills/zod/references/object-discriminated-unions.md
@@ -15,13 +15,13 @@ When a field's type depends on another field's value (e.g., `type: 'success'` me
 import { z } from 'zod'
 
 const successSchema = z.object({
-  type: z.literal('success'),
-  data: z.object({ id: z.string() }),
+    type: z.literal('success'),
+    data: z.object({ id: z.string() }),
 })
 
 const errorSchema = z.object({
-  type: z.literal('error'),
-  message: z.string(),
+    type: z.literal('error'),
+    message: z.string(),
 })
 
 // Regular union - Zod tries each option in order
@@ -30,11 +30,11 @@ const responseSchema = z.union([successSchema, errorSchema])
 type Response = z.infer<typeof responseSchema>
 
 function handleResponse(response: Response) {
-  // TypeScript doesn't narrow automatically
-  if (response.type === 'success') {
-    response.data  // Error: Property 'data' does not exist on type 'Response'
-    // Must cast or use type guards
-  }
+    // TypeScript doesn't narrow automatically
+    if (response.type === 'success') {
+        response.data // Error: Property 'data' does not exist on type 'Response'
+        // Must cast or use type guards
+    }
 }
 ```
 
@@ -44,30 +44,30 @@ function handleResponse(response: Response) {
 import { z } from 'zod'
 
 const successSchema = z.object({
-  type: z.literal('success'),
-  data: z.object({ id: z.string() }),
+    type: z.literal('success'),
+    data: z.object({ id: z.string() }),
 })
 
 const errorSchema = z.object({
-  type: z.literal('error'),
-  message: z.string(),
+    type: z.literal('error'),
+    message: z.string(),
 })
 
 // Discriminated union - Zod uses 'type' field for O(1) dispatch
 const responseSchema = z.discriminatedUnion('type', [
-  successSchema,
-  errorSchema,
+    successSchema,
+    errorSchema,
 ])
 
 type Response = z.infer<typeof responseSchema>
 
 function handleResponse(response: Response) {
-  // TypeScript narrows automatically!
-  if (response.type === 'success') {
-    response.data.id  // Works - TypeScript knows data exists
-  } else {
-    response.message  // Works - TypeScript knows message exists
-  }
+    // TypeScript narrows automatically!
+    if (response.type === 'success') {
+        response.data.id // Works - TypeScript knows data exists
+    } else {
+        response.message // Works - TypeScript knows message exists
+    }
 }
 ```
 
@@ -76,23 +76,27 @@ function handleResponse(response: Response) {
 ```typescript
 // API responses
 const apiResponse = z.discriminatedUnion('status', [
-  z.object({ status: z.literal('success'), data: z.unknown() }),
-  z.object({ status: z.literal('error'), error: z.string(), code: z.number() }),
-  z.object({ status: z.literal('loading') }),
+    z.object({ status: z.literal('success'), data: z.unknown() }),
+    z.object({
+        status: z.literal('error'),
+        error: z.string(),
+        code: z.number(),
+    }),
+    z.object({ status: z.literal('loading') }),
 ])
 
 // Event types
 const event = z.discriminatedUnion('type', [
-  z.object({ type: z.literal('click'), x: z.number(), y: z.number() }),
-  z.object({ type: z.literal('keypress'), key: z.string() }),
-  z.object({ type: z.literal('scroll'), delta: z.number() }),
+    z.object({ type: z.literal('click'), x: z.number(), y: z.number() }),
+    z.object({ type: z.literal('keypress'), key: z.string() }),
+    z.object({ type: z.literal('scroll'), delta: z.number() }),
 ])
 
 // Database records with polymorphic types
 const notification = z.discriminatedUnion('channel', [
-  z.object({ channel: z.literal('email'), address: z.string().email() }),
-  z.object({ channel: z.literal('sms'), phoneNumber: z.string() }),
-  z.object({ channel: z.literal('push'), deviceToken: z.string() }),
+    z.object({ channel: z.literal('email'), address: z.string().email() }),
+    z.object({ channel: z.literal('sms'), phoneNumber: z.string() }),
+    z.object({ channel: z.literal('push'), deviceToken: z.string() }),
 ])
 ```
 
@@ -100,38 +104,42 @@ const notification = z.discriminatedUnion('channel', [
 
 ```typescript
 const paymentSchema = z.discriminatedUnion('method', [
-  z.object({
-    method: z.literal('card'),
-    cardNumber: z.string(),
-    expiryDate: z.string(),
-  }),
-  z.object({
-    method: z.literal('bank'),
-    accountNumber: z.string(),
-    routingNumber: z.string(),
-  }),
-  z.object({
-    method: z.literal('crypto'),
-    walletAddress: z.string(),
-  }),
+    z.object({
+        method: z.literal('card'),
+        cardNumber: z.string(),
+        expiryDate: z.string(),
+    }),
+    z.object({
+        method: z.literal('bank'),
+        accountNumber: z.string(),
+        routingNumber: z.string(),
+    }),
+    z.object({
+        method: z.literal('crypto'),
+        walletAddress: z.string(),
+    }),
 ])
 
 type Payment = z.infer<typeof paymentSchema>
 
 function processPayment(payment: Payment) {
-  switch (payment.method) {
-    case 'card':
-      return chargeCard(payment.cardNumber, payment.expiryDate)
-    case 'bank':
-      return initiateBankTransfer(payment.accountNumber, payment.routingNumber)
-    case 'crypto':
-      return sendCrypto(payment.walletAddress)
-    // TypeScript exhaustiveness check - no default needed
-  }
+    switch (payment.method) {
+        case 'card':
+            return chargeCard(payment.cardNumber, payment.expiryDate)
+        case 'bank':
+            return initiateBankTransfer(
+                payment.accountNumber,
+                payment.routingNumber,
+            )
+        case 'crypto':
+            return sendCrypto(payment.walletAddress)
+        // TypeScript exhaustiveness check - no default needed
+    }
 }
 ```
 
 **When NOT to use this pattern:**
+
 - When variants don't share a common discriminator field
 - When the discriminator isn't a literal type (use regular union)
 

--- a/.agents/skills/zod/references/object-extend-for-composition.md
+++ b/.agents/skills/zod/references/object-extend-for-composition.md
@@ -1,0 +1,147 @@
+---
+title: Use extend() for Adding Fields
+impact: MEDIUM-HIGH
+impactDescription: Merging objects manually loses type information; extend() preserves types and allows overriding fields safely
+tags: object, extend, composition, inheritance
+---
+
+## Use extend() for Adding Fields
+
+When building on existing schemas, use `.extend()` to add new fields rather than manually spreading. Extend preserves type information, allows overriding existing fields, and keeps the schema relationship explicit.
+
+**Incorrect (manual object spreading):**
+
+```typescript
+import { z } from 'zod'
+
+const baseUserSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+})
+
+// Manual spreading loses Zod's schema relationship
+const adminUserSchema = z.object({
+  ...baseUserSchema.shape,  // Accessing internal .shape
+  role: z.literal('admin'),
+  permissions: z.array(z.string()),
+})
+
+// Problems:
+// 1. If baseUserSchema changes, TypeScript might not catch issues
+// 2. Can't override fields easily
+// 3. Loses schema methods and metadata
+```
+
+**Correct (using extend):**
+
+```typescript
+import { z } from 'zod'
+
+const baseUserSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  email: z.string().email(),
+})
+
+// Extend to add fields
+const adminUserSchema = baseUserSchema.extend({
+  role: z.literal('admin'),
+  permissions: z.array(z.string()),
+})
+
+type AdminUser = z.infer<typeof adminUserSchema>
+// {
+//   id: string;
+//   name: string;
+//   email: string;
+//   role: 'admin';
+//   permissions: string[];
+// }
+
+// Override existing fields
+const strictEmailSchema = baseUserSchema.extend({
+  email: z.string().email().endsWith('@company.com'),  // Stricter validation
+})
+```
+
+**Building hierarchies with extend:**
+
+```typescript
+// Base entity with common fields
+const entitySchema = z.object({
+  id: z.string().uuid(),
+  createdAt: z.date(),
+  updatedAt: z.date(),
+})
+
+// User extends entity
+const userSchema = entitySchema.extend({
+  email: z.string().email(),
+  name: z.string(),
+})
+
+// Product extends entity
+const productSchema = entitySchema.extend({
+  name: z.string(),
+  price: z.number().positive(),
+  sku: z.string(),
+})
+
+// Order extends entity with references
+const orderSchema = entitySchema.extend({
+  userId: z.string().uuid(),
+  items: z.array(z.object({
+    productId: z.string().uuid(),
+    quantity: z.number().int().positive(),
+  })),
+  total: z.number().positive(),
+})
+```
+
+**Combining extend with other methods:**
+
+```typescript
+const baseSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  email: z.string(),
+})
+
+// Create input: no id, add password
+const createSchema = baseSchema
+  .omit({ id: true })
+  .extend({
+    password: z.string().min(8),
+  })
+
+// Update input: all optional except id
+const updateSchema = baseSchema
+  .partial()
+  .extend({
+    id: z.string(),  // Override to make required
+  })
+```
+
+**Merge for combining independent schemas:**
+
+```typescript
+const addressSchema = z.object({
+  street: z.string(),
+  city: z.string(),
+})
+
+const contactSchema = z.object({
+  email: z.string().email(),
+  phone: z.string(),
+})
+
+// Merge combines two schemas (both required)
+const customerSchema = addressSchema.merge(contactSchema)
+// { street: string; city: string; email: string; phone: string }
+```
+
+**When NOT to use this pattern:**
+- When schemas are genuinely independent (use merge or intersection)
+- When you need to remove fields (use omit)
+
+Reference: [Zod API - extend](https://zod.dev/api#extend)

--- a/.agents/skills/zod/references/object-extend-for-composition.md
+++ b/.agents/skills/zod/references/object-extend-for-composition.md
@@ -15,15 +15,15 @@ When building on existing schemas, use `.extend()` to add new fields rather than
 import { z } from 'zod'
 
 const baseUserSchema = z.object({
-  id: z.string(),
-  name: z.string(),
+    id: z.string(),
+    name: z.string(),
 })
 
 // Manual spreading loses Zod's schema relationship
 const adminUserSchema = z.object({
-  ...baseUserSchema.shape,  // Accessing internal .shape
-  role: z.literal('admin'),
-  permissions: z.array(z.string()),
+    ...baseUserSchema.shape, // Accessing internal .shape
+    role: z.literal('admin'),
+    permissions: z.array(z.string()),
 })
 
 // Problems:
@@ -38,15 +38,15 @@ const adminUserSchema = z.object({
 import { z } from 'zod'
 
 const baseUserSchema = z.object({
-  id: z.string(),
-  name: z.string(),
-  email: z.string().email(),
+    id: z.string(),
+    name: z.string(),
+    email: z.string().email(),
 })
 
 // Extend to add fields
 const adminUserSchema = baseUserSchema.extend({
-  role: z.literal('admin'),
-  permissions: z.array(z.string()),
+    role: z.literal('admin'),
+    permissions: z.array(z.string()),
 })
 
 type AdminUser = z.infer<typeof adminUserSchema>
@@ -60,7 +60,7 @@ type AdminUser = z.infer<typeof adminUserSchema>
 
 // Override existing fields
 const strictEmailSchema = baseUserSchema.extend({
-  email: z.string().email().endsWith('@company.com'),  // Stricter validation
+    email: z.string().email().endsWith('@company.com'), // Stricter validation
 })
 ```
 
@@ -69,32 +69,34 @@ const strictEmailSchema = baseUserSchema.extend({
 ```typescript
 // Base entity with common fields
 const entitySchema = z.object({
-  id: z.string().uuid(),
-  createdAt: z.date(),
-  updatedAt: z.date(),
+    id: z.string().uuid(),
+    createdAt: z.date(),
+    updatedAt: z.date(),
 })
 
 // User extends entity
 const userSchema = entitySchema.extend({
-  email: z.string().email(),
-  name: z.string(),
+    email: z.string().email(),
+    name: z.string(),
 })
 
 // Product extends entity
 const productSchema = entitySchema.extend({
-  name: z.string(),
-  price: z.number().positive(),
-  sku: z.string(),
+    name: z.string(),
+    price: z.number().positive(),
+    sku: z.string(),
 })
 
 // Order extends entity with references
 const orderSchema = entitySchema.extend({
-  userId: z.string().uuid(),
-  items: z.array(z.object({
-    productId: z.string().uuid(),
-    quantity: z.number().int().positive(),
-  })),
-  total: z.number().positive(),
+    userId: z.string().uuid(),
+    items: z.array(
+        z.object({
+            productId: z.string().uuid(),
+            quantity: z.number().int().positive(),
+        }),
+    ),
+    total: z.number().positive(),
 })
 ```
 
@@ -102,37 +104,33 @@ const orderSchema = entitySchema.extend({
 
 ```typescript
 const baseSchema = z.object({
-  id: z.string(),
-  name: z.string(),
-  email: z.string(),
+    id: z.string(),
+    name: z.string(),
+    email: z.string(),
 })
 
 // Create input: no id, add password
-const createSchema = baseSchema
-  .omit({ id: true })
-  .extend({
+const createSchema = baseSchema.omit({ id: true }).extend({
     password: z.string().min(8),
-  })
+})
 
 // Update input: all optional except id
-const updateSchema = baseSchema
-  .partial()
-  .extend({
-    id: z.string(),  // Override to make required
-  })
+const updateSchema = baseSchema.partial().extend({
+    id: z.string(), // Override to make required
+})
 ```
 
 **Merge for combining independent schemas:**
 
 ```typescript
 const addressSchema = z.object({
-  street: z.string(),
-  city: z.string(),
+    street: z.string(),
+    city: z.string(),
 })
 
 const contactSchema = z.object({
-  email: z.string().email(),
-  phone: z.string(),
+    email: z.string().email(),
+    phone: z.string(),
 })
 
 // Merge combines two schemas (both required)
@@ -141,6 +139,7 @@ const customerSchema = addressSchema.merge(contactSchema)
 ```
 
 **When NOT to use this pattern:**
+
 - When schemas are genuinely independent (use merge or intersection)
 - When you need to remove fields (use omit)
 

--- a/.agents/skills/zod/references/object-optional-vs-nullable.md
+++ b/.agents/skills/zod/references/object-optional-vs-nullable.md
@@ -1,0 +1,117 @@
+---
+title: Distinguish optional() from nullable()
+impact: MEDIUM-HIGH
+impactDescription: Confusing undefined and null semantics causes "property does not exist" vs "property is null" bugs; choose deliberately
+tags: object, optional, nullable, undefined
+---
+
+## Distinguish optional() from nullable()
+
+`.optional()` allows `undefined` (field can be missing), while `.nullable()` allows `null` (field must be present but can be null). Choosing the wrong one causes subtle bugs in database operations, JSON serialization, and API contracts.
+
+**Incorrect (confusing optional and nullable):**
+
+```typescript
+import { z } from 'zod'
+
+const userSchema = z.object({
+  name: z.string(),
+  // Intended: field might not exist
+  nickname: z.string().nullable(),  // Wrong! Requires field to be present
+  // Intended: field exists but might be null
+  deletedAt: z.date().optional(),  // Wrong! Allows field to be missing
+})
+
+// This fails - nickname is required
+userSchema.parse({ name: 'John' })
+// ZodError: Required at "nickname"
+
+// This passes but loses semantic meaning
+userSchema.parse({ name: 'John', nickname: null, deletedAt: undefined })
+// Is deletedAt undefined because not deleted, or because data is incomplete?
+```
+
+**Correct (using optional and nullable deliberately):**
+
+```typescript
+import { z } from 'zod'
+
+const userSchema = z.object({
+  name: z.string(),
+
+  // optional() - field might not exist in the object
+  nickname: z.string().optional(),
+  // Type: string | undefined
+
+  // nullable() - field must exist, but value can be null
+  deletedAt: z.date().nullable(),
+  // Type: Date | null
+})
+
+// Field can be omitted
+userSchema.parse({ name: 'John', deletedAt: null })  // Valid
+
+// Field must be present (even if null)
+userSchema.parse({ name: 'John', nickname: 'Johnny' })
+// ZodError: Required at "deletedAt"
+
+// Correct usage
+userSchema.parse({
+  name: 'John',
+  nickname: 'Johnny',  // Or omit entirely
+  deletedAt: null,  // Must be present, null means "not deleted"
+})
+```
+
+**When to use each:**
+
+```typescript
+// optional() - field may not exist
+// Use for: Optional form fields, sparse updates, optional config
+z.object({
+  bio: z.string().optional(),  // User might not have filled this
+  middleName: z.string().optional(),  // Not everyone has one
+})
+
+// nullable() - field exists but value can be null
+// Use for: Database nullable columns, "cleared" values, explicit absence
+z.object({
+  deletedAt: z.date().nullable(),  // null = not deleted, Date = when deleted
+  parentId: z.string().nullable(),  // null = root node, string = has parent
+  approvedBy: z.string().nullable(),  // null = pending, string = approver
+})
+
+// nullish() - either undefined or null
+// Use for: Lenient APIs, legacy data, optional nullable DB columns
+z.object({
+  legacyField: z.string().nullish(),  // string | null | undefined
+})
+```
+
+**API response patterns:**
+
+```typescript
+// API includes null for "no value" (good for explicit absence)
+const apiResponseSchema = z.object({
+  data: z.object({
+    user: z.object({
+      name: z.string(),
+      avatar: z.string().nullable(),  // null = no avatar set
+    }).nullable(),  // null = user not found
+  }),
+})
+
+// Type: { data: { user: { name: string; avatar: string | null } | null } }
+
+// Partial updates send only changed fields
+const updateSchema = z.object({
+  name: z.string().optional(),  // Omitted = don't change
+  avatar: z.string().nullable().optional(),  // null = clear avatar
+})
+```
+
+**When NOT to use this pattern:**
+- When interacting with systems that treat null and undefined as equivalent
+- When using nullish() for maximum flexibility is acceptable
+
+Reference: [Zod API - optional/nullable](https://zod.dev/api#optional)

--- a/.agents/skills/zod/references/object-optional-vs-nullable.md
+++ b/.agents/skills/zod/references/object-optional-vs-nullable.md
@@ -15,11 +15,11 @@ tags: object, optional, nullable, undefined
 import { z } from 'zod'
 
 const userSchema = z.object({
-  name: z.string(),
-  // Intended: field might not exist
-  nickname: z.string().nullable(),  // Wrong! Requires field to be present
-  // Intended: field exists but might be null
-  deletedAt: z.date().optional(),  // Wrong! Allows field to be missing
+    name: z.string(),
+    // Intended: field might not exist
+    nickname: z.string().nullable(), // Wrong! Requires field to be present
+    // Intended: field exists but might be null
+    deletedAt: z.date().optional(), // Wrong! Allows field to be missing
 })
 
 // This fails - nickname is required
@@ -37,19 +37,19 @@ userSchema.parse({ name: 'John', nickname: null, deletedAt: undefined })
 import { z } from 'zod'
 
 const userSchema = z.object({
-  name: z.string(),
+    name: z.string(),
 
-  // optional() - field might not exist in the object
-  nickname: z.string().optional(),
-  // Type: string | undefined
+    // optional() - field might not exist in the object
+    nickname: z.string().optional(),
+    // Type: string | undefined
 
-  // nullable() - field must exist, but value can be null
-  deletedAt: z.date().nullable(),
-  // Type: Date | null
+    // nullable() - field must exist, but value can be null
+    deletedAt: z.date().nullable(),
+    // Type: Date | null
 })
 
 // Field can be omitted
-userSchema.parse({ name: 'John', deletedAt: null })  // Valid
+userSchema.parse({ name: 'John', deletedAt: null }) // Valid
 
 // Field must be present (even if null)
 userSchema.parse({ name: 'John', nickname: 'Johnny' })
@@ -57,9 +57,9 @@ userSchema.parse({ name: 'John', nickname: 'Johnny' })
 
 // Correct usage
 userSchema.parse({
-  name: 'John',
-  nickname: 'Johnny',  // Or omit entirely
-  deletedAt: null,  // Must be present, null means "not deleted"
+    name: 'John',
+    nickname: 'Johnny', // Or omit entirely
+    deletedAt: null, // Must be present, null means "not deleted"
 })
 ```
 
@@ -69,22 +69,22 @@ userSchema.parse({
 // optional() - field may not exist
 // Use for: Optional form fields, sparse updates, optional config
 z.object({
-  bio: z.string().optional(),  // User might not have filled this
-  middleName: z.string().optional(),  // Not everyone has one
+    bio: z.string().optional(), // User might not have filled this
+    middleName: z.string().optional(), // Not everyone has one
 })
 
 // nullable() - field exists but value can be null
 // Use for: Database nullable columns, "cleared" values, explicit absence
 z.object({
-  deletedAt: z.date().nullable(),  // null = not deleted, Date = when deleted
-  parentId: z.string().nullable(),  // null = root node, string = has parent
-  approvedBy: z.string().nullable(),  // null = pending, string = approver
+    deletedAt: z.date().nullable(), // null = not deleted, Date = when deleted
+    parentId: z.string().nullable(), // null = root node, string = has parent
+    approvedBy: z.string().nullable(), // null = pending, string = approver
 })
 
 // nullish() - either undefined or null
 // Use for: Lenient APIs, legacy data, optional nullable DB columns
 z.object({
-  legacyField: z.string().nullish(),  // string | null | undefined
+    legacyField: z.string().nullish(), // string | null | undefined
 })
 ```
 
@@ -93,24 +93,27 @@ z.object({
 ```typescript
 // API includes null for "no value" (good for explicit absence)
 const apiResponseSchema = z.object({
-  data: z.object({
-    user: z.object({
-      name: z.string(),
-      avatar: z.string().nullable(),  // null = no avatar set
-    }).nullable(),  // null = user not found
-  }),
+    data: z.object({
+        user: z
+            .object({
+                name: z.string(),
+                avatar: z.string().nullable(), // null = no avatar set
+            })
+            .nullable(), // null = user not found
+    }),
 })
 
 // Type: { data: { user: { name: string; avatar: string | null } | null } }
 
 // Partial updates send only changed fields
 const updateSchema = z.object({
-  name: z.string().optional(),  // Omitted = don't change
-  avatar: z.string().nullable().optional(),  // null = clear avatar
+    name: z.string().optional(), // Omitted = don't change
+    avatar: z.string().nullable().optional(), // null = clear avatar
 })
 ```
 
 **When NOT to use this pattern:**
+
 - When interacting with systems that treat null and undefined as equivalent
 - When using nullish() for maximum flexibility is acceptable
 

--- a/.agents/skills/zod/references/object-partial-for-updates.md
+++ b/.agents/skills/zod/references/object-partial-for-updates.md
@@ -1,0 +1,123 @@
+---
+title: Use partial() for Update Schemas
+impact: MEDIUM-HIGH
+impactDescription: Creating separate update schemas duplicates definitions; partial() derives update schema from base, staying in sync
+tags: object, partial, update, patch
+---
+
+## Use partial() for Update Schemas
+
+When handling PATCH/PUT updates, you need a schema where all fields are optional. Instead of duplicating the schema with optional fields, use `.partial()` to derive it from your base schema. This keeps both schemas in sync automatically.
+
+**Incorrect (duplicating schemas):**
+
+```typescript
+import { z } from 'zod'
+
+// Base schema
+const userSchema = z.object({
+  name: z.string().min(1),
+  email: z.string().email(),
+  age: z.number().int().positive(),
+  role: z.enum(['admin', 'user']),
+})
+
+// Manually duplicated for updates - will drift!
+const updateUserSchema = z.object({
+  name: z.string().min(1).optional(),
+  email: z.string().email().optional(),
+  age: z.number().int().positive().optional(),
+  // Forgot to add role - schemas out of sync!
+})
+
+// Later, you add a field to userSchema but forget updateUserSchema
+// Now updates silently ignore the new field
+```
+
+**Correct (using partial):**
+
+```typescript
+import { z } from 'zod'
+
+// Base schema - single source of truth
+const userSchema = z.object({
+  name: z.string().min(1),
+  email: z.string().email(),
+  age: z.number().int().positive(),
+  role: z.enum(['admin', 'user']),
+})
+
+// All fields optional for updates
+const updateUserSchema = userSchema.partial()
+
+type User = z.infer<typeof userSchema>
+// { name: string; email: string; age: number; role: 'admin' | 'user' }
+
+type UpdateUser = z.infer<typeof updateUserSchema>
+// { name?: string; email?: string; age?: number; role?: 'admin' | 'user' }
+
+// Validate partial updates
+updateUserSchema.parse({ email: 'new@example.com' })  // Valid
+updateUserSchema.parse({})  // Valid - all fields optional
+```
+
+**Partial specific fields only:**
+
+```typescript
+// Only name and email are optional for updates
+const updateUserSchema = userSchema.partial({
+  name: true,
+  email: true,
+})
+
+type UpdateUser = z.infer<typeof updateUserSchema>
+// { name?: string; email?: string; age: number; role: 'admin' | 'user' }
+// age and role still required
+```
+
+**Deep partial for nested objects:**
+
+```typescript
+const addressSchema = z.object({
+  street: z.string(),
+  city: z.string(),
+  country: z.string(),
+})
+
+const userSchema = z.object({
+  name: z.string(),
+  address: addressSchema,
+})
+
+// .partial() only makes top-level fields optional
+const shallowPartial = userSchema.partial()
+// { name?: string; address?: { street: string; city: string; country: string } }
+// If address is provided, all its fields are still required!
+
+// Use deepPartial for nested optionality
+const deepPartialSchema = userSchema.deepPartial()
+// { name?: string; address?: { street?: string; city?: string; country?: string } }
+```
+
+**Combining with required() for create vs update:**
+
+```typescript
+const baseSchema = z.object({
+  id: z.string().uuid(),
+  name: z.string(),
+  email: z.string().email(),
+  createdAt: z.date(),
+})
+
+// Create: id and createdAt are generated, rest required
+const createSchema = baseSchema.omit({ id: true, createdAt: true })
+
+// Update: all user-editable fields optional
+const updateSchema = baseSchema.partial().omit({ id: true, createdAt: true })
+```
+
+**When NOT to use this pattern:**
+- When update logic differs significantly from create (different validations)
+- When using GraphQL with explicit input types
+
+Reference: [Zod API - partial](https://zod.dev/api#partial)

--- a/.agents/skills/zod/references/object-partial-for-updates.md
+++ b/.agents/skills/zod/references/object-partial-for-updates.md
@@ -16,18 +16,18 @@ import { z } from 'zod'
 
 // Base schema
 const userSchema = z.object({
-  name: z.string().min(1),
-  email: z.string().email(),
-  age: z.number().int().positive(),
-  role: z.enum(['admin', 'user']),
+    name: z.string().min(1),
+    email: z.string().email(),
+    age: z.number().int().positive(),
+    role: z.enum(['admin', 'user']),
 })
 
 // Manually duplicated for updates - will drift!
 const updateUserSchema = z.object({
-  name: z.string().min(1).optional(),
-  email: z.string().email().optional(),
-  age: z.number().int().positive().optional(),
-  // Forgot to add role - schemas out of sync!
+    name: z.string().min(1).optional(),
+    email: z.string().email().optional(),
+    age: z.number().int().positive().optional(),
+    // Forgot to add role - schemas out of sync!
 })
 
 // Later, you add a field to userSchema but forget updateUserSchema
@@ -41,10 +41,10 @@ import { z } from 'zod'
 
 // Base schema - single source of truth
 const userSchema = z.object({
-  name: z.string().min(1),
-  email: z.string().email(),
-  age: z.number().int().positive(),
-  role: z.enum(['admin', 'user']),
+    name: z.string().min(1),
+    email: z.string().email(),
+    age: z.number().int().positive(),
+    role: z.enum(['admin', 'user']),
 })
 
 // All fields optional for updates
@@ -57,8 +57,8 @@ type UpdateUser = z.infer<typeof updateUserSchema>
 // { name?: string; email?: string; age?: number; role?: 'admin' | 'user' }
 
 // Validate partial updates
-updateUserSchema.parse({ email: 'new@example.com' })  // Valid
-updateUserSchema.parse({})  // Valid - all fields optional
+updateUserSchema.parse({ email: 'new@example.com' }) // Valid
+updateUserSchema.parse({}) // Valid - all fields optional
 ```
 
 **Partial specific fields only:**
@@ -66,8 +66,8 @@ updateUserSchema.parse({})  // Valid - all fields optional
 ```typescript
 // Only name and email are optional for updates
 const updateUserSchema = userSchema.partial({
-  name: true,
-  email: true,
+    name: true,
+    email: true,
 })
 
 type UpdateUser = z.infer<typeof updateUserSchema>
@@ -79,14 +79,14 @@ type UpdateUser = z.infer<typeof updateUserSchema>
 
 ```typescript
 const addressSchema = z.object({
-  street: z.string(),
-  city: z.string(),
-  country: z.string(),
+    street: z.string(),
+    city: z.string(),
+    country: z.string(),
 })
 
 const userSchema = z.object({
-  name: z.string(),
-  address: addressSchema,
+    name: z.string(),
+    address: addressSchema,
 })
 
 // .partial() only makes top-level fields optional
@@ -103,10 +103,10 @@ const deepPartialSchema = userSchema.deepPartial()
 
 ```typescript
 const baseSchema = z.object({
-  id: z.string().uuid(),
-  name: z.string(),
-  email: z.string().email(),
-  createdAt: z.date(),
+    id: z.string().uuid(),
+    name: z.string(),
+    email: z.string().email(),
+    createdAt: z.date(),
 })
 
 // Create: id and createdAt are generated, rest required
@@ -117,6 +117,7 @@ const updateSchema = baseSchema.partial().omit({ id: true, createdAt: true })
 ```
 
 **When NOT to use this pattern:**
+
 - When update logic differs significantly from create (different validations)
 - When using GraphQL with explicit input types
 

--- a/.agents/skills/zod/references/object-pick-omit.md
+++ b/.agents/skills/zod/references/object-pick-omit.md
@@ -1,0 +1,146 @@
+---
+title: Use pick() and omit() for Schema Variants
+impact: MEDIUM-HIGH
+impactDescription: Copying fields between schemas creates duplication; pick/omit derive variants that stay in sync with base schema
+tags: object, pick, omit, variants
+---
+
+## Use pick() and omit() for Schema Variants
+
+When you need different views of the same data (public vs private, create vs response), use `.pick()` and `.omit()` instead of duplicating fields. This ensures derived schemas stay in sync with the base schema.
+
+**Incorrect (duplicating for variants):**
+
+```typescript
+import { z } from 'zod'
+
+// Full user schema
+const userSchema = z.object({
+  id: z.string().uuid(),
+  email: z.string().email(),
+  passwordHash: z.string(),
+  name: z.string(),
+  createdAt: z.date(),
+  isAdmin: z.boolean(),
+})
+
+// Public view - manually duplicated
+const publicUserSchema = z.object({
+  id: z.string().uuid(),
+  name: z.string(),
+  // Forgot email - now users can't see it
+  // Added avatar field - doesn't exist in base schema
+  avatar: z.string().optional(),
+})
+
+// Create input - manually duplicated
+const createUserSchema = z.object({
+  email: z.string().email(),
+  password: z.string().min(8),  // Different from passwordHash
+  name: z.string(),
+  // Missing isAdmin - can't set on create? Intentional?
+})
+```
+
+**Correct (using pick and omit):**
+
+```typescript
+import { z } from 'zod'
+
+// Full user schema - single source of truth
+const userSchema = z.object({
+  id: z.string().uuid(),
+  email: z.string().email(),
+  passwordHash: z.string(),
+  name: z.string(),
+  createdAt: z.date(),
+  isAdmin: z.boolean(),
+})
+
+// Public view - explicitly pick public fields
+const publicUserSchema = userSchema.pick({
+  id: true,
+  email: true,
+  name: true,
+})
+
+type PublicUser = z.infer<typeof publicUserSchema>
+// { id: string; email: string; name: string }
+
+// API response - omit sensitive fields
+const userResponseSchema = userSchema.omit({
+  passwordHash: true,
+})
+
+type UserResponse = z.infer<typeof userResponseSchema>
+// { id: string; email: string; name: string; createdAt: Date; isAdmin: boolean }
+
+// Create input - omit generated fields
+const createUserInputSchema = userSchema
+  .omit({ id: true, createdAt: true, passwordHash: true })
+  .extend({
+    password: z.string().min(8),  // Add password (different from hash)
+  })
+
+type CreateUserInput = z.infer<typeof createUserInputSchema>
+// { email: string; name: string; isAdmin: boolean; password: string }
+```
+
+**Common patterns:**
+
+```typescript
+// Database row → API response (hide internal fields)
+const dbRowSchema = z.object({
+  id: z.number(),
+  public_id: z.string().uuid(),
+  email: z.string(),
+  password_hash: z.string(),
+  internal_notes: z.string(),
+  created_at: z.date(),
+})
+
+const apiResponseSchema = dbRowSchema.omit({
+  id: true,  // Internal DB id
+  password_hash: true,  // Sensitive
+  internal_notes: true,  // Staff only
+})
+
+// Form data → Database insert (add generated fields)
+const formSchema = z.object({
+  title: z.string(),
+  content: z.string(),
+})
+
+const dbInsertSchema = formSchema.extend({
+  id: z.string().uuid(),
+  authorId: z.string().uuid(),
+  createdAt: z.date(),
+  updatedAt: z.date(),
+})
+```
+
+**Chaining operations:**
+
+```typescript
+const baseSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  email: z.string(),
+  role: z.enum(['admin', 'user']),
+  secret: z.string(),
+})
+
+// Combine pick, omit, partial, extend
+const updateSchema = baseSchema
+  .omit({ id: true, secret: true })  // Remove immutable/sensitive
+  .partial()  // Make all optional for updates
+  .extend({
+    updatedAt: z.date().optional(),  // Add update timestamp
+  })
+```
+
+**When NOT to use this pattern:**
+- When derived schemas need different validation rules (not just different fields)
+- When the relationship between schemas is not subset/superset
+
+Reference: [Zod API - pick/omit](https://zod.dev/api#pickomit)

--- a/.agents/skills/zod/references/object-pick-omit.md
+++ b/.agents/skills/zod/references/object-pick-omit.md
@@ -16,29 +16,29 @@ import { z } from 'zod'
 
 // Full user schema
 const userSchema = z.object({
-  id: z.string().uuid(),
-  email: z.string().email(),
-  passwordHash: z.string(),
-  name: z.string(),
-  createdAt: z.date(),
-  isAdmin: z.boolean(),
+    id: z.string().uuid(),
+    email: z.string().email(),
+    passwordHash: z.string(),
+    name: z.string(),
+    createdAt: z.date(),
+    isAdmin: z.boolean(),
 })
 
 // Public view - manually duplicated
 const publicUserSchema = z.object({
-  id: z.string().uuid(),
-  name: z.string(),
-  // Forgot email - now users can't see it
-  // Added avatar field - doesn't exist in base schema
-  avatar: z.string().optional(),
+    id: z.string().uuid(),
+    name: z.string(),
+    // Forgot email - now users can't see it
+    // Added avatar field - doesn't exist in base schema
+    avatar: z.string().optional(),
 })
 
 // Create input - manually duplicated
 const createUserSchema = z.object({
-  email: z.string().email(),
-  password: z.string().min(8),  // Different from passwordHash
-  name: z.string(),
-  // Missing isAdmin - can't set on create? Intentional?
+    email: z.string().email(),
+    password: z.string().min(8), // Different from passwordHash
+    name: z.string(),
+    // Missing isAdmin - can't set on create? Intentional?
 })
 ```
 
@@ -49,19 +49,19 @@ import { z } from 'zod'
 
 // Full user schema - single source of truth
 const userSchema = z.object({
-  id: z.string().uuid(),
-  email: z.string().email(),
-  passwordHash: z.string(),
-  name: z.string(),
-  createdAt: z.date(),
-  isAdmin: z.boolean(),
+    id: z.string().uuid(),
+    email: z.string().email(),
+    passwordHash: z.string(),
+    name: z.string(),
+    createdAt: z.date(),
+    isAdmin: z.boolean(),
 })
 
 // Public view - explicitly pick public fields
 const publicUserSchema = userSchema.pick({
-  id: true,
-  email: true,
-  name: true,
+    id: true,
+    email: true,
+    name: true,
 })
 
 type PublicUser = z.infer<typeof publicUserSchema>
@@ -69,7 +69,7 @@ type PublicUser = z.infer<typeof publicUserSchema>
 
 // API response - omit sensitive fields
 const userResponseSchema = userSchema.omit({
-  passwordHash: true,
+    passwordHash: true,
 })
 
 type UserResponse = z.infer<typeof userResponseSchema>
@@ -77,10 +77,10 @@ type UserResponse = z.infer<typeof userResponseSchema>
 
 // Create input - omit generated fields
 const createUserInputSchema = userSchema
-  .omit({ id: true, createdAt: true, passwordHash: true })
-  .extend({
-    password: z.string().min(8),  // Add password (different from hash)
-  })
+    .omit({ id: true, createdAt: true, passwordHash: true })
+    .extend({
+        password: z.string().min(8), // Add password (different from hash)
+    })
 
 type CreateUserInput = z.infer<typeof createUserInputSchema>
 // { email: string; name: string; isAdmin: boolean; password: string }
@@ -91,31 +91,31 @@ type CreateUserInput = z.infer<typeof createUserInputSchema>
 ```typescript
 // Database row → API response (hide internal fields)
 const dbRowSchema = z.object({
-  id: z.number(),
-  public_id: z.string().uuid(),
-  email: z.string(),
-  password_hash: z.string(),
-  internal_notes: z.string(),
-  created_at: z.date(),
+    id: z.number(),
+    public_id: z.string().uuid(),
+    email: z.string(),
+    password_hash: z.string(),
+    internal_notes: z.string(),
+    created_at: z.date(),
 })
 
 const apiResponseSchema = dbRowSchema.omit({
-  id: true,  // Internal DB id
-  password_hash: true,  // Sensitive
-  internal_notes: true,  // Staff only
+    id: true, // Internal DB id
+    password_hash: true, // Sensitive
+    internal_notes: true, // Staff only
 })
 
 // Form data → Database insert (add generated fields)
 const formSchema = z.object({
-  title: z.string(),
-  content: z.string(),
+    title: z.string(),
+    content: z.string(),
 })
 
 const dbInsertSchema = formSchema.extend({
-  id: z.string().uuid(),
-  authorId: z.string().uuid(),
-  createdAt: z.date(),
-  updatedAt: z.date(),
+    id: z.string().uuid(),
+    authorId: z.string().uuid(),
+    createdAt: z.date(),
+    updatedAt: z.date(),
 })
 ```
 
@@ -123,23 +123,24 @@ const dbInsertSchema = formSchema.extend({
 
 ```typescript
 const baseSchema = z.object({
-  id: z.string(),
-  name: z.string(),
-  email: z.string(),
-  role: z.enum(['admin', 'user']),
-  secret: z.string(),
+    id: z.string(),
+    name: z.string(),
+    email: z.string(),
+    role: z.enum(['admin', 'user']),
+    secret: z.string(),
 })
 
 // Combine pick, omit, partial, extend
 const updateSchema = baseSchema
-  .omit({ id: true, secret: true })  // Remove immutable/sensitive
-  .partial()  // Make all optional for updates
-  .extend({
-    updatedAt: z.date().optional(),  // Add update timestamp
-  })
+    .omit({ id: true, secret: true }) // Remove immutable/sensitive
+    .partial() // Make all optional for updates
+    .extend({
+        updatedAt: z.date().optional(), // Add update timestamp
+    })
 ```
 
 **When NOT to use this pattern:**
+
 - When derived schemas need different validation rules (not just different fields)
 - When the relationship between schemas is not subset/superset
 

--- a/.agents/skills/zod/references/object-strict-vs-strip.md
+++ b/.agents/skills/zod/references/object-strict-vs-strip.md
@@ -1,0 +1,109 @@
+---
+title: Choose strict() vs strip() for Unknown Keys
+impact: MEDIUM-HIGH
+impactDescription: Default passthrough mode leaks unexpected data; strict() catches schema mismatches, strip() silently removes extras
+tags: object, strict, strip, passthrough
+---
+
+## Choose strict() vs strip() for Unknown Keys
+
+By default, Zod objects use `.strip()` behavior, silently removing unrecognized keys. This can hide schema/data mismatches. Use `.strict()` to reject unknown keys (catching errors) or explicitly use `.strip()` to document the intention.
+
+**Default behavior (strip - silent removal):**
+
+```typescript
+import { z } from 'zod'
+
+const userSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+})
+
+const input = {
+  id: '123',
+  name: 'John',
+  role: 'admin',  // Extra field
+  secretToken: 'abc123',  // Another extra field
+}
+
+const user = userSchema.parse(input)
+// { id: '123', name: 'John' }
+// Extra fields silently removed - was this intentional?
+```
+
+**Using strict() to catch schema mismatches:**
+
+```typescript
+import { z } from 'zod'
+
+const userSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+}).strict()
+
+const input = {
+  id: '123',
+  name: 'John',
+  role: 'admin',
+}
+
+userSchema.parse(input)
+// ZodError: Unrecognized key(s) in object: 'role'
+
+// This catches:
+// - Client sending fields the server doesn't expect
+// - Schema out of sync with actual data structure
+// - Typos in field names
+```
+
+**When to use each mode:**
+
+```typescript
+// strict() - Catch unexpected data (API contracts)
+const apiRequestSchema = z.object({
+  action: z.string(),
+  payload: z.unknown(),
+}).strict()  // Fail if client sends unknown fields
+
+// strip() - Clean up data (explicit intention)
+const dbInsertSchema = z.object({
+  name: z.string(),
+  email: z.string(),
+}).strip()  // Explicitly remove metadata before insert
+
+// passthrough() - Keep everything (pass-through proxy)
+const proxySchema = z.object({
+  id: z.string(),
+}).passthrough()  // Keep fields we don't validate
+
+const input = { id: '123', extra: 'data' }
+proxySchema.parse(input)  // { id: '123', extra: 'data' }
+```
+
+**Choosing the right mode:**
+
+| Mode | Behavior | Use When |
+|------|----------|----------|
+| `.strict()` | Reject unknown keys | API contracts, security-sensitive, debugging |
+| `.strip()` (default) | Remove unknown keys | General validation, data cleaning |
+| `.passthrough()` | Keep unknown keys | Proxying, partial validation |
+
+**Handling specific unknown keys:**
+
+```typescript
+const schema = z.object({
+  id: z.string(),
+  name: z.string(),
+}).catchall(z.unknown())  // Allow any additional fields of any type
+
+// Or restrict additional fields to specific type
+const metadataSchema = z.object({
+  id: z.string(),
+}).catchall(z.string())  // Only allow string extras
+```
+
+**When NOT to use this pattern:**
+- `.strict()`: When forwarding data to another system that may add fields
+- `.passthrough()`: When you need to ensure only known fields are stored
+
+Reference: [Zod API - Objects](https://zod.dev/api#objects)

--- a/.agents/skills/zod/references/object-strict-vs-strip.md
+++ b/.agents/skills/zod/references/object-strict-vs-strip.md
@@ -15,15 +15,15 @@ By default, Zod objects use `.strip()` behavior, silently removing unrecognized 
 import { z } from 'zod'
 
 const userSchema = z.object({
-  id: z.string(),
-  name: z.string(),
+    id: z.string(),
+    name: z.string(),
 })
 
 const input = {
-  id: '123',
-  name: 'John',
-  role: 'admin',  // Extra field
-  secretToken: 'abc123',  // Another extra field
+    id: '123',
+    name: 'John',
+    role: 'admin', // Extra field
+    secretToken: 'abc123', // Another extra field
 }
 
 const user = userSchema.parse(input)
@@ -36,15 +36,17 @@ const user = userSchema.parse(input)
 ```typescript
 import { z } from 'zod'
 
-const userSchema = z.object({
-  id: z.string(),
-  name: z.string(),
-}).strict()
+const userSchema = z
+    .object({
+        id: z.string(),
+        name: z.string(),
+    })
+    .strict()
 
 const input = {
-  id: '123',
-  name: 'John',
-  role: 'admin',
+    id: '123',
+    name: 'John',
+    role: 'admin',
 }
 
 userSchema.parse(input)
@@ -60,49 +62,60 @@ userSchema.parse(input)
 
 ```typescript
 // strict() - Catch unexpected data (API contracts)
-const apiRequestSchema = z.object({
-  action: z.string(),
-  payload: z.unknown(),
-}).strict()  // Fail if client sends unknown fields
+const apiRequestSchema = z
+    .object({
+        action: z.string(),
+        payload: z.unknown(),
+    })
+    .strict() // Fail if client sends unknown fields
 
 // strip() - Clean up data (explicit intention)
-const dbInsertSchema = z.object({
-  name: z.string(),
-  email: z.string(),
-}).strip()  // Explicitly remove metadata before insert
+const dbInsertSchema = z
+    .object({
+        name: z.string(),
+        email: z.string(),
+    })
+    .strip() // Explicitly remove metadata before insert
 
 // passthrough() - Keep everything (pass-through proxy)
-const proxySchema = z.object({
-  id: z.string(),
-}).passthrough()  // Keep fields we don't validate
+const proxySchema = z
+    .object({
+        id: z.string(),
+    })
+    .passthrough() // Keep fields we don't validate
 
 const input = { id: '123', extra: 'data' }
-proxySchema.parse(input)  // { id: '123', extra: 'data' }
+proxySchema.parse(input) // { id: '123', extra: 'data' }
 ```
 
 **Choosing the right mode:**
 
-| Mode | Behavior | Use When |
-|------|----------|----------|
-| `.strict()` | Reject unknown keys | API contracts, security-sensitive, debugging |
-| `.strip()` (default) | Remove unknown keys | General validation, data cleaning |
-| `.passthrough()` | Keep unknown keys | Proxying, partial validation |
+| Mode                 | Behavior            | Use When                                     |
+| -------------------- | ------------------- | -------------------------------------------- |
+| `.strict()`          | Reject unknown keys | API contracts, security-sensitive, debugging |
+| `.strip()` (default) | Remove unknown keys | General validation, data cleaning            |
+| `.passthrough()`     | Keep unknown keys   | Proxying, partial validation                 |
 
 **Handling specific unknown keys:**
 
 ```typescript
-const schema = z.object({
-  id: z.string(),
-  name: z.string(),
-}).catchall(z.unknown())  // Allow any additional fields of any type
+const schema = z
+    .object({
+        id: z.string(),
+        name: z.string(),
+    })
+    .catchall(z.unknown()) // Allow any additional fields of any type
 
 // Or restrict additional fields to specific type
-const metadataSchema = z.object({
-  id: z.string(),
-}).catchall(z.string())  // Only allow string extras
+const metadataSchema = z
+    .object({
+        id: z.string(),
+    })
+    .catchall(z.string()) // Only allow string extras
 ```
 
 **When NOT to use this pattern:**
+
 - `.strict()`: When forwarding data to another system that may add fields
 - `.passthrough()`: When you need to ensure only known fields are stored
 

--- a/.agents/skills/zod/references/parse-async-for-async-refinements.md
+++ b/.agents/skills/zod/references/parse-async-for-async-refinements.md
@@ -1,0 +1,118 @@
+---
+title: Use parseAsync for Async Refinements
+impact: CRITICAL
+impactDescription: Using parse() with async refinements throws an error; async validation silently fails or crashes the application
+tags: parse, async, parseAsync, refinement
+---
+
+## Use parseAsync for Async Refinements
+
+If your schema uses `refine()` or `superRefine()` with async validation (like database lookups), you must use `parseAsync()` or `safeParseAsync()`. Using synchronous `parse()` with async refinements throws an error.
+
+**Incorrect (sync parse with async refinement):**
+
+```typescript
+import { z } from 'zod'
+
+const userSchema = z.object({
+  email: z.string().email(),
+  username: z.string().min(3),
+}).refine(
+  async (data) => {
+    // Async database check
+    const exists = await db.users.findByEmail(data.email)
+    return !exists
+  },
+  { message: 'Email already registered' }
+)
+
+// This throws an error!
+const user = userSchema.parse(formData)
+// Error: Async refinement encountered during synchronous parse operation.
+// Use .parseAsync instead.
+```
+
+**Correct (using parseAsync):**
+
+```typescript
+import { z } from 'zod'
+
+const userSchema = z.object({
+  email: z.string().email(),
+  username: z.string().min(3),
+}).refine(
+  async (data) => {
+    const exists = await db.users.findByEmail(data.email)
+    return !exists
+  },
+  { message: 'Email already registered' }
+)
+
+// Use parseAsync for async refinements
+const user = await userSchema.parseAsync(formData)
+
+// Or safeParseAsync for error handling
+const result = await userSchema.safeParseAsync(formData)
+if (!result.success) {
+  console.log(result.error.issues)
+}
+```
+
+**Async transforms also require parseAsync:**
+
+```typescript
+const enrichedUserSchema = z.object({
+  userId: z.string().uuid(),
+}).transform(async (data) => {
+  // Async data enrichment
+  const user = await db.users.findById(data.userId)
+  return {
+    ...data,
+    email: user.email,
+    name: user.name,
+  }
+})
+
+// Must use parseAsync
+const enrichedUser = await enrichedUserSchema.parseAsync({ userId: '123' })
+```
+
+**Pattern for API routes:**
+
+```typescript
+import { z } from 'zod'
+import { NextRequest, NextResponse } from 'next/server'
+
+const registerSchema = z.object({
+  email: z.string().email(),
+  password: z.string().min(8),
+}).superRefine(async (data, ctx) => {
+  const existingUser = await db.users.findByEmail(data.email)
+  if (existingUser) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ['email'],
+      message: 'Email already registered',
+    })
+  }
+})
+
+export async function POST(req: NextRequest) {
+  const body = await req.json()
+
+  // Always use safeParseAsync with async schemas
+  const result = await registerSchema.safeParseAsync(body)
+
+  if (!result.success) {
+    return NextResponse.json({ errors: result.error.issues }, { status: 400 })
+  }
+
+  // Proceed with registration
+}
+```
+
+**When NOT to use this pattern:**
+- Schemas with only synchronous validation (use parse/safeParse)
+- When async validation can be moved outside Zod (validate, then check)
+
+Reference: [Zod API - parseAsync](https://zod.dev/api#parseasync)

--- a/.agents/skills/zod/references/parse-async-for-async-refinements.md
+++ b/.agents/skills/zod/references/parse-async-for-async-refinements.md
@@ -14,17 +14,19 @@ If your schema uses `refine()` or `superRefine()` with async validation (like da
 ```typescript
 import { z } from 'zod'
 
-const userSchema = z.object({
-  email: z.string().email(),
-  username: z.string().min(3),
-}).refine(
-  async (data) => {
-    // Async database check
-    const exists = await db.users.findByEmail(data.email)
-    return !exists
-  },
-  { message: 'Email already registered' }
-)
+const userSchema = z
+    .object({
+        email: z.string().email(),
+        username: z.string().min(3),
+    })
+    .refine(
+        async data => {
+            // Async database check
+            const exists = await db.users.findByEmail(data.email)
+            return !exists
+        },
+        { message: 'Email already registered' },
+    )
 
 // This throws an error!
 const user = userSchema.parse(formData)
@@ -37,16 +39,18 @@ const user = userSchema.parse(formData)
 ```typescript
 import { z } from 'zod'
 
-const userSchema = z.object({
-  email: z.string().email(),
-  username: z.string().min(3),
-}).refine(
-  async (data) => {
-    const exists = await db.users.findByEmail(data.email)
-    return !exists
-  },
-  { message: 'Email already registered' }
-)
+const userSchema = z
+    .object({
+        email: z.string().email(),
+        username: z.string().min(3),
+    })
+    .refine(
+        async data => {
+            const exists = await db.users.findByEmail(data.email)
+            return !exists
+        },
+        { message: 'Email already registered' },
+    )
 
 // Use parseAsync for async refinements
 const user = await userSchema.parseAsync(formData)
@@ -54,24 +58,26 @@ const user = await userSchema.parseAsync(formData)
 // Or safeParseAsync for error handling
 const result = await userSchema.safeParseAsync(formData)
 if (!result.success) {
-  console.log(result.error.issues)
+    console.log(result.error.issues)
 }
 ```
 
 **Async transforms also require parseAsync:**
 
 ```typescript
-const enrichedUserSchema = z.object({
-  userId: z.string().uuid(),
-}).transform(async (data) => {
-  // Async data enrichment
-  const user = await db.users.findById(data.userId)
-  return {
-    ...data,
-    email: user.email,
-    name: user.name,
-  }
-})
+const enrichedUserSchema = z
+    .object({
+        userId: z.string().uuid(),
+    })
+    .transform(async data => {
+        // Async data enrichment
+        const user = await db.users.findById(data.userId)
+        return {
+            ...data,
+            email: user.email,
+            name: user.name,
+        }
+    })
 
 // Must use parseAsync
 const enrichedUser = await enrichedUserSchema.parseAsync({ userId: '123' })
@@ -83,35 +89,41 @@ const enrichedUser = await enrichedUserSchema.parseAsync({ userId: '123' })
 import { z } from 'zod'
 import { NextRequest, NextResponse } from 'next/server'
 
-const registerSchema = z.object({
-  email: z.string().email(),
-  password: z.string().min(8),
-}).superRefine(async (data, ctx) => {
-  const existingUser = await db.users.findByEmail(data.email)
-  if (existingUser) {
-    ctx.addIssue({
-      code: z.ZodIssueCode.custom,
-      path: ['email'],
-      message: 'Email already registered',
+const registerSchema = z
+    .object({
+        email: z.string().email(),
+        password: z.string().min(8),
     })
-  }
-})
+    .superRefine(async (data, ctx) => {
+        const existingUser = await db.users.findByEmail(data.email)
+        if (existingUser) {
+            ctx.addIssue({
+                code: z.ZodIssueCode.custom,
+                path: ['email'],
+                message: 'Email already registered',
+            })
+        }
+    })
 
 export async function POST(req: NextRequest) {
-  const body = await req.json()
+    const body = await req.json()
 
-  // Always use safeParseAsync with async schemas
-  const result = await registerSchema.safeParseAsync(body)
+    // Always use safeParseAsync with async schemas
+    const result = await registerSchema.safeParseAsync(body)
 
-  if (!result.success) {
-    return NextResponse.json({ errors: result.error.issues }, { status: 400 })
-  }
+    if (!result.success) {
+        return NextResponse.json(
+            { errors: result.error.issues },
+            { status: 400 },
+        )
+    }
 
-  // Proceed with registration
+    // Proceed with registration
 }
 ```
 
 **When NOT to use this pattern:**
+
 - Schemas with only synchronous validation (use parse/safeParse)
 - When async validation can be moved outside Zod (validate, then check)
 

--- a/.agents/skills/zod/references/parse-avoid-double-validation.md
+++ b/.agents/skills/zod/references/parse-avoid-double-validation.md
@@ -1,0 +1,129 @@
+---
+title: Avoid Double Validation
+impact: HIGH
+impactDescription: Parsing the same data twice wastes CPU cycles; in hot paths this adds measurable latency
+tags: parse, performance, optimization, architecture
+---
+
+## Avoid Double Validation
+
+Once data is validated by Zod, trust the result. Re-validating the same data in multiple layers doubles CPU usage and adds latency. Pass the typed result through your application instead.
+
+**Incorrect (validating at every layer):**
+
+```typescript
+import { z } from 'zod'
+
+const userSchema = z.object({
+  id: z.string().uuid(),
+  email: z.string().email(),
+  name: z.string(),
+})
+
+// Controller validates
+export async function POST(req: NextRequest) {
+  const body = await req.json()
+  const user = userSchema.parse(body)  // First parse
+  return await userService.create(user)
+}
+
+// Service validates again
+const userService = {
+  async create(data: unknown) {
+    const user = userSchema.parse(data)  // Second parse - redundant
+    return await userRepository.insert(user)
+  }
+}
+
+// Repository validates again
+const userRepository = {
+  async insert(data: unknown) {
+    const user = userSchema.parse(data)  // Third parse - wasteful
+    return await db.users.create({ data: user })
+  }
+}
+```
+
+**Correct (validate once, pass typed data):**
+
+```typescript
+import { z } from 'zod'
+
+const userSchema = z.object({
+  id: z.string().uuid(),
+  email: z.string().email(),
+  name: z.string(),
+})
+
+type User = z.infer<typeof userSchema>
+
+// Controller validates at boundary
+export async function POST(req: NextRequest) {
+  const body = await req.json()
+
+  const result = userSchema.safeParse(body)
+  if (!result.success) {
+    return NextResponse.json({ errors: result.error.issues }, { status: 400 })
+  }
+
+  // Pass validated, typed data
+  return await userService.create(result.data)
+}
+
+// Service receives typed data, no re-validation needed
+const userService = {
+  async create(user: User) {
+    // user is guaranteed to match schema
+    return await userRepository.insert(user)
+  }
+}
+
+// Repository receives typed data
+const userRepository = {
+  async insert(user: User) {
+    return await db.users.create({ data: user })
+  }
+}
+```
+
+**When you might validate at multiple layers:**
+
+```typescript
+// Different schemas for different layers
+const apiUserSchema = z.object({
+  email: z.string().email(),
+  password: z.string().min(8),  // Only in API layer
+})
+
+const dbUserSchema = z.object({
+  id: z.string().uuid(),
+  email: z.string().email(),
+  passwordHash: z.string(),  // Transformed before storage
+})
+
+// API validates input format
+export async function POST(req: NextRequest) {
+  const input = apiUserSchema.parse(await req.json())
+  const user = await userService.create(input)
+  return NextResponse.json(user)
+}
+
+// Service transforms and validates for storage
+const userService = {
+  async create(input: z.infer<typeof apiUserSchema>) {
+    const dbUser = dbUserSchema.parse({
+      id: crypto.randomUUID(),
+      email: input.email,
+      passwordHash: await hash(input.password),
+    })
+    return await userRepository.insert(dbUser)
+  }
+}
+```
+
+**When NOT to use this pattern:**
+- When schemas differ between layers (API vs DB shape)
+- When data crosses trust boundaries (external service response)
+- During development when debugging data flow
+
+Reference: [Zod Performance](https://zod.dev/v4#performance)

--- a/.agents/skills/zod/references/parse-avoid-double-validation.md
+++ b/.agents/skills/zod/references/parse-avoid-double-validation.md
@@ -15,32 +15,32 @@ Once data is validated by Zod, trust the result. Re-validating the same data in 
 import { z } from 'zod'
 
 const userSchema = z.object({
-  id: z.string().uuid(),
-  email: z.string().email(),
-  name: z.string(),
+    id: z.string().uuid(),
+    email: z.string().email(),
+    name: z.string(),
 })
 
 // Controller validates
 export async function POST(req: NextRequest) {
-  const body = await req.json()
-  const user = userSchema.parse(body)  // First parse
-  return await userService.create(user)
+    const body = await req.json()
+    const user = userSchema.parse(body) // First parse
+    return await userService.create(user)
 }
 
 // Service validates again
 const userService = {
-  async create(data: unknown) {
-    const user = userSchema.parse(data)  // Second parse - redundant
-    return await userRepository.insert(user)
-  }
+    async create(data: unknown) {
+        const user = userSchema.parse(data) // Second parse - redundant
+        return await userRepository.insert(user)
+    },
 }
 
 // Repository validates again
 const userRepository = {
-  async insert(data: unknown) {
-    const user = userSchema.parse(data)  // Third parse - wasteful
-    return await db.users.create({ data: user })
-  }
+    async insert(data: unknown) {
+        const user = userSchema.parse(data) // Third parse - wasteful
+        return await db.users.create({ data: user })
+    },
 }
 ```
 
@@ -50,39 +50,42 @@ const userRepository = {
 import { z } from 'zod'
 
 const userSchema = z.object({
-  id: z.string().uuid(),
-  email: z.string().email(),
-  name: z.string(),
+    id: z.string().uuid(),
+    email: z.string().email(),
+    name: z.string(),
 })
 
 type User = z.infer<typeof userSchema>
 
 // Controller validates at boundary
 export async function POST(req: NextRequest) {
-  const body = await req.json()
+    const body = await req.json()
 
-  const result = userSchema.safeParse(body)
-  if (!result.success) {
-    return NextResponse.json({ errors: result.error.issues }, { status: 400 })
-  }
+    const result = userSchema.safeParse(body)
+    if (!result.success) {
+        return NextResponse.json(
+            { errors: result.error.issues },
+            { status: 400 },
+        )
+    }
 
-  // Pass validated, typed data
-  return await userService.create(result.data)
+    // Pass validated, typed data
+    return await userService.create(result.data)
 }
 
 // Service receives typed data, no re-validation needed
 const userService = {
-  async create(user: User) {
-    // user is guaranteed to match schema
-    return await userRepository.insert(user)
-  }
+    async create(user: User) {
+        // user is guaranteed to match schema
+        return await userRepository.insert(user)
+    },
 }
 
 // Repository receives typed data
 const userRepository = {
-  async insert(user: User) {
-    return await db.users.create({ data: user })
-  }
+    async insert(user: User) {
+        return await db.users.create({ data: user })
+    },
 }
 ```
 
@@ -91,37 +94,38 @@ const userRepository = {
 ```typescript
 // Different schemas for different layers
 const apiUserSchema = z.object({
-  email: z.string().email(),
-  password: z.string().min(8),  // Only in API layer
+    email: z.string().email(),
+    password: z.string().min(8), // Only in API layer
 })
 
 const dbUserSchema = z.object({
-  id: z.string().uuid(),
-  email: z.string().email(),
-  passwordHash: z.string(),  // Transformed before storage
+    id: z.string().uuid(),
+    email: z.string().email(),
+    passwordHash: z.string(), // Transformed before storage
 })
 
 // API validates input format
 export async function POST(req: NextRequest) {
-  const input = apiUserSchema.parse(await req.json())
-  const user = await userService.create(input)
-  return NextResponse.json(user)
+    const input = apiUserSchema.parse(await req.json())
+    const user = await userService.create(input)
+    return NextResponse.json(user)
 }
 
 // Service transforms and validates for storage
 const userService = {
-  async create(input: z.infer<typeof apiUserSchema>) {
-    const dbUser = dbUserSchema.parse({
-      id: crypto.randomUUID(),
-      email: input.email,
-      passwordHash: await hash(input.password),
-    })
-    return await userRepository.insert(dbUser)
-  }
+    async create(input: z.infer<typeof apiUserSchema>) {
+        const dbUser = dbUserSchema.parse({
+            id: crypto.randomUUID(),
+            email: input.email,
+            passwordHash: await hash(input.password),
+        })
+        return await userRepository.insert(dbUser)
+    },
 }
 ```
 
 **When NOT to use this pattern:**
+
 - When schemas differ between layers (API vs DB shape)
 - When data crosses trust boundaries (external service response)
 - During development when debugging data flow

--- a/.agents/skills/zod/references/parse-handle-all-issues.md
+++ b/.agents/skills/zod/references/parse-handle-all-issues.md
@@ -1,0 +1,125 @@
+---
+title: Handle All Validation Issues Not Just First
+impact: CRITICAL
+impactDescription: Showing only the first error forces users to fix-submit-fix repeatedly; collecting all errors improves UX dramatically
+tags: parse, errors, issues, user-experience
+---
+
+## Handle All Validation Issues Not Just First
+
+Zod collects all validation failures, not just the first one. When displaying errors to users, show all issues so they can fix everything at once instead of playing whack-a-mole with one error at a time.
+
+**Incorrect (showing only first error):**
+
+```typescript
+import { z } from 'zod'
+
+const formSchema = z.object({
+  email: z.string().email('Invalid email'),
+  password: z.string().min(8, 'Password must be 8+ characters'),
+  confirmPassword: z.string(),
+  age: z.number().min(18, 'Must be 18 or older'),
+})
+
+function validateForm(data: unknown) {
+  const result = formSchema.safeParse(data)
+
+  if (!result.success) {
+    // Only shows first error - terrible UX
+    return { error: result.error.issues[0].message }
+  }
+
+  return { data: result.data }
+}
+
+// User submits empty form
+validateForm({})
+// Returns: { error: 'Invalid email' }
+// User fixes email, submits again
+// Returns: { error: 'Password must be 8+ characters' }
+// User fixes password, submits again...
+// 4 round trips to fix 4 errors!
+```
+
+**Correct (showing all errors):**
+
+```typescript
+import { z } from 'zod'
+
+const formSchema = z.object({
+  email: z.string().email('Invalid email'),
+  password: z.string().min(8, 'Password must be 8+ characters'),
+  confirmPassword: z.string(),
+  age: z.number().min(18, 'Must be 18 or older'),
+})
+
+function validateForm(data: unknown) {
+  const result = formSchema.safeParse(data)
+
+  if (!result.success) {
+    // Collect errors by field for form display
+    const fieldErrors: Record<string, string[]> = {}
+
+    for (const issue of result.error.issues) {
+      const field = issue.path.join('.')
+      if (!fieldErrors[field]) {
+        fieldErrors[field] = []
+      }
+      fieldErrors[field].push(issue.message)
+    }
+
+    return { errors: fieldErrors }
+  }
+
+  return { data: result.data }
+}
+
+// User submits empty form
+validateForm({})
+// Returns: {
+//   errors: {
+//     email: ['Invalid email'],
+//     password: ['Password must be 8+ characters'],
+//     confirmPassword: ['Required'],
+//     age: ['Expected number, received undefined']
+//   }
+// }
+// User sees ALL errors, fixes everything, submits once!
+```
+
+**Using flatten() for simpler error structure:**
+
+```typescript
+const result = formSchema.safeParse(data)
+
+if (!result.success) {
+  const flattened = result.error.flatten()
+  // {
+  //   formErrors: [],  // Top-level errors
+  //   fieldErrors: {
+  //     email: ['Invalid email'],
+  //     password: ['Password must be 8+ characters'],
+  //     ...
+  //   }
+  // }
+  return { errors: flattened.fieldErrors }
+}
+```
+
+**With React Hook Form integration:**
+
+```typescript
+import { zodResolver } from '@hookform/resolvers/zod'
+import { useForm } from 'react-hook-form'
+
+const form = useForm({
+  resolver: zodResolver(formSchema),
+  // All errors are automatically collected and displayed
+})
+```
+
+**When NOT to use this pattern:**
+- Rate-limited APIs where you want to fail fast on first error
+- Large batch processing where full validation is expensive
+
+Reference: [Zod Error Handling](https://zod.dev/error-handling)

--- a/.agents/skills/zod/references/parse-handle-all-issues.md
+++ b/.agents/skills/zod/references/parse-handle-all-issues.md
@@ -15,21 +15,21 @@ Zod collects all validation failures, not just the first one. When displaying er
 import { z } from 'zod'
 
 const formSchema = z.object({
-  email: z.string().email('Invalid email'),
-  password: z.string().min(8, 'Password must be 8+ characters'),
-  confirmPassword: z.string(),
-  age: z.number().min(18, 'Must be 18 or older'),
+    email: z.string().email('Invalid email'),
+    password: z.string().min(8, 'Password must be 8+ characters'),
+    confirmPassword: z.string(),
+    age: z.number().min(18, 'Must be 18 or older'),
 })
 
 function validateForm(data: unknown) {
-  const result = formSchema.safeParse(data)
+    const result = formSchema.safeParse(data)
 
-  if (!result.success) {
-    // Only shows first error - terrible UX
-    return { error: result.error.issues[0].message }
-  }
+    if (!result.success) {
+        // Only shows first error - terrible UX
+        return { error: result.error.issues[0].message }
+    }
 
-  return { data: result.data }
+    return { data: result.data }
 }
 
 // User submits empty form
@@ -47,31 +47,31 @@ validateForm({})
 import { z } from 'zod'
 
 const formSchema = z.object({
-  email: z.string().email('Invalid email'),
-  password: z.string().min(8, 'Password must be 8+ characters'),
-  confirmPassword: z.string(),
-  age: z.number().min(18, 'Must be 18 or older'),
+    email: z.string().email('Invalid email'),
+    password: z.string().min(8, 'Password must be 8+ characters'),
+    confirmPassword: z.string(),
+    age: z.number().min(18, 'Must be 18 or older'),
 })
 
 function validateForm(data: unknown) {
-  const result = formSchema.safeParse(data)
+    const result = formSchema.safeParse(data)
 
-  if (!result.success) {
-    // Collect errors by field for form display
-    const fieldErrors: Record<string, string[]> = {}
+    if (!result.success) {
+        // Collect errors by field for form display
+        const fieldErrors: Record<string, string[]> = {}
 
-    for (const issue of result.error.issues) {
-      const field = issue.path.join('.')
-      if (!fieldErrors[field]) {
-        fieldErrors[field] = []
-      }
-      fieldErrors[field].push(issue.message)
+        for (const issue of result.error.issues) {
+            const field = issue.path.join('.')
+            if (!fieldErrors[field]) {
+                fieldErrors[field] = []
+            }
+            fieldErrors[field].push(issue.message)
+        }
+
+        return { errors: fieldErrors }
     }
 
-    return { errors: fieldErrors }
-  }
-
-  return { data: result.data }
+    return { data: result.data }
 }
 
 // User submits empty form
@@ -93,16 +93,16 @@ validateForm({})
 const result = formSchema.safeParse(data)
 
 if (!result.success) {
-  const flattened = result.error.flatten()
-  // {
-  //   formErrors: [],  // Top-level errors
-  //   fieldErrors: {
-  //     email: ['Invalid email'],
-  //     password: ['Password must be 8+ characters'],
-  //     ...
-  //   }
-  // }
-  return { errors: flattened.fieldErrors }
+    const flattened = result.error.flatten()
+    // {
+    //   formErrors: [],  // Top-level errors
+    //   fieldErrors: {
+    //     email: ['Invalid email'],
+    //     password: ['Password must be 8+ characters'],
+    //     ...
+    //   }
+    // }
+    return { errors: flattened.fieldErrors }
 }
 ```
 
@@ -113,12 +113,13 @@ import { zodResolver } from '@hookform/resolvers/zod'
 import { useForm } from 'react-hook-form'
 
 const form = useForm({
-  resolver: zodResolver(formSchema),
-  // All errors are automatically collected and displayed
+    resolver: zodResolver(formSchema),
+    // All errors are automatically collected and displayed
 })
 ```
 
 **When NOT to use this pattern:**
+
 - Rate-limited APIs where you want to fail fast on first error
 - Large batch processing where full validation is expensive
 

--- a/.agents/skills/zod/references/parse-never-trust-json.md
+++ b/.agents/skills/zod/references/parse-never-trust-json.md
@@ -1,0 +1,113 @@
+---
+title: Never Trust JSON.parse Output
+impact: CRITICAL
+impactDescription: JSON.parse returns any type; unvalidated JSON allows type confusion attacks and runtime crashes
+tags: parse, json, security, type-safety
+---
+
+## Never Trust JSON.parse Output
+
+`JSON.parse()` returns `any` (or `unknown` in strict mode), providing no type guarantees. Always validate JSON output with Zod before using it, even if you control the JSON source. This catches corruption, version mismatches, and ensures type safety.
+
+**Incorrect (trusting JSON.parse):**
+
+```typescript
+// JSON.parse returns any - no type safety
+const config = JSON.parse(fs.readFileSync('config.json', 'utf-8'))
+// config is 'any' - TypeScript allows anything
+
+// This might crash at runtime if structure changed
+console.log(config.database.host)  // TypeError: Cannot read property 'host' of undefined
+
+// API response - also unvalidated
+const response = await fetch('/api/user')
+const user = await response.json()  // any type
+console.log(user.name.toUpperCase())  // Crash if name is null/undefined
+```
+
+**Correct (validate after JSON.parse):**
+
+```typescript
+import { z } from 'zod'
+
+const configSchema = z.object({
+  database: z.object({
+    host: z.string(),
+    port: z.number(),
+    name: z.string(),
+  }),
+  api: z.object({
+    key: z.string(),
+    timeout: z.number().default(5000),
+  }),
+})
+
+// Parse JSON then validate
+const rawConfig = JSON.parse(fs.readFileSync('config.json', 'utf-8'))
+const config = configSchema.parse(rawConfig)
+// config is fully typed: { database: { host: string, ... }, ... }
+
+// API response validation
+const userSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  email: z.string().email(),
+})
+
+const response = await fetch('/api/user')
+const rawUser = await response.json()
+const user = userSchema.parse(rawUser)
+// user is fully typed and validated
+```
+
+**Helper for validated JSON parsing:**
+
+```typescript
+function parseJSON<T>(schema: z.ZodType<T>, json: string): T {
+  return schema.parse(JSON.parse(json))
+}
+
+function safeParseJSON<T>(schema: z.ZodType<T>, json: string) {
+  try {
+    return { success: true as const, data: schema.parse(JSON.parse(json)) }
+  } catch (error) {
+    if (error instanceof SyntaxError) {
+      return { success: false as const, error: 'Invalid JSON' }
+    }
+    if (error instanceof z.ZodError) {
+      return { success: false as const, error: error.issues }
+    }
+    throw error
+  }
+}
+
+// Usage
+const config = parseJSON(configSchema, fs.readFileSync('config.json', 'utf-8'))
+```
+
+**Validate localStorage/sessionStorage:**
+
+```typescript
+const cartSchema = z.array(z.object({
+  productId: z.string(),
+  quantity: z.number().int().positive(),
+}))
+
+function getCart() {
+  const raw = localStorage.getItem('cart')
+  if (!raw) return []
+
+  const result = cartSchema.safeParse(JSON.parse(raw))
+  if (!result.success) {
+    // Corrupted cart data - clear it
+    localStorage.removeItem('cart')
+    return []
+  }
+  return result.data
+}
+```
+
+**When NOT to use this pattern:**
+- When you genuinely need to pass through arbitrary JSON without processing
+
+Reference: [Zod API - parse](https://zod.dev/api#parse)

--- a/.agents/skills/zod/references/parse-never-trust-json.md
+++ b/.agents/skills/zod/references/parse-never-trust-json.md
@@ -17,12 +17,12 @@ const config = JSON.parse(fs.readFileSync('config.json', 'utf-8'))
 // config is 'any' - TypeScript allows anything
 
 // This might crash at runtime if structure changed
-console.log(config.database.host)  // TypeError: Cannot read property 'host' of undefined
+console.log(config.database.host) // TypeError: Cannot read property 'host' of undefined
 
 // API response - also unvalidated
 const response = await fetch('/api/user')
-const user = await response.json()  // any type
-console.log(user.name.toUpperCase())  // Crash if name is null/undefined
+const user = await response.json() // any type
+console.log(user.name.toUpperCase()) // Crash if name is null/undefined
 ```
 
 **Correct (validate after JSON.parse):**
@@ -31,15 +31,15 @@ console.log(user.name.toUpperCase())  // Crash if name is null/undefined
 import { z } from 'zod'
 
 const configSchema = z.object({
-  database: z.object({
-    host: z.string(),
-    port: z.number(),
-    name: z.string(),
-  }),
-  api: z.object({
-    key: z.string(),
-    timeout: z.number().default(5000),
-  }),
+    database: z.object({
+        host: z.string(),
+        port: z.number(),
+        name: z.string(),
+    }),
+    api: z.object({
+        key: z.string(),
+        timeout: z.number().default(5000),
+    }),
 })
 
 // Parse JSON then validate
@@ -49,9 +49,9 @@ const config = configSchema.parse(rawConfig)
 
 // API response validation
 const userSchema = z.object({
-  id: z.string(),
-  name: z.string(),
-  email: z.string().email(),
+    id: z.string(),
+    name: z.string(),
+    email: z.string().email(),
 })
 
 const response = await fetch('/api/user')
@@ -64,21 +64,21 @@ const user = userSchema.parse(rawUser)
 
 ```typescript
 function parseJSON<T>(schema: z.ZodType<T>, json: string): T {
-  return schema.parse(JSON.parse(json))
+    return schema.parse(JSON.parse(json))
 }
 
 function safeParseJSON<T>(schema: z.ZodType<T>, json: string) {
-  try {
-    return { success: true as const, data: schema.parse(JSON.parse(json)) }
-  } catch (error) {
-    if (error instanceof SyntaxError) {
-      return { success: false as const, error: 'Invalid JSON' }
+    try {
+        return { success: true as const, data: schema.parse(JSON.parse(json)) }
+    } catch (error) {
+        if (error instanceof SyntaxError) {
+            return { success: false as const, error: 'Invalid JSON' }
+        }
+        if (error instanceof z.ZodError) {
+            return { success: false as const, error: error.issues }
+        }
+        throw error
     }
-    if (error instanceof z.ZodError) {
-      return { success: false as const, error: error.issues }
-    }
-    throw error
-  }
 }
 
 // Usage
@@ -88,26 +88,29 @@ const config = parseJSON(configSchema, fs.readFileSync('config.json', 'utf-8'))
 **Validate localStorage/sessionStorage:**
 
 ```typescript
-const cartSchema = z.array(z.object({
-  productId: z.string(),
-  quantity: z.number().int().positive(),
-}))
+const cartSchema = z.array(
+    z.object({
+        productId: z.string(),
+        quantity: z.number().int().positive(),
+    }),
+)
 
 function getCart() {
-  const raw = localStorage.getItem('cart')
-  if (!raw) return []
+    const raw = localStorage.getItem('cart')
+    if (!raw) return []
 
-  const result = cartSchema.safeParse(JSON.parse(raw))
-  if (!result.success) {
-    // Corrupted cart data - clear it
-    localStorage.removeItem('cart')
-    return []
-  }
-  return result.data
+    const result = cartSchema.safeParse(JSON.parse(raw))
+    if (!result.success) {
+        // Corrupted cart data - clear it
+        localStorage.removeItem('cart')
+        return []
+    }
+    return result.data
 }
 ```
 
 **When NOT to use this pattern:**
+
 - When you genuinely need to pass through arbitrary JSON without processing
 
 Reference: [Zod API - parse](https://zod.dev/api#parse)

--- a/.agents/skills/zod/references/parse-use-safeparse.md
+++ b/.agents/skills/zod/references/parse-use-safeparse.md
@@ -1,0 +1,102 @@
+---
+title: Use safeParse() for User Input
+impact: CRITICAL
+impactDescription: parse() throws exceptions on invalid data; unhandled exceptions crash servers and expose stack traces to users
+tags: parse, safeParse, error-handling, validation
+---
+
+## Use safeParse() for User Input
+
+`parse()` throws a `ZodError` when validation fails, which crashes your application if not caught. `safeParse()` returns a result object that you can inspect without try/catch. Use `safeParse()` for any user-provided or external data.
+
+**Incorrect (parse without error handling):**
+
+```typescript
+import { z } from 'zod'
+import { NextRequest, NextResponse } from 'next/server'
+
+const createUserSchema = z.object({
+  email: z.string().email(),
+  name: z.string().min(1),
+})
+
+export async function POST(req: NextRequest) {
+  const body = await req.json()
+
+  // If validation fails, this throws and crashes the handler
+  const user = createUserSchema.parse(body)
+
+  // Never reached if parse throws
+  await db.users.create({ data: user })
+  return NextResponse.json({ success: true })
+}
+// Result: 500 Internal Server Error with stack trace
+```
+
+**Correct (using safeParse):**
+
+```typescript
+import { z } from 'zod'
+import { NextRequest, NextResponse } from 'next/server'
+
+const createUserSchema = z.object({
+  email: z.string().email(),
+  name: z.string().min(1),
+})
+
+export async function POST(req: NextRequest) {
+  const body = await req.json()
+
+  const result = createUserSchema.safeParse(body)
+
+  if (!result.success) {
+    // Return structured error response
+    return NextResponse.json(
+      { error: 'Validation failed', issues: result.error.issues },
+      { status: 400 }
+    )
+  }
+
+  // result.data is typed correctly
+  await db.users.create({ data: result.data })
+  return NextResponse.json({ success: true })
+}
+```
+
+**The result object structure:**
+
+```typescript
+// Success case
+{ success: true, data: T }
+
+// Error case
+{ success: false, error: ZodError }
+
+// Type narrowing works automatically
+if (result.success) {
+  result.data  // T - fully typed
+} else {
+  result.error  // ZodError
+  result.error.issues  // Array of validation issues
+}
+```
+
+**When parse() is acceptable:**
+
+```typescript
+// Internal data you control - parse is fine
+const config = configSchema.parse(JSON.parse(process.env.CONFIG))
+
+// Test assertions - parse throws helpful errors
+expect(() => schema.parse(invalidData)).toThrow()
+
+// Schema development - see errors immediately
+schema.parse(testData)  // See what fails during development
+```
+
+**When NOT to use this pattern:**
+- Internal configuration parsing where invalid data should crash early
+- Tests where you want exceptions to fail the test
+- Scripts where you want to see the full error
+
+Reference: [Zod API - safeParse](https://zod.dev/api#safeparse)

--- a/.agents/skills/zod/references/parse-use-safeparse.md
+++ b/.agents/skills/zod/references/parse-use-safeparse.md
@@ -16,19 +16,19 @@ import { z } from 'zod'
 import { NextRequest, NextResponse } from 'next/server'
 
 const createUserSchema = z.object({
-  email: z.string().email(),
-  name: z.string().min(1),
+    email: z.string().email(),
+    name: z.string().min(1),
 })
 
 export async function POST(req: NextRequest) {
-  const body = await req.json()
+    const body = await req.json()
 
-  // If validation fails, this throws and crashes the handler
-  const user = createUserSchema.parse(body)
+    // If validation fails, this throws and crashes the handler
+    const user = createUserSchema.parse(body)
 
-  // Never reached if parse throws
-  await db.users.create({ data: user })
-  return NextResponse.json({ success: true })
+    // Never reached if parse throws
+    await db.users.create({ data: user })
+    return NextResponse.json({ success: true })
 }
 // Result: 500 Internal Server Error with stack trace
 ```
@@ -40,26 +40,26 @@ import { z } from 'zod'
 import { NextRequest, NextResponse } from 'next/server'
 
 const createUserSchema = z.object({
-  email: z.string().email(),
-  name: z.string().min(1),
+    email: z.string().email(),
+    name: z.string().min(1),
 })
 
 export async function POST(req: NextRequest) {
-  const body = await req.json()
+    const body = await req.json()
 
-  const result = createUserSchema.safeParse(body)
+    const result = createUserSchema.safeParse(body)
 
-  if (!result.success) {
-    // Return structured error response
-    return NextResponse.json(
-      { error: 'Validation failed', issues: result.error.issues },
-      { status: 400 }
-    )
-  }
+    if (!result.success) {
+        // Return structured error response
+        return NextResponse.json(
+            { error: 'Validation failed', issues: result.error.issues },
+            { status: 400 },
+        )
+    }
 
-  // result.data is typed correctly
-  await db.users.create({ data: result.data })
-  return NextResponse.json({ success: true })
+    // result.data is typed correctly
+    await db.users.create({ data: result.data })
+    return NextResponse.json({ success: true })
 }
 ```
 
@@ -91,10 +91,11 @@ const config = configSchema.parse(JSON.parse(process.env.CONFIG))
 expect(() => schema.parse(invalidData)).toThrow()
 
 // Schema development - see errors immediately
-schema.parse(testData)  // See what fails during development
+schema.parse(testData) // See what fails during development
 ```
 
 **When NOT to use this pattern:**
+
 - Internal configuration parsing where invalid data should crash early
 - Tests where you want exceptions to fail the test
 - Scripts where you want to see the full error

--- a/.agents/skills/zod/references/parse-validate-early.md
+++ b/.agents/skills/zod/references/parse-validate-early.md
@@ -1,0 +1,120 @@
+---
+title: Validate at System Boundaries
+impact: CRITICAL
+impactDescription: Validating deep in business logic allows corrupt data to propagate; validating at boundaries catches issues before they spread
+tags: parse, boundaries, architecture, defense-in-depth
+---
+
+## Validate at System Boundaries
+
+Validate external data immediately when it enters your system—at API endpoints, form handlers, message queue consumers, and configuration loaders. Validating deep in business logic allows corrupt data to propagate and makes debugging harder.
+
+**Incorrect (validating deep in business logic):**
+
+```typescript
+import { z } from 'zod'
+
+// No validation at API boundary
+export async function POST(req: NextRequest) {
+  const body = await req.json()
+  // Raw unknown data passed through
+  return await processOrder(body)
+}
+
+async function processOrder(data: unknown) {
+  // Data passed around unvalidated
+  const items = await calculateTotals(data)
+  return await chargeCustomer(data, items)
+}
+
+async function calculateTotals(data: unknown) {
+  // Finally validating way too late
+  const order = orderSchema.parse(data)  // Throws here, far from entry point
+  // ...
+}
+// Hard to trace where bad data came from
+```
+
+**Correct (validating at boundary):**
+
+```typescript
+import { z } from 'zod'
+
+const orderSchema = z.object({
+  customerId: z.string().uuid(),
+  items: z.array(z.object({
+    productId: z.string(),
+    quantity: z.number().int().positive(),
+  })).min(1),
+  shippingAddress: z.object({
+    street: z.string(),
+    city: z.string(),
+    country: z.string(),
+  }),
+})
+
+type Order = z.infer<typeof orderSchema>
+
+// Validate immediately at boundary
+export async function POST(req: NextRequest) {
+  const body = await req.json()
+
+  const result = orderSchema.safeParse(body)
+  if (!result.success) {
+    return NextResponse.json(
+      { error: 'Invalid order', issues: result.error.issues },
+      { status: 400 }
+    )
+  }
+
+  // Now data is validated and typed
+  return await processOrder(result.data)
+}
+
+// Business logic receives typed, validated data
+async function processOrder(order: Order) {
+  // order is guaranteed to match schema
+  const items = await calculateTotals(order)
+  return await chargeCustomer(order, items)
+}
+
+async function calculateTotals(order: Order) {
+  // No validation needed - type guarantees shape
+  return order.items.map(item => ({
+    ...item,
+    total: item.quantity * getPrice(item.productId),
+  }))
+}
+```
+
+**Boundaries to validate:**
+
+```typescript
+// API endpoints
+export async function POST(req: NextRequest) {
+  const data = await req.json()
+  const validated = requestSchema.safeParse(data)
+  // ...
+}
+
+// Message queue consumers
+async function handleMessage(rawMessage: string) {
+  const data = JSON.parse(rawMessage)
+  const validated = messageSchema.safeParse(data)
+  // ...
+}
+
+// Configuration loading
+const config = configSchema.parse(JSON.parse(process.env.CONFIG!))
+
+// External API responses
+const response = await fetch('/api/users')
+const data = await response.json()
+const users = usersResponseSchema.parse(data)
+```
+
+**When NOT to use this pattern:**
+- Internal function calls with already-validated data
+- Performance-critical hot paths (validate once, trust afterward)
+
+Reference: [Zod with TypeScript for Server-side Validation](https://stack.convex.dev/typescript-zod-function-validation)

--- a/.agents/skills/zod/references/parse-validate-early.md
+++ b/.agents/skills/zod/references/parse-validate-early.md
@@ -16,21 +16,21 @@ import { z } from 'zod'
 
 // No validation at API boundary
 export async function POST(req: NextRequest) {
-  const body = await req.json()
-  // Raw unknown data passed through
-  return await processOrder(body)
+    const body = await req.json()
+    // Raw unknown data passed through
+    return await processOrder(body)
 }
 
 async function processOrder(data: unknown) {
-  // Data passed around unvalidated
-  const items = await calculateTotals(data)
-  return await chargeCustomer(data, items)
+    // Data passed around unvalidated
+    const items = await calculateTotals(data)
+    return await chargeCustomer(data, items)
 }
 
 async function calculateTotals(data: unknown) {
-  // Finally validating way too late
-  const order = orderSchema.parse(data)  // Throws here, far from entry point
-  // ...
+    // Finally validating way too late
+    const order = orderSchema.parse(data) // Throws here, far from entry point
+    // ...
 }
 // Hard to trace where bad data came from
 ```
@@ -41,49 +41,53 @@ async function calculateTotals(data: unknown) {
 import { z } from 'zod'
 
 const orderSchema = z.object({
-  customerId: z.string().uuid(),
-  items: z.array(z.object({
-    productId: z.string(),
-    quantity: z.number().int().positive(),
-  })).min(1),
-  shippingAddress: z.object({
-    street: z.string(),
-    city: z.string(),
-    country: z.string(),
-  }),
+    customerId: z.string().uuid(),
+    items: z
+        .array(
+            z.object({
+                productId: z.string(),
+                quantity: z.number().int().positive(),
+            }),
+        )
+        .min(1),
+    shippingAddress: z.object({
+        street: z.string(),
+        city: z.string(),
+        country: z.string(),
+    }),
 })
 
 type Order = z.infer<typeof orderSchema>
 
 // Validate immediately at boundary
 export async function POST(req: NextRequest) {
-  const body = await req.json()
+    const body = await req.json()
 
-  const result = orderSchema.safeParse(body)
-  if (!result.success) {
-    return NextResponse.json(
-      { error: 'Invalid order', issues: result.error.issues },
-      { status: 400 }
-    )
-  }
+    const result = orderSchema.safeParse(body)
+    if (!result.success) {
+        return NextResponse.json(
+            { error: 'Invalid order', issues: result.error.issues },
+            { status: 400 },
+        )
+    }
 
-  // Now data is validated and typed
-  return await processOrder(result.data)
+    // Now data is validated and typed
+    return await processOrder(result.data)
 }
 
 // Business logic receives typed, validated data
 async function processOrder(order: Order) {
-  // order is guaranteed to match schema
-  const items = await calculateTotals(order)
-  return await chargeCustomer(order, items)
+    // order is guaranteed to match schema
+    const items = await calculateTotals(order)
+    return await chargeCustomer(order, items)
 }
 
 async function calculateTotals(order: Order) {
-  // No validation needed - type guarantees shape
-  return order.items.map(item => ({
-    ...item,
-    total: item.quantity * getPrice(item.productId),
-  }))
+    // No validation needed - type guarantees shape
+    return order.items.map(item => ({
+        ...item,
+        total: item.quantity * getPrice(item.productId),
+    }))
 }
 ```
 
@@ -92,16 +96,16 @@ async function calculateTotals(order: Order) {
 ```typescript
 // API endpoints
 export async function POST(req: NextRequest) {
-  const data = await req.json()
-  const validated = requestSchema.safeParse(data)
-  // ...
+    const data = await req.json()
+    const validated = requestSchema.safeParse(data)
+    // ...
 }
 
 // Message queue consumers
 async function handleMessage(rawMessage: string) {
-  const data = JSON.parse(rawMessage)
-  const validated = messageSchema.safeParse(data)
-  // ...
+    const data = JSON.parse(rawMessage)
+    const validated = messageSchema.safeParse(data)
+    // ...
 }
 
 // Configuration loading
@@ -114,6 +118,7 @@ const users = usersResponseSchema.parse(data)
 ```
 
 **When NOT to use this pattern:**
+
 - Internal function calls with already-validated data
 - Performance-critical hot paths (validate once, trust afterward)
 

--- a/.agents/skills/zod/references/perf-arrays.md
+++ b/.agents/skills/zod/references/perf-arrays.md
@@ -1,0 +1,153 @@
+---
+title: Optimize Large Array Validation
+impact: LOW-MEDIUM
+impactDescription: Validating 10,000 items takes ~100ms; early exits, sampling, or batching reduce time for large datasets
+tags: perf, arrays, batch, large-data
+---
+
+## Optimize Large Array Validation
+
+Validating large arrays (thousands of items) can become a performance bottleneck. For batch imports, streaming data, or large datasets, consider strategies like early exit, sampling, or batched validation.
+
+**Baseline performance:**
+
+```typescript
+import { z } from 'zod'
+
+const itemSchema = z.object({
+  id: z.string(),
+  value: z.number(),
+})
+
+const arraySchema = z.array(itemSchema)
+
+// 10,000 items: ~100ms
+// 100,000 items: ~1000ms
+arraySchema.parse(largeArray)
+```
+
+**Early exit on first error:**
+
+```typescript
+import { z } from 'zod'
+
+function validateArrayFastFail<T>(
+  schema: z.ZodType<T>,
+  items: unknown[]
+): { success: true; data: T[] } | { success: false; error: z.ZodError; index: number } {
+  const validated: T[] = []
+
+  for (let i = 0; i < items.length; i++) {
+    const result = schema.safeParse(items[i])
+    if (!result.success) {
+      return { success: false, error: result.error, index: i }
+    }
+    validated.push(result.data)
+  }
+
+  return { success: true, data: validated }
+}
+
+// Stops at first invalid item instead of validating all
+```
+
+**Sample validation for large datasets:**
+
+```typescript
+function validateSample<T>(
+  schema: z.ZodType<T>,
+  items: unknown[],
+  sampleSize: number = 100
+): { valid: boolean; sampleErrors?: z.ZodIssue[] } {
+  // Validate random sample
+  const indices = new Set<number>()
+  while (indices.size < Math.min(sampleSize, items.length)) {
+    indices.add(Math.floor(Math.random() * items.length))
+  }
+
+  const errors: z.ZodIssue[] = []
+
+  for (const i of indices) {
+    const result = schema.safeParse(items[i])
+    if (!result.success) {
+      errors.push(...result.error.issues)
+    }
+  }
+
+  return errors.length > 0
+    ? { valid: false, sampleErrors: errors }
+    : { valid: true }
+}
+
+// Check 100 random items from 100,000 - very fast
+const check = validateSample(itemSchema, hugeArray)
+```
+
+**Batched validation with progress:**
+
+```typescript
+async function validateInBatches<T>(
+  schema: z.ZodType<T>,
+  items: unknown[],
+  batchSize: number = 1000,
+  onProgress?: (percent: number) => void
+): Promise<z.SafeParseReturnType<unknown, T[]>> {
+  const validated: T[] = []
+  const errors: z.ZodIssue[] = []
+
+  for (let i = 0; i < items.length; i += batchSize) {
+    const batch = items.slice(i, i + batchSize)
+
+    // Validate batch
+    for (let j = 0; j < batch.length; j++) {
+      const result = schema.safeParse(batch[j])
+      if (result.success) {
+        validated.push(result.data)
+      } else {
+        errors.push(...result.error.issues.map(issue => ({
+          ...issue,
+          path: [i + j, ...issue.path],
+        })))
+      }
+    }
+
+    // Report progress and yield to event loop
+    onProgress?.(Math.min(100, ((i + batchSize) / items.length) * 100))
+    await new Promise(resolve => setTimeout(resolve, 0))
+  }
+
+  if (errors.length > 0) {
+    return { success: false, error: new z.ZodError(errors) }
+  }
+  return { success: true, data: validated }
+}
+
+// Use with progress reporting
+await validateInBatches(itemSchema, largeArray, 1000, (percent) => {
+  console.log(`Validating: ${percent.toFixed(1)}%`)
+})
+```
+
+**Streaming validation:**
+
+```typescript
+async function* validateStream<T>(
+  schema: z.ZodType<T>,
+  items: AsyncIterable<unknown>
+): AsyncGenerator<T, void, unknown> {
+  for await (const item of items) {
+    yield schema.parse(item)  // Throws on invalid
+  }
+}
+
+// Process items as they arrive
+for await (const validItem of validateStream(itemSchema, dataStream)) {
+  await processItem(validItem)
+}
+```
+
+**When NOT to use this pattern:**
+- Small arrays (< 1000 items) - standard validation is fine
+- When all items must be validated for correctness guarantees
+
+Reference: [Zod Performance](https://zod.dev/v4#performance)

--- a/.agents/skills/zod/references/perf-arrays.md
+++ b/.agents/skills/zod/references/perf-arrays.md
@@ -15,8 +15,8 @@ Validating large arrays (thousands of items) can become a performance bottleneck
 import { z } from 'zod'
 
 const itemSchema = z.object({
-  id: z.string(),
-  value: z.number(),
+    id: z.string(),
+    value: z.number(),
 })
 
 const arraySchema = z.array(itemSchema)
@@ -32,20 +32,22 @@ arraySchema.parse(largeArray)
 import { z } from 'zod'
 
 function validateArrayFastFail<T>(
-  schema: z.ZodType<T>,
-  items: unknown[]
-): { success: true; data: T[] } | { success: false; error: z.ZodError; index: number } {
-  const validated: T[] = []
+    schema: z.ZodType<T>,
+    items: unknown[],
+):
+    | { success: true; data: T[] }
+    | { success: false; error: z.ZodError; index: number } {
+    const validated: T[] = []
 
-  for (let i = 0; i < items.length; i++) {
-    const result = schema.safeParse(items[i])
-    if (!result.success) {
-      return { success: false, error: result.error, index: i }
+    for (let i = 0; i < items.length; i++) {
+        const result = schema.safeParse(items[i])
+        if (!result.success) {
+            return { success: false, error: result.error, index: i }
+        }
+        validated.push(result.data)
     }
-    validated.push(result.data)
-  }
 
-  return { success: true, data: validated }
+    return { success: true, data: validated }
 }
 
 // Stops at first invalid item instead of validating all
@@ -55,28 +57,28 @@ function validateArrayFastFail<T>(
 
 ```typescript
 function validateSample<T>(
-  schema: z.ZodType<T>,
-  items: unknown[],
-  sampleSize: number = 100
+    schema: z.ZodType<T>,
+    items: unknown[],
+    sampleSize: number = 100,
 ): { valid: boolean; sampleErrors?: z.ZodIssue[] } {
-  // Validate random sample
-  const indices = new Set<number>()
-  while (indices.size < Math.min(sampleSize, items.length)) {
-    indices.add(Math.floor(Math.random() * items.length))
-  }
-
-  const errors: z.ZodIssue[] = []
-
-  for (const i of indices) {
-    const result = schema.safeParse(items[i])
-    if (!result.success) {
-      errors.push(...result.error.issues)
+    // Validate random sample
+    const indices = new Set<number>()
+    while (indices.size < Math.min(sampleSize, items.length)) {
+        indices.add(Math.floor(Math.random() * items.length))
     }
-  }
 
-  return errors.length > 0
-    ? { valid: false, sampleErrors: errors }
-    : { valid: true }
+    const errors: z.ZodIssue[] = []
+
+    for (const i of indices) {
+        const result = schema.safeParse(items[i])
+        if (!result.success) {
+            errors.push(...result.error.issues)
+        }
+    }
+
+    return errors.length > 0 ?
+            { valid: false, sampleErrors: errors }
+        :   { valid: true }
 }
 
 // Check 100 random items from 100,000 - very fast
@@ -87,44 +89,46 @@ const check = validateSample(itemSchema, hugeArray)
 
 ```typescript
 async function validateInBatches<T>(
-  schema: z.ZodType<T>,
-  items: unknown[],
-  batchSize: number = 1000,
-  onProgress?: (percent: number) => void
+    schema: z.ZodType<T>,
+    items: unknown[],
+    batchSize: number = 1000,
+    onProgress?: (percent: number) => void,
 ): Promise<z.SafeParseReturnType<unknown, T[]>> {
-  const validated: T[] = []
-  const errors: z.ZodIssue[] = []
+    const validated: T[] = []
+    const errors: z.ZodIssue[] = []
 
-  for (let i = 0; i < items.length; i += batchSize) {
-    const batch = items.slice(i, i + batchSize)
+    for (let i = 0; i < items.length; i += batchSize) {
+        const batch = items.slice(i, i + batchSize)
 
-    // Validate batch
-    for (let j = 0; j < batch.length; j++) {
-      const result = schema.safeParse(batch[j])
-      if (result.success) {
-        validated.push(result.data)
-      } else {
-        errors.push(...result.error.issues.map(issue => ({
-          ...issue,
-          path: [i + j, ...issue.path],
-        })))
-      }
+        // Validate batch
+        for (let j = 0; j < batch.length; j++) {
+            const result = schema.safeParse(batch[j])
+            if (result.success) {
+                validated.push(result.data)
+            } else {
+                errors.push(
+                    ...result.error.issues.map(issue => ({
+                        ...issue,
+                        path: [i + j, ...issue.path],
+                    })),
+                )
+            }
+        }
+
+        // Report progress and yield to event loop
+        onProgress?.(Math.min(100, ((i + batchSize) / items.length) * 100))
+        await new Promise(resolve => setTimeout(resolve, 0))
     }
 
-    // Report progress and yield to event loop
-    onProgress?.(Math.min(100, ((i + batchSize) / items.length) * 100))
-    await new Promise(resolve => setTimeout(resolve, 0))
-  }
-
-  if (errors.length > 0) {
-    return { success: false, error: new z.ZodError(errors) }
-  }
-  return { success: true, data: validated }
+    if (errors.length > 0) {
+        return { success: false, error: new z.ZodError(errors) }
+    }
+    return { success: true, data: validated }
 }
 
 // Use with progress reporting
-await validateInBatches(itemSchema, largeArray, 1000, (percent) => {
-  console.log(`Validating: ${percent.toFixed(1)}%`)
+await validateInBatches(itemSchema, largeArray, 1000, percent => {
+    console.log(`Validating: ${percent.toFixed(1)}%`)
 })
 ```
 
@@ -132,21 +136,22 @@ await validateInBatches(itemSchema, largeArray, 1000, (percent) => {
 
 ```typescript
 async function* validateStream<T>(
-  schema: z.ZodType<T>,
-  items: AsyncIterable<unknown>
+    schema: z.ZodType<T>,
+    items: AsyncIterable<unknown>,
 ): AsyncGenerator<T, void, unknown> {
-  for await (const item of items) {
-    yield schema.parse(item)  // Throws on invalid
-  }
+    for await (const item of items) {
+        yield schema.parse(item) // Throws on invalid
+    }
 }
 
 // Process items as they arrive
 for await (const validItem of validateStream(itemSchema, dataStream)) {
-  await processItem(validItem)
+    await processItem(validItem)
 }
 ```
 
 **When NOT to use this pattern:**
+
 - Small arrays (< 1000 items) - standard validation is fine
 - When all items must be validated for correctness guarantees
 

--- a/.agents/skills/zod/references/perf-avoid-dynamic-creation.md
+++ b/.agents/skills/zod/references/perf-avoid-dynamic-creation.md
@@ -1,0 +1,139 @@
+---
+title: Avoid Dynamic Schema Creation in Hot Paths
+impact: LOW-MEDIUM
+impactDescription: Zod 4's JIT compilation makes schema creation slower; creating schemas in loops adds ~0.15ms per creation
+tags: perf, dynamic, hot-path, optimization
+---
+
+## Avoid Dynamic Schema Creation in Hot Paths
+
+Zod 4 uses JIT (Just-In-Time) compilation to speed up repeated parsing, but this makes initial schema creation slower. Avoid creating schemas inside loops or frequently-called functions—pre-create them instead.
+
+**Incorrect (schema creation in hot path):**
+
+```typescript
+import { z } from 'zod'
+
+async function validateBatch(items: unknown[]) {
+  const results = []
+
+  for (const item of items) {
+    // Schema created for EACH item - slow!
+    const schema = z.object({
+      id: z.string(),
+      value: z.number(),
+    })
+
+    results.push(schema.safeParse(item))
+  }
+
+  return results
+}
+
+// 1000 items = 1000 schema creations = ~150ms overhead
+```
+
+**Correct (pre-created schema):**
+
+```typescript
+import { z } from 'zod'
+
+// Schema created ONCE
+const itemSchema = z.object({
+  id: z.string(),
+  value: z.number(),
+})
+
+async function validateBatch(items: unknown[]) {
+  // Reuse the same schema instance
+  return items.map(item => itemSchema.safeParse(item))
+}
+
+// 1000 items = 1 schema creation + 1000 fast parses
+```
+
+**Dynamic schemas with caching:**
+
+```typescript
+import { z } from 'zod'
+
+// Cache for dynamically-configured schemas
+const schemaCache = new WeakMap<object, z.ZodType>()
+
+function getSchemaForConfig(config: { fields: string[] }) {
+  // Check cache first
+  if (schemaCache.has(config)) {
+    return schemaCache.get(config)!
+  }
+
+  // Create and cache
+  const shape: Record<string, z.ZodString> = {}
+  for (const field of config.fields) {
+    shape[field] = z.string()
+  }
+
+  const schema = z.object(shape)
+  schemaCache.set(config, schema)
+  return schema
+}
+
+// Subsequent calls with same config reuse cached schema
+```
+
+**Lazy schema creation:**
+
+```typescript
+import { z } from 'zod'
+
+// Schema created only when first used
+let _userSchema: z.ZodObject<any> | null = null
+
+function getUserSchema() {
+  if (!_userSchema) {
+    _userSchema = z.object({
+      id: z.string().uuid(),
+      email: z.string().email(),
+      profile: z.object({
+        name: z.string(),
+        avatar: z.string().url().optional(),
+      }),
+    })
+  }
+  return _userSchema
+}
+
+// Or use a getter
+const schemas = {
+  _user: null as z.ZodType | null,
+  get user() {
+    if (!this._user) {
+      this._user = z.object({ /* ... */ })
+    }
+    return this._user
+  }
+}
+```
+
+**Benchmark considerations:**
+
+```typescript
+// Zod 4 JIT compilation:
+// - Schema creation: ~0.15ms per schema
+// - First parse: triggers JIT compile
+// - Subsequent parses: 7-14x faster
+
+// For schemas used once:
+// - Creation + parse: ~0.15ms + first-parse overhead
+// - Consider if validation is even needed
+
+// For schemas used many times:
+// - Create once, parse many: optimal
+// - JIT compilation amortized over all parses
+```
+
+**When NOT to use this pattern:**
+- One-off validation where schema is used once
+- Dynamically generated forms where fields change per request
+- Test files where performance doesn't matter
+
+Reference: [Zod v4 Performance](https://zod.dev/v4#performance)

--- a/.agents/skills/zod/references/perf-avoid-dynamic-creation.md
+++ b/.agents/skills/zod/references/perf-avoid-dynamic-creation.md
@@ -15,19 +15,19 @@ Zod 4 uses JIT (Just-In-Time) compilation to speed up repeated parsing, but this
 import { z } from 'zod'
 
 async function validateBatch(items: unknown[]) {
-  const results = []
+    const results = []
 
-  for (const item of items) {
-    // Schema created for EACH item - slow!
-    const schema = z.object({
-      id: z.string(),
-      value: z.number(),
-    })
+    for (const item of items) {
+        // Schema created for EACH item - slow!
+        const schema = z.object({
+            id: z.string(),
+            value: z.number(),
+        })
 
-    results.push(schema.safeParse(item))
-  }
+        results.push(schema.safeParse(item))
+    }
 
-  return results
+    return results
 }
 
 // 1000 items = 1000 schema creations = ~150ms overhead
@@ -40,13 +40,13 @@ import { z } from 'zod'
 
 // Schema created ONCE
 const itemSchema = z.object({
-  id: z.string(),
-  value: z.number(),
+    id: z.string(),
+    value: z.number(),
 })
 
 async function validateBatch(items: unknown[]) {
-  // Reuse the same schema instance
-  return items.map(item => itemSchema.safeParse(item))
+    // Reuse the same schema instance
+    return items.map(item => itemSchema.safeParse(item))
 }
 
 // 1000 items = 1 schema creation + 1000 fast parses
@@ -61,20 +61,20 @@ import { z } from 'zod'
 const schemaCache = new WeakMap<object, z.ZodType>()
 
 function getSchemaForConfig(config: { fields: string[] }) {
-  // Check cache first
-  if (schemaCache.has(config)) {
-    return schemaCache.get(config)!
-  }
+    // Check cache first
+    if (schemaCache.has(config)) {
+        return schemaCache.get(config)!
+    }
 
-  // Create and cache
-  const shape: Record<string, z.ZodString> = {}
-  for (const field of config.fields) {
-    shape[field] = z.string()
-  }
+    // Create and cache
+    const shape: Record<string, z.ZodString> = {}
+    for (const field of config.fields) {
+        shape[field] = z.string()
+    }
 
-  const schema = z.object(shape)
-  schemaCache.set(config, schema)
-  return schema
+    const schema = z.object(shape)
+    schemaCache.set(config, schema)
+    return schema
 }
 
 // Subsequent calls with same config reuse cached schema
@@ -89,28 +89,30 @@ import { z } from 'zod'
 let _userSchema: z.ZodObject<any> | null = null
 
 function getUserSchema() {
-  if (!_userSchema) {
-    _userSchema = z.object({
-      id: z.string().uuid(),
-      email: z.string().email(),
-      profile: z.object({
-        name: z.string(),
-        avatar: z.string().url().optional(),
-      }),
-    })
-  }
-  return _userSchema
+    if (!_userSchema) {
+        _userSchema = z.object({
+            id: z.string().uuid(),
+            email: z.string().email(),
+            profile: z.object({
+                name: z.string(),
+                avatar: z.string().url().optional(),
+            }),
+        })
+    }
+    return _userSchema
 }
 
 // Or use a getter
 const schemas = {
-  _user: null as z.ZodType | null,
-  get user() {
-    if (!this._user) {
-      this._user = z.object({ /* ... */ })
-    }
-    return this._user
-  }
+    _user: null as z.ZodType | null,
+    get user() {
+        if (!this._user) {
+            this._user = z.object({
+                /* ... */
+            })
+        }
+        return this._user
+    },
 }
 ```
 
@@ -132,6 +134,7 @@ const schemas = {
 ```
 
 **When NOT to use this pattern:**
+
 - One-off validation where schema is used once
 - Dynamically generated forms where fields change per request
 - Test files where performance doesn't matter

--- a/.agents/skills/zod/references/perf-cache-schemas.md
+++ b/.agents/skills/zod/references/perf-cache-schemas.md
@@ -1,0 +1,138 @@
+---
+title: Cache Schema Instances
+impact: LOW-MEDIUM
+impactDescription: Creating schemas on every render/call wastes CPU; module-level or memoized schemas are created once
+tags: perf, cache, memoization, optimization
+---
+
+## Cache Schema Instances
+
+Schema creation has overhead. Creating schemas inside render functions or on every function call wastes CPU cycles. Define schemas at module level or memoize them so they're created once and reused.
+
+**Incorrect (creating schema every render):**
+
+```typescript
+import { z } from 'zod'
+
+function UserForm() {
+  // Schema created on EVERY render - wasteful
+  const userSchema = z.object({
+    name: z.string().min(1),
+    email: z.string().email(),
+    age: z.number().int().positive(),
+  })
+
+  const handleSubmit = (data: unknown) => {
+    const result = userSchema.safeParse(data)
+    // ...
+  }
+
+  return <form onSubmit={handleSubmit}>...</form>
+}
+```
+
+**Correct (module-level schema):**
+
+```typescript
+import { z } from 'zod'
+
+// Schema created ONCE at module load
+const userSchema = z.object({
+  name: z.string().min(1),
+  email: z.string().email(),
+  age: z.number().int().positive(),
+})
+
+type User = z.infer<typeof userSchema>
+
+function UserForm() {
+  const handleSubmit = (data: unknown) => {
+    const result = userSchema.safeParse(data)
+    // ...
+  }
+
+  return <form onSubmit={handleSubmit}>...</form>
+}
+```
+
+**For dynamic schemas, use useMemo:**
+
+```typescript
+import { z } from 'zod'
+import { useMemo } from 'react'
+
+function DynamicForm({ minAge }: { minAge: number }) {
+  // Schema only recreated when minAge changes
+  const userSchema = useMemo(() =>
+    z.object({
+      name: z.string().min(1),
+      age: z.number().min(minAge),
+    }),
+    [minAge]
+  )
+
+  // ...
+}
+```
+
+**For server-side, use module cache:**
+
+```typescript
+// schemas/user.ts - created once per process
+import { z } from 'zod'
+
+export const userSchema = z.object({
+  id: z.string().uuid(),
+  email: z.string().email(),
+})
+
+// api/users.ts
+import { userSchema } from '@/schemas/user'
+
+export async function POST(req: Request) {
+  const body = await req.json()
+  const result = userSchema.safeParse(body)  // Reuses cached schema
+  // ...
+}
+```
+
+**Avoid schema factories in hot paths:**
+
+```typescript
+// BAD: Factory called on every validation
+function createUserSchema(role: string) {
+  return z.object({
+    name: z.string(),
+    permissions: z.array(z.string()),
+  })
+}
+
+// Called in hot loop
+users.forEach(user => {
+  createUserSchema(user.role).parse(user)  // New schema every iteration!
+})
+
+// GOOD: Cache by key
+const schemaCache = new Map<string, z.ZodObject<any>>()
+
+function getUserSchema(role: string) {
+  if (!schemaCache.has(role)) {
+    schemaCache.set(role, z.object({
+      name: z.string(),
+      permissions: z.array(z.string()),
+    }))
+  }
+  return schemaCache.get(role)!
+}
+
+// Reuses cached schemas
+users.forEach(user => {
+  getUserSchema(user.role).parse(user)
+})
+```
+
+**When NOT to use this pattern:**
+- One-off validation where schema is used once
+- Test files where performance doesn't matter
+
+Reference: [Zod Performance](https://zod.dev/v4#performance)

--- a/.agents/skills/zod/references/perf-cache-schemas.md
+++ b/.agents/skills/zod/references/perf-cache-schemas.md
@@ -62,16 +62,17 @@ import { z } from 'zod'
 import { useMemo } from 'react'
 
 function DynamicForm({ minAge }: { minAge: number }) {
-  // Schema only recreated when minAge changes
-  const userSchema = useMemo(() =>
-    z.object({
-      name: z.string().min(1),
-      age: z.number().min(minAge),
-    }),
-    [minAge]
-  )
+    // Schema only recreated when minAge changes
+    const userSchema = useMemo(
+        () =>
+            z.object({
+                name: z.string().min(1),
+                age: z.number().min(minAge),
+            }),
+        [minAge],
+    )
 
-  // ...
+    // ...
 }
 ```
 
@@ -82,17 +83,17 @@ function DynamicForm({ minAge }: { minAge: number }) {
 import { z } from 'zod'
 
 export const userSchema = z.object({
-  id: z.string().uuid(),
-  email: z.string().email(),
+    id: z.string().uuid(),
+    email: z.string().email(),
 })
 
 // api/users.ts
 import { userSchema } from '@/schemas/user'
 
 export async function POST(req: Request) {
-  const body = await req.json()
-  const result = userSchema.safeParse(body)  // Reuses cached schema
-  // ...
+    const body = await req.json()
+    const result = userSchema.safeParse(body) // Reuses cached schema
+    // ...
 }
 ```
 
@@ -101,37 +102,41 @@ export async function POST(req: Request) {
 ```typescript
 // BAD: Factory called on every validation
 function createUserSchema(role: string) {
-  return z.object({
-    name: z.string(),
-    permissions: z.array(z.string()),
-  })
+    return z.object({
+        name: z.string(),
+        permissions: z.array(z.string()),
+    })
 }
 
 // Called in hot loop
 users.forEach(user => {
-  createUserSchema(user.role).parse(user)  // New schema every iteration!
+    createUserSchema(user.role).parse(user) // New schema every iteration!
 })
 
 // GOOD: Cache by key
 const schemaCache = new Map<string, z.ZodObject<any>>()
 
 function getUserSchema(role: string) {
-  if (!schemaCache.has(role)) {
-    schemaCache.set(role, z.object({
-      name: z.string(),
-      permissions: z.array(z.string()),
-    }))
-  }
-  return schemaCache.get(role)!
+    if (!schemaCache.has(role)) {
+        schemaCache.set(
+            role,
+            z.object({
+                name: z.string(),
+                permissions: z.array(z.string()),
+            }),
+        )
+    }
+    return schemaCache.get(role)!
 }
 
 // Reuses cached schemas
 users.forEach(user => {
-  getUserSchema(user.role).parse(user)
+    getUserSchema(user.role).parse(user)
 })
 ```
 
 **When NOT to use this pattern:**
+
 - One-off validation where schema is used once
 - Test files where performance doesn't matter
 

--- a/.agents/skills/zod/references/perf-lazy-loading.md
+++ b/.agents/skills/zod/references/perf-lazy-loading.md
@@ -1,0 +1,135 @@
+---
+title: Lazy Load Large Schemas
+impact: LOW-MEDIUM
+impactDescription: Large schemas increase initial bundle and parse time; dynamic imports defer loading until needed
+tags: perf, lazy, import, code-splitting
+---
+
+## Lazy Load Large Schemas
+
+For applications with many complex schemas, importing all of them upfront increases initial bundle size and startup time. Use dynamic imports to lazy load schemas that aren't needed immediately.
+
+**Incorrect (importing all schemas upfront):**
+
+```typescript
+// schemas/index.ts - barrel file with everything
+export * from './user'
+export * from './order'
+export * from './product'
+export * from './analytics'  // Large, complex schema
+export * from './reports'    // Another large schema
+export * from './admin'      // Admin-only schemas
+
+// app/page.tsx
+import { userSchema, orderSchema, analyticsSchema, reportsSchema } from '@/schemas'
+// All schemas loaded even if not used on this page
+```
+
+**Correct (lazy loading schemas):**
+
+```typescript
+// Only import what's immediately needed
+import { userSchema } from '@/schemas/user'
+
+async function loadAnalyticsSchema() {
+  const { analyticsSchema } = await import('@/schemas/analytics')
+  return analyticsSchema
+}
+
+// Use when needed
+async function handleAnalyticsData(data: unknown) {
+  const schema = await loadAnalyticsSchema()
+  return schema.safeParse(data)
+}
+```
+
+**Route-based schema loading:**
+
+```typescript
+// app/admin/reports/page.tsx
+'use client'
+
+import { useEffect, useState } from 'react'
+import type { z } from 'zod'
+
+export default function ReportsPage() {
+  const [schema, setSchema] = useState<z.ZodType | null>(null)
+
+  useEffect(() => {
+    // Load schema only when this route is accessed
+    import('@/schemas/reports').then(({ reportsSchema }) => {
+      setSchema(reportsSchema)
+    })
+  }, [])
+
+  if (!schema) return <Loading />
+
+  // Use schema...
+}
+```
+
+**Better pattern with React Suspense:**
+
+```typescript
+// schemas/reports.ts
+import { z } from 'zod'
+
+export const reportsSchema = z.object({
+  // Large complex schema
+})
+
+// app/admin/reports/page.tsx
+import { lazy, Suspense } from 'react'
+
+const ReportsForm = lazy(() => import('./ReportsForm'))
+
+export default function ReportsPage() {
+  return (
+    <Suspense fallback={<Loading />}>
+      <ReportsForm />
+    </Suspense>
+  )
+}
+
+// ReportsForm.tsx - schema imported with component
+import { reportsSchema } from '@/schemas/reports'
+
+export default function ReportsForm() {
+  // Schema available when component loads
+}
+```
+
+**Schema registry for conditional loading:**
+
+```typescript
+// schemas/registry.ts
+const schemaLoaders = {
+  user: () => import('./user').then(m => m.userSchema),
+  order: () => import('./order').then(m => m.orderSchema),
+  analytics: () => import('./analytics').then(m => m.analyticsSchema),
+  reports: () => import('./reports').then(m => m.reportsSchema),
+} as const
+
+type SchemaName = keyof typeof schemaLoaders
+
+const schemaCache = new Map<SchemaName, z.ZodType>()
+
+export async function getSchema(name: SchemaName) {
+  if (!schemaCache.has(name)) {
+    const schema = await schemaLoaders[name]()
+    schemaCache.set(name, schema)
+  }
+  return schemaCache.get(name)!
+}
+
+// Usage
+const schema = await getSchema('analytics')
+schema.parse(data)
+```
+
+**When NOT to use this pattern:**
+- Server-side rendering where all code is available
+- Small applications with few schemas
+- Schemas used on every page (defeats purpose)
+
+Reference: [Next.js Dynamic Imports](https://nextjs.org/docs/app/building-your-application/optimizing/lazy-loading)

--- a/.agents/skills/zod/references/perf-lazy-loading.md
+++ b/.agents/skills/zod/references/perf-lazy-loading.md
@@ -16,12 +16,17 @@ For applications with many complex schemas, importing all of them upfront increa
 export * from './user'
 export * from './order'
 export * from './product'
-export * from './analytics'  // Large, complex schema
-export * from './reports'    // Another large schema
-export * from './admin'      // Admin-only schemas
+export * from './analytics' // Large, complex schema
+export * from './reports' // Another large schema
+export * from './admin' // Admin-only schemas
 
 // app/page.tsx
-import { userSchema, orderSchema, analyticsSchema, reportsSchema } from '@/schemas'
+import {
+    userSchema,
+    orderSchema,
+    analyticsSchema,
+    reportsSchema,
+} from '@/schemas'
 // All schemas loaded even if not used on this page
 ```
 
@@ -32,14 +37,14 @@ import { userSchema, orderSchema, analyticsSchema, reportsSchema } from '@/schem
 import { userSchema } from '@/schemas/user'
 
 async function loadAnalyticsSchema() {
-  const { analyticsSchema } = await import('@/schemas/analytics')
-  return analyticsSchema
+    const { analyticsSchema } = await import('@/schemas/analytics')
+    return analyticsSchema
 }
 
 // Use when needed
 async function handleAnalyticsData(data: unknown) {
-  const schema = await loadAnalyticsSchema()
-  return schema.safeParse(data)
+    const schema = await loadAnalyticsSchema()
+    return schema.safeParse(data)
 }
 ```
 
@@ -104,10 +109,10 @@ export default function ReportsForm() {
 ```typescript
 // schemas/registry.ts
 const schemaLoaders = {
-  user: () => import('./user').then(m => m.userSchema),
-  order: () => import('./order').then(m => m.orderSchema),
-  analytics: () => import('./analytics').then(m => m.analyticsSchema),
-  reports: () => import('./reports').then(m => m.reportsSchema),
+    user: () => import('./user').then(m => m.userSchema),
+    order: () => import('./order').then(m => m.orderSchema),
+    analytics: () => import('./analytics').then(m => m.analyticsSchema),
+    reports: () => import('./reports').then(m => m.reportsSchema),
 } as const
 
 type SchemaName = keyof typeof schemaLoaders
@@ -115,11 +120,11 @@ type SchemaName = keyof typeof schemaLoaders
 const schemaCache = new Map<SchemaName, z.ZodType>()
 
 export async function getSchema(name: SchemaName) {
-  if (!schemaCache.has(name)) {
-    const schema = await schemaLoaders[name]()
-    schemaCache.set(name, schema)
-  }
-  return schemaCache.get(name)!
+    if (!schemaCache.has(name)) {
+        const schema = await schemaLoaders[name]()
+        schemaCache.set(name, schema)
+    }
+    return schemaCache.get(name)!
 }
 
 // Usage
@@ -128,6 +133,7 @@ schema.parse(data)
 ```
 
 **When NOT to use this pattern:**
+
 - Server-side rendering where all code is available
 - Small applications with few schemas
 - Schemas used on every page (defeats purpose)

--- a/.agents/skills/zod/references/perf-zod-mini.md
+++ b/.agents/skills/zod/references/perf-zod-mini.md
@@ -1,0 +1,117 @@
+---
+title: Use Zod Mini for Bundle-Sensitive Applications
+impact: LOW-MEDIUM
+impactDescription: Full Zod is ~17kb gzipped; Zod Mini is ~1.9kb - 85% smaller for frontend-critical bundles
+tags: perf, bundle, mini, tree-shaking
+---
+
+## Use Zod Mini for Bundle-Sensitive Applications
+
+For frontend applications where bundle size is critical, use `@zod/mini` instead of `zod`. Zod Mini provides the same validation capabilities with a functional API that tree-shakes better, reducing bundle size by ~85%.
+
+**When to consider Zod Mini:**
+
+```typescript
+// Your app if:
+// - Bundle size is critical (mobile-first, slow networks)
+// - Edge functions with size limits
+// - Simple validation needs (no complex transforms)
+// - Tree-shaking is important
+
+// Zod: ~17kb gzipped
+import { z } from 'zod'
+
+// Zod Mini: ~1.9kb gzipped (when tree-shaken)
+import * as z from '@zod/mini'
+```
+
+**Standard Zod (method chaining):**
+
+```typescript
+import { z } from 'zod'
+
+// Methods are attached to schema objects - hard to tree-shake
+const userSchema = z.object({
+  name: z.string().min(1).max(100),
+  email: z.string().email(),
+  age: z.number().int().positive(),
+})
+
+const result = userSchema.safeParse(data)
+```
+
+**Zod Mini (functional API):**
+
+```typescript
+import * as z from '@zod/mini'
+
+// Functions are imported individually - tree-shakeable
+const userSchema = z.object({
+  name: z.pipe(z.string(), z.minLength(1), z.maxLength(100)),
+  email: z.pipe(z.string(), z.email()),
+  age: z.pipe(z.number(), z.int(), z.positive()),
+})
+
+const result = z.safeParse(userSchema, data)
+```
+
+**API differences:**
+
+```typescript
+// Standard Zod
+z.string().min(5).max(100).email()
+z.number().int().positive()
+z.array(z.string()).min(1)
+schema.parse(data)
+schema.safeParse(data)
+
+// Zod Mini
+z.pipe(z.string(), z.minLength(5), z.maxLength(100), z.email())
+z.pipe(z.number(), z.int(), z.positive())
+z.pipe(z.array(z.string()), z.minLength(1))
+z.parse(schema, data)
+z.safeParse(schema, data)
+```
+
+**When to stick with regular Zod:**
+
+```typescript
+// Use regular Zod when:
+// - Server-side where bundle size doesn't matter
+// - Complex schemas with many transforms
+// - Need full method chaining ergonomics
+// - Bundle size isn't a constraint
+
+// The 17kb isn't huge - only optimize if needed
+// Server: 17kb is negligible
+// Browser: 17kb ≈ 0.6ms additional startup on 3G
+```
+
+**Shared schemas between packages:**
+
+```typescript
+// shared-schemas/package.json
+{
+  "dependencies": {
+    "@zod/mini": "^4.0.0"  // Mini for frontend-shared schemas
+  }
+}
+
+// If you need both, Zod Mini schemas work with regular Zod
+// But prefer consistency - pick one for your codebase
+```
+
+**Bundle size comparison:**
+
+| Package | Gzipped Size | Use Case |
+|---------|--------------|----------|
+| `zod@3` | ~13kb | Legacy, stable |
+| `zod@4` | ~17kb | Full features |
+| `@zod/mini` | ~1.9kb | Bundle-critical |
+
+**When NOT to use this pattern:**
+- Server-side applications (bundle size irrelevant)
+- When method chaining ergonomics are preferred
+- Complex schemas that benefit from full API
+
+Reference: [Zod Mini](https://zod.dev/packages/mini)

--- a/.agents/skills/zod/references/perf-zod-mini.md
+++ b/.agents/skills/zod/references/perf-zod-mini.md
@@ -32,9 +32,9 @@ import { z } from 'zod'
 
 // Methods are attached to schema objects - hard to tree-shake
 const userSchema = z.object({
-  name: z.string().min(1).max(100),
-  email: z.string().email(),
-  age: z.number().int().positive(),
+    name: z.string().min(1).max(100),
+    email: z.string().email(),
+    age: z.number().int().positive(),
 })
 
 const result = userSchema.safeParse(data)
@@ -47,9 +47,9 @@ import * as z from '@zod/mini'
 
 // Functions are imported individually - tree-shakeable
 const userSchema = z.object({
-  name: z.pipe(z.string(), z.minLength(1), z.maxLength(100)),
-  email: z.pipe(z.string(), z.email()),
-  age: z.pipe(z.number(), z.int(), z.positive()),
+    name: z.pipe(z.string(), z.minLength(1), z.maxLength(100)),
+    email: z.pipe(z.string(), z.email()),
+    age: z.pipe(z.number(), z.int(), z.positive()),
 })
 
 const result = z.safeParse(userSchema, data)
@@ -103,13 +103,14 @@ z.safeParse(schema, data)
 
 **Bundle size comparison:**
 
-| Package | Gzipped Size | Use Case |
-|---------|--------------|----------|
-| `zod@3` | ~13kb | Legacy, stable |
-| `zod@4` | ~17kb | Full features |
-| `@zod/mini` | ~1.9kb | Bundle-critical |
+| Package     | Gzipped Size | Use Case        |
+| ----------- | ------------ | --------------- |
+| `zod@3`     | ~13kb        | Legacy, stable  |
+| `zod@4`     | ~17kb        | Full features   |
+| `@zod/mini` | ~1.9kb       | Bundle-critical |
 
 **When NOT to use this pattern:**
+
 - Server-side applications (bundle size irrelevant)
 - When method chaining ergonomics are preferred
 - Complex schemas that benefit from full API

--- a/.agents/skills/zod/references/refine-add-path.md
+++ b/.agents/skills/zod/references/refine-add-path.md
@@ -1,0 +1,141 @@
+---
+title: Add Path to Refinement Errors
+impact: MEDIUM
+impactDescription: Errors without path show at object level; adding path highlights the specific field that failed
+tags: refine, path, errors, forms
+---
+
+## Add Path to Refinement Errors
+
+When using `.refine()` on object schemas for cross-field validation, add a `path` option to indicate which field the error relates to. Without it, the error appears at the object level, making form error display confusing.
+
+**Incorrect (error at object level):**
+
+```typescript
+import { z } from 'zod'
+
+const formSchema = z.object({
+  password: z.string().min(8),
+  confirmPassword: z.string(),
+}).refine(
+  (data) => data.password === data.confirmPassword,
+  { message: 'Passwords do not match' }  // No path specified
+)
+
+const result = formSchema.safeParse({
+  password: 'secret123',
+  confirmPassword: 'different',
+})
+
+if (!result.success) {
+  const flattened = result.error.flatten()
+  // {
+  //   formErrors: ['Passwords do not match'],  // At form level!
+  //   fieldErrors: {}  // Empty - no field association
+  // }
+}
+
+// Form UI can't highlight which field has the error
+```
+
+**Correct (error with path):**
+
+```typescript
+import { z } from 'zod'
+
+const formSchema = z.object({
+  password: z.string().min(8),
+  confirmPassword: z.string(),
+}).refine(
+  (data) => data.password === data.confirmPassword,
+  {
+    message: 'Passwords do not match',
+    path: ['confirmPassword'],  // Error appears on this field
+  }
+)
+
+const result = formSchema.safeParse({
+  password: 'secret123',
+  confirmPassword: 'different',
+})
+
+if (!result.success) {
+  const flattened = result.error.flatten()
+  // {
+  //   formErrors: [],
+  //   fieldErrors: {
+  //     confirmPassword: ['Passwords do not match']  // Associated with field
+  //   }
+  // }
+}
+
+// Form can now show error next to confirmPassword input
+```
+
+**Multiple cross-field validations:**
+
+```typescript
+const dateRangeSchema = z.object({
+  startDate: z.coerce.date(),
+  endDate: z.coerce.date(),
+  minDays: z.number().optional(),
+  maxDays: z.number().optional(),
+}).refine(
+  (data) => data.endDate >= data.startDate,
+  { message: 'End date must be after start date', path: ['endDate'] }
+).refine(
+  (data) => {
+    if (!data.minDays) return true
+    const days = (data.endDate.getTime() - data.startDate.getTime()) / 86400000
+    return days >= data.minDays
+  },
+  { message: 'Date range is too short', path: ['endDate'] }
+).refine(
+  (data) => {
+    if (!data.maxDays) return true
+    const days = (data.endDate.getTime() - data.startDate.getTime()) / 86400000
+    return days <= data.maxDays
+  },
+  { message: 'Date range is too long', path: ['endDate'] }
+)
+```
+
+**With superRefine for multiple path errors:**
+
+```typescript
+const orderSchema = z.object({
+  billingAddress: z.object({
+    street: z.string(),
+    city: z.string(),
+  }),
+  shippingAddress: z.object({
+    street: z.string(),
+    city: z.string(),
+  }),
+  sameAsBilling: z.boolean(),
+}).superRefine((data, ctx) => {
+  if (data.sameAsBilling) {
+    // If sameAsBilling but addresses differ, show errors on shipping
+    if (data.shippingAddress.street !== data.billingAddress.street) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'Must match billing address',
+        path: ['shippingAddress', 'street'],  // Nested path
+      })
+    }
+    if (data.shippingAddress.city !== data.billingAddress.city) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'Must match billing address',
+        path: ['shippingAddress', 'city'],
+      })
+    }
+  }
+})
+```
+
+**When NOT to use this pattern:**
+- When the error genuinely applies to the whole object
+- Simple single-field refinements (path is implicit)
+
+Reference: [Zod API - refine](https://zod.dev/api#refine)

--- a/.agents/skills/zod/references/refine-add-path.md
+++ b/.agents/skills/zod/references/refine-add-path.md
@@ -14,25 +14,27 @@ When using `.refine()` on object schemas for cross-field validation, add a `path
 ```typescript
 import { z } from 'zod'
 
-const formSchema = z.object({
-  password: z.string().min(8),
-  confirmPassword: z.string(),
-}).refine(
-  (data) => data.password === data.confirmPassword,
-  { message: 'Passwords do not match' }  // No path specified
-)
+const formSchema = z
+    .object({
+        password: z.string().min(8),
+        confirmPassword: z.string(),
+    })
+    .refine(
+        data => data.password === data.confirmPassword,
+        { message: 'Passwords do not match' }, // No path specified
+    )
 
 const result = formSchema.safeParse({
-  password: 'secret123',
-  confirmPassword: 'different',
+    password: 'secret123',
+    confirmPassword: 'different',
 })
 
 if (!result.success) {
-  const flattened = result.error.flatten()
-  // {
-  //   formErrors: ['Passwords do not match'],  // At form level!
-  //   fieldErrors: {}  // Empty - no field association
-  // }
+    const flattened = result.error.flatten()
+    // {
+    //   formErrors: ['Passwords do not match'],  // At form level!
+    //   fieldErrors: {}  // Empty - no field association
+    // }
 }
 
 // Form UI can't highlight which field has the error
@@ -43,30 +45,29 @@ if (!result.success) {
 ```typescript
 import { z } from 'zod'
 
-const formSchema = z.object({
-  password: z.string().min(8),
-  confirmPassword: z.string(),
-}).refine(
-  (data) => data.password === data.confirmPassword,
-  {
-    message: 'Passwords do not match',
-    path: ['confirmPassword'],  // Error appears on this field
-  }
-)
+const formSchema = z
+    .object({
+        password: z.string().min(8),
+        confirmPassword: z.string(),
+    })
+    .refine(data => data.password === data.confirmPassword, {
+        message: 'Passwords do not match',
+        path: ['confirmPassword'], // Error appears on this field
+    })
 
 const result = formSchema.safeParse({
-  password: 'secret123',
-  confirmPassword: 'different',
+    password: 'secret123',
+    confirmPassword: 'different',
 })
 
 if (!result.success) {
-  const flattened = result.error.flatten()
-  // {
-  //   formErrors: [],
-  //   fieldErrors: {
-  //     confirmPassword: ['Passwords do not match']  // Associated with field
-  //   }
-  // }
+    const flattened = result.error.flatten()
+    // {
+    //   formErrors: [],
+    //   fieldErrors: {
+    //     confirmPassword: ['Passwords do not match']  // Associated with field
+    //   }
+    // }
 }
 
 // Form can now show error next to confirmPassword input
@@ -75,66 +76,75 @@ if (!result.success) {
 **Multiple cross-field validations:**
 
 ```typescript
-const dateRangeSchema = z.object({
-  startDate: z.coerce.date(),
-  endDate: z.coerce.date(),
-  minDays: z.number().optional(),
-  maxDays: z.number().optional(),
-}).refine(
-  (data) => data.endDate >= data.startDate,
-  { message: 'End date must be after start date', path: ['endDate'] }
-).refine(
-  (data) => {
-    if (!data.minDays) return true
-    const days = (data.endDate.getTime() - data.startDate.getTime()) / 86400000
-    return days >= data.minDays
-  },
-  { message: 'Date range is too short', path: ['endDate'] }
-).refine(
-  (data) => {
-    if (!data.maxDays) return true
-    const days = (data.endDate.getTime() - data.startDate.getTime()) / 86400000
-    return days <= data.maxDays
-  },
-  { message: 'Date range is too long', path: ['endDate'] }
-)
+const dateRangeSchema = z
+    .object({
+        startDate: z.coerce.date(),
+        endDate: z.coerce.date(),
+        minDays: z.number().optional(),
+        maxDays: z.number().optional(),
+    })
+    .refine(data => data.endDate >= data.startDate, {
+        message: 'End date must be after start date',
+        path: ['endDate'],
+    })
+    .refine(
+        data => {
+            if (!data.minDays) return true
+            const days =
+                (data.endDate.getTime() - data.startDate.getTime()) / 86400000
+            return days >= data.minDays
+        },
+        { message: 'Date range is too short', path: ['endDate'] },
+    )
+    .refine(
+        data => {
+            if (!data.maxDays) return true
+            const days =
+                (data.endDate.getTime() - data.startDate.getTime()) / 86400000
+            return days <= data.maxDays
+        },
+        { message: 'Date range is too long', path: ['endDate'] },
+    )
 ```
 
 **With superRefine for multiple path errors:**
 
 ```typescript
-const orderSchema = z.object({
-  billingAddress: z.object({
-    street: z.string(),
-    city: z.string(),
-  }),
-  shippingAddress: z.object({
-    street: z.string(),
-    city: z.string(),
-  }),
-  sameAsBilling: z.boolean(),
-}).superRefine((data, ctx) => {
-  if (data.sameAsBilling) {
-    // If sameAsBilling but addresses differ, show errors on shipping
-    if (data.shippingAddress.street !== data.billingAddress.street) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        message: 'Must match billing address',
-        path: ['shippingAddress', 'street'],  // Nested path
-      })
-    }
-    if (data.shippingAddress.city !== data.billingAddress.city) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        message: 'Must match billing address',
-        path: ['shippingAddress', 'city'],
-      })
-    }
-  }
-})
+const orderSchema = z
+    .object({
+        billingAddress: z.object({
+            street: z.string(),
+            city: z.string(),
+        }),
+        shippingAddress: z.object({
+            street: z.string(),
+            city: z.string(),
+        }),
+        sameAsBilling: z.boolean(),
+    })
+    .superRefine((data, ctx) => {
+        if (data.sameAsBilling) {
+            // If sameAsBilling but addresses differ, show errors on shipping
+            if (data.shippingAddress.street !== data.billingAddress.street) {
+                ctx.addIssue({
+                    code: z.ZodIssueCode.custom,
+                    message: 'Must match billing address',
+                    path: ['shippingAddress', 'street'], // Nested path
+                })
+            }
+            if (data.shippingAddress.city !== data.billingAddress.city) {
+                ctx.addIssue({
+                    code: z.ZodIssueCode.custom,
+                    message: 'Must match billing address',
+                    path: ['shippingAddress', 'city'],
+                })
+            }
+        }
+    })
 ```
 
 **When NOT to use this pattern:**
+
 - When the error genuinely applies to the whole object
 - Simple single-field refinements (path is implicit)
 

--- a/.agents/skills/zod/references/refine-catch.md
+++ b/.agents/skills/zod/references/refine-catch.md
@@ -1,0 +1,143 @@
+---
+title: Use catch() for Fault-Tolerant Parsing
+impact: MEDIUM
+impactDescription: parse() fails on first invalid field; catch() provides fallback values, enabling partial success with degraded data
+tags: refine, catch, fallback, resilience
+---
+
+## Use catch() for Fault-Tolerant Parsing
+
+When parsing data that might have some invalid fields but you want to accept what's valid, use `.catch()` to provide fallback values instead of failing entirely. This enables graceful degradation for partially corrupted data.
+
+**Incorrect (all-or-nothing parsing):**
+
+```typescript
+import { z } from 'zod'
+
+const userPrefsSchema = z.object({
+  theme: z.enum(['light', 'dark']),
+  fontSize: z.number().min(8).max(32),
+  language: z.string(),
+  notifications: z.boolean(),
+})
+
+// Corrupted localStorage data
+const stored = {
+  theme: 'invalid-theme',  // Bad
+  fontSize: 200,  // Bad
+  language: 'en',  // Good
+  notifications: 'yes',  // Bad - should be boolean
+}
+
+userPrefsSchema.parse(stored)
+// ZodError: Invalid enum value at "theme"
+// User loses ALL their preferences because one field is bad
+```
+
+**Correct (fault-tolerant with catch):**
+
+```typescript
+import { z } from 'zod'
+
+const userPrefsSchema = z.object({
+  theme: z.enum(['light', 'dark']).catch('light'),
+  fontSize: z.number().min(8).max(32).catch(16),
+  language: z.string().catch('en'),
+  notifications: z.boolean().catch(true),
+})
+
+// Corrupted data
+const stored = {
+  theme: 'invalid-theme',
+  fontSize: 200,
+  language: 'en',
+  notifications: 'yes',
+}
+
+const prefs = userPrefsSchema.parse(stored)
+// {
+//   theme: 'light',      // Fallback used
+//   fontSize: 16,        // Fallback used
+//   language: 'en',      // Original value preserved
+//   notifications: true  // Fallback used
+// }
+// User gets mostly working preferences instead of error
+```
+
+**Catch with factory function:**
+
+```typescript
+// Factory function receives the caught error
+const schema = z.object({
+  data: z.array(z.number()).catch((ctx) => {
+    console.warn('Invalid data array:', ctx.error)
+    return []  // Return empty array as fallback
+  }),
+})
+```
+
+**Use case: API response resilience:**
+
+```typescript
+const productSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  price: z.number().positive(),
+  // Legacy field that might be missing or wrong format
+  legacyCode: z.string().catch('UNKNOWN'),
+  // External data that might be malformed
+  metadata: z.record(z.string()).catch({}),
+})
+
+// API returns partial data
+const apiResponse = {
+  id: 'prod-123',
+  name: 'Widget',
+  price: 29.99,
+  legacyCode: null,  // Bad - should be string
+  metadata: 'invalid',  // Bad - should be object
+}
+
+const product = productSchema.parse(apiResponse)
+// Works! Returns product with fallbacks for bad fields
+```
+
+**Difference between catch() and default():**
+
+```typescript
+// .default() - only fills in undefined
+z.string().default('fallback')
+// undefined -> 'fallback'
+// null -> ZodError
+// '' -> '' (empty string is valid)
+
+// .catch() - fallback for ANY parse failure
+z.string().catch('fallback')
+// undefined -> 'fallback'
+// null -> 'fallback'
+// 123 -> 'fallback'
+// Even valid strings pass through unchanged
+```
+
+**Combining catch with validation:**
+
+```typescript
+// Catch only specific validation failures
+const schema = z.string()
+  .email()
+  .catch('invalid@example.com')  // Fallback if not valid email
+
+// Chain for complex defaults
+const ageSchema = z.coerce.number()
+  .int()
+  .min(0)
+  .max(120)
+  .catch(0)  // Invalid ages become 0
+```
+
+**When NOT to use this pattern:**
+- When invalid data should cause errors (strict validation)
+- When you need to know which fields failed (use safeParse)
+- Critical fields that must be valid
+
+Reference: [Zod API - catch](https://zod.dev/api#catch)

--- a/.agents/skills/zod/references/refine-catch.md
+++ b/.agents/skills/zod/references/refine-catch.md
@@ -15,18 +15,18 @@ When parsing data that might have some invalid fields but you want to accept wha
 import { z } from 'zod'
 
 const userPrefsSchema = z.object({
-  theme: z.enum(['light', 'dark']),
-  fontSize: z.number().min(8).max(32),
-  language: z.string(),
-  notifications: z.boolean(),
+    theme: z.enum(['light', 'dark']),
+    fontSize: z.number().min(8).max(32),
+    language: z.string(),
+    notifications: z.boolean(),
 })
 
 // Corrupted localStorage data
 const stored = {
-  theme: 'invalid-theme',  // Bad
-  fontSize: 200,  // Bad
-  language: 'en',  // Good
-  notifications: 'yes',  // Bad - should be boolean
+    theme: 'invalid-theme', // Bad
+    fontSize: 200, // Bad
+    language: 'en', // Good
+    notifications: 'yes', // Bad - should be boolean
 }
 
 userPrefsSchema.parse(stored)
@@ -40,18 +40,18 @@ userPrefsSchema.parse(stored)
 import { z } from 'zod'
 
 const userPrefsSchema = z.object({
-  theme: z.enum(['light', 'dark']).catch('light'),
-  fontSize: z.number().min(8).max(32).catch(16),
-  language: z.string().catch('en'),
-  notifications: z.boolean().catch(true),
+    theme: z.enum(['light', 'dark']).catch('light'),
+    fontSize: z.number().min(8).max(32).catch(16),
+    language: z.string().catch('en'),
+    notifications: z.boolean().catch(true),
 })
 
 // Corrupted data
 const stored = {
-  theme: 'invalid-theme',
-  fontSize: 200,
-  language: 'en',
-  notifications: 'yes',
+    theme: 'invalid-theme',
+    fontSize: 200,
+    language: 'en',
+    notifications: 'yes',
 }
 
 const prefs = userPrefsSchema.parse(stored)
@@ -69,10 +69,10 @@ const prefs = userPrefsSchema.parse(stored)
 ```typescript
 // Factory function receives the caught error
 const schema = z.object({
-  data: z.array(z.number()).catch((ctx) => {
-    console.warn('Invalid data array:', ctx.error)
-    return []  // Return empty array as fallback
-  }),
+    data: z.array(z.number()).catch(ctx => {
+        console.warn('Invalid data array:', ctx.error)
+        return [] // Return empty array as fallback
+    }),
 })
 ```
 
@@ -80,22 +80,22 @@ const schema = z.object({
 
 ```typescript
 const productSchema = z.object({
-  id: z.string(),
-  name: z.string(),
-  price: z.number().positive(),
-  // Legacy field that might be missing or wrong format
-  legacyCode: z.string().catch('UNKNOWN'),
-  // External data that might be malformed
-  metadata: z.record(z.string()).catch({}),
+    id: z.string(),
+    name: z.string(),
+    price: z.number().positive(),
+    // Legacy field that might be missing or wrong format
+    legacyCode: z.string().catch('UNKNOWN'),
+    // External data that might be malformed
+    metadata: z.record(z.string()).catch({}),
 })
 
 // API returns partial data
 const apiResponse = {
-  id: 'prod-123',
-  name: 'Widget',
-  price: 29.99,
-  legacyCode: null,  // Bad - should be string
-  metadata: 'invalid',  // Bad - should be object
+    id: 'prod-123',
+    name: 'Widget',
+    price: 29.99,
+    legacyCode: null, // Bad - should be string
+    metadata: 'invalid', // Bad - should be object
 }
 
 const product = productSchema.parse(apiResponse)
@@ -123,19 +123,14 @@ z.string().catch('fallback')
 
 ```typescript
 // Catch only specific validation failures
-const schema = z.string()
-  .email()
-  .catch('invalid@example.com')  // Fallback if not valid email
+const schema = z.string().email().catch('invalid@example.com') // Fallback if not valid email
 
 // Chain for complex defaults
-const ageSchema = z.coerce.number()
-  .int()
-  .min(0)
-  .max(120)
-  .catch(0)  // Invalid ages become 0
+const ageSchema = z.coerce.number().int().min(0).max(120).catch(0) // Invalid ages become 0
 ```
 
 **When NOT to use this pattern:**
+
 - When invalid data should cause errors (strict validation)
 - When you need to know which fields failed (use safeParse)
 - Critical fields that must be valid

--- a/.agents/skills/zod/references/refine-defaults.md
+++ b/.agents/skills/zod/references/refine-defaults.md
@@ -1,0 +1,131 @@
+---
+title: Use default() for Optional Fields with Defaults
+impact: MEDIUM
+impactDescription: Manual default handling spreads logic across codebase; .default() centralizes defaults in schema
+tags: refine, default, optional, configuration
+---
+
+## Use default() for Optional Fields with Defaults
+
+When a field is optional but should have a default value when missing, use `.default()` instead of handling defaults in business logic. This keeps default values centralized in the schema and ensures consistent behavior.
+
+**Incorrect (defaults spread across codebase):**
+
+```typescript
+import { z } from 'zod'
+
+const configSchema = z.object({
+  timeout: z.number().optional(),
+  retries: z.number().optional(),
+  debug: z.boolean().optional(),
+})
+
+type Config = z.infer<typeof configSchema>
+
+function createClient(config: Config) {
+  // Defaults handled in business logic - duplicated everywhere
+  const timeout = config.timeout ?? 5000
+  const retries = config.retries ?? 3
+  const debug = config.debug ?? false
+
+  // ...
+}
+
+function createOtherClient(config: Config) {
+  // Same defaults duplicated - risk of inconsistency
+  const timeout = config.timeout ?? 5000
+  const retries = config.retries ?? 3  // What if someone uses 2 here?
+  const debug = config.debug ?? false
+
+  // ...
+}
+```
+
+**Correct (defaults in schema):**
+
+```typescript
+import { z } from 'zod'
+
+const configSchema = z.object({
+  timeout: z.number().default(5000),
+  retries: z.number().default(3),
+  debug: z.boolean().default(false),
+})
+
+type Config = z.infer<typeof configSchema>
+// { timeout: number; retries: number; debug: boolean }
+// No optional - defaults fill in missing values
+
+function createClient(config: Config) {
+  // config.timeout is guaranteed to exist
+  console.log(config.timeout)  // 5000 if not provided
+  console.log(config.retries)  // 3 if not provided
+  console.log(config.debug)    // false if not provided
+}
+
+// Parse fills in defaults
+configSchema.parse({})
+// { timeout: 5000, retries: 3, debug: false }
+
+configSchema.parse({ timeout: 10000 })
+// { timeout: 10000, retries: 3, debug: false }
+```
+
+**Input type vs Output type with defaults:**
+
+```typescript
+const schema = z.object({
+  name: z.string(),
+  role: z.enum(['admin', 'user']).default('user'),
+})
+
+type SchemaInput = z.input<typeof schema>
+// { name: string; role?: 'admin' | 'user' }
+
+type SchemaOutput = z.output<typeof schema>
+// { name: string; role: 'admin' | 'user' }
+
+// Input type is optional, output type is required
+```
+
+**Default with factory function:**
+
+```typescript
+// Static default
+const schema1 = z.object({
+  id: z.string().default('temp-id'),
+})
+
+// Factory function for dynamic defaults
+const schema2 = z.object({
+  id: z.string().default(() => crypto.randomUUID()),
+  createdAt: z.date().default(() => new Date()),
+})
+
+// Each parse creates new values
+schema2.parse({})  // { id: 'abc-123...', createdAt: 2024-01-15... }
+schema2.parse({})  // { id: 'def-456...', createdAt: 2024-01-15... }
+```
+
+**Combining with optional/nullable:**
+
+```typescript
+// .optional().default() - if undefined, use default
+z.string().optional().default('fallback')
+
+// .nullable().default() - null stays null, only undefined gets default
+z.string().nullable().default('fallback')
+// null -> null
+// undefined -> 'fallback'
+
+// .nullish().default() - both null and undefined get default
+z.string().nullish().default('fallback')
+// null -> 'fallback'
+// undefined -> 'fallback'
+```
+
+**When NOT to use this pattern:**
+- When absence of value has different meaning than default
+- When defaults depend on other fields (use transform)
+
+Reference: [Zod API - default](https://zod.dev/api#default)

--- a/.agents/skills/zod/references/refine-defaults.md
+++ b/.agents/skills/zod/references/refine-defaults.md
@@ -15,29 +15,29 @@ When a field is optional but should have a default value when missing, use `.def
 import { z } from 'zod'
 
 const configSchema = z.object({
-  timeout: z.number().optional(),
-  retries: z.number().optional(),
-  debug: z.boolean().optional(),
+    timeout: z.number().optional(),
+    retries: z.number().optional(),
+    debug: z.boolean().optional(),
 })
 
 type Config = z.infer<typeof configSchema>
 
 function createClient(config: Config) {
-  // Defaults handled in business logic - duplicated everywhere
-  const timeout = config.timeout ?? 5000
-  const retries = config.retries ?? 3
-  const debug = config.debug ?? false
+    // Defaults handled in business logic - duplicated everywhere
+    const timeout = config.timeout ?? 5000
+    const retries = config.retries ?? 3
+    const debug = config.debug ?? false
 
-  // ...
+    // ...
 }
 
 function createOtherClient(config: Config) {
-  // Same defaults duplicated - risk of inconsistency
-  const timeout = config.timeout ?? 5000
-  const retries = config.retries ?? 3  // What if someone uses 2 here?
-  const debug = config.debug ?? false
+    // Same defaults duplicated - risk of inconsistency
+    const timeout = config.timeout ?? 5000
+    const retries = config.retries ?? 3 // What if someone uses 2 here?
+    const debug = config.debug ?? false
 
-  // ...
+    // ...
 }
 ```
 
@@ -47,9 +47,9 @@ function createOtherClient(config: Config) {
 import { z } from 'zod'
 
 const configSchema = z.object({
-  timeout: z.number().default(5000),
-  retries: z.number().default(3),
-  debug: z.boolean().default(false),
+    timeout: z.number().default(5000),
+    retries: z.number().default(3),
+    debug: z.boolean().default(false),
 })
 
 type Config = z.infer<typeof configSchema>
@@ -57,10 +57,10 @@ type Config = z.infer<typeof configSchema>
 // No optional - defaults fill in missing values
 
 function createClient(config: Config) {
-  // config.timeout is guaranteed to exist
-  console.log(config.timeout)  // 5000 if not provided
-  console.log(config.retries)  // 3 if not provided
-  console.log(config.debug)    // false if not provided
+    // config.timeout is guaranteed to exist
+    console.log(config.timeout) // 5000 if not provided
+    console.log(config.retries) // 3 if not provided
+    console.log(config.debug) // false if not provided
 }
 
 // Parse fills in defaults
@@ -75,8 +75,8 @@ configSchema.parse({ timeout: 10000 })
 
 ```typescript
 const schema = z.object({
-  name: z.string(),
-  role: z.enum(['admin', 'user']).default('user'),
+    name: z.string(),
+    role: z.enum(['admin', 'user']).default('user'),
 })
 
 type SchemaInput = z.input<typeof schema>
@@ -93,18 +93,18 @@ type SchemaOutput = z.output<typeof schema>
 ```typescript
 // Static default
 const schema1 = z.object({
-  id: z.string().default('temp-id'),
+    id: z.string().default('temp-id'),
 })
 
 // Factory function for dynamic defaults
 const schema2 = z.object({
-  id: z.string().default(() => crypto.randomUUID()),
-  createdAt: z.date().default(() => new Date()),
+    id: z.string().default(() => crypto.randomUUID()),
+    createdAt: z.date().default(() => new Date()),
 })
 
 // Each parse creates new values
-schema2.parse({})  // { id: 'abc-123...', createdAt: 2024-01-15... }
-schema2.parse({})  // { id: 'def-456...', createdAt: 2024-01-15... }
+schema2.parse({}) // { id: 'abc-123...', createdAt: 2024-01-15... }
+schema2.parse({}) // { id: 'def-456...', createdAt: 2024-01-15... }
 ```
 
 **Combining with optional/nullable:**
@@ -125,6 +125,7 @@ z.string().nullish().default('fallback')
 ```
 
 **When NOT to use this pattern:**
+
 - When absence of value has different meaning than default
 - When defaults depend on other fields (use transform)
 

--- a/.agents/skills/zod/references/refine-transform-coerce.md
+++ b/.agents/skills/zod/references/refine-transform-coerce.md
@@ -1,0 +1,105 @@
+---
+title: Distinguish transform() from refine() and coerce()
+impact: MEDIUM
+impactDescription: Using wrong method causes validation to pass with wrong data; each method has distinct purpose
+tags: refine, transform, coerce, conversion
+---
+
+## Distinguish transform() from refine() and coerce()
+
+`.refine()` validates and returns boolean, `.transform()` converts data to new format, and `.coerce` converts input before validation. Using the wrong one causes bugs where validation passes but data is wrong.
+
+**Purpose of each method:**
+
+```typescript
+import { z } from 'zod'
+
+// coerce: Convert type BEFORE validation
+// Input: unknown -> Output: validated type
+z.coerce.number().parse('42')  // Converts "42" to 42, then validates as number
+
+// refine: Validate with custom logic, return boolean
+// Input: T -> Output: T (unchanged, but validated)
+z.number().refine((n) => n > 0)  // Validates n > 0, returns n unchanged
+
+// transform: Convert to different type AFTER validation
+// Input: T -> Output: U (different type)
+z.string().transform((s) => s.length)  // Validates string, returns length
+```
+
+**Incorrect (using transform for validation):**
+
+```typescript
+// Wrong: transform should convert, not validate
+const schema = z.number().transform((n) => {
+  if (n < 0) throw new Error('Must be positive')  // Don't throw in transform
+  return n
+})
+```
+
+**Correct (using appropriate method):**
+
+```typescript
+import { z } from 'zod'
+
+// VALIDATION: Use refine - returns boolean, data unchanged
+const positiveNumber = z.number().refine(
+  (n) => n > 0,
+  { message: 'Must be positive' }
+)
+
+positiveNumber.parse(5)  // 5
+positiveNumber.parse(-1)  // ZodError: Must be positive
+
+// CONVERSION: Use transform - returns new value
+const stringLength = z.string().transform((s) => s.length)
+
+type StringLength = z.infer<typeof stringLength>  // number
+stringLength.parse('hello')  // 5
+
+// COERCION: Use coerce - converts input type
+const coercedNumber = z.coerce.number()
+
+coercedNumber.parse('42')  // 42 (from string)
+coercedNumber.parse(42)  // 42 (already number)
+```
+
+**Combining methods correctly:**
+
+```typescript
+// Input: string -> Coerce to number -> Validate positive -> Transform to dollars
+const priceSchema = z.coerce
+  .number()
+  .refine((n) => n >= 0, 'Price cannot be negative')
+  .transform((cents) => `$${(cents / 100).toFixed(2)}`)
+
+priceSchema.parse('1999')  // "$19.99"
+priceSchema.parse('-100')  // ZodError: Price cannot be negative
+```
+
+**Order of operations:**
+
+```typescript
+const schema = z
+  .preprocess(val => val, z.string())  // 1. preprocess (before type check)
+  .transform(s => s.trim())             // 2. transform (after type check)
+  .refine(s => s.length > 0)            // 3. refine (custom validation)
+  .transform(s => s.toUpperCase())      // 4. another transform
+
+// Input flows: preprocess -> type check -> transforms/refines in order
+```
+
+**Use case comparison:**
+
+| Need | Method | Example |
+|------|--------|---------|
+| Convert string to number | `z.coerce.number()` | Form input |
+| Validate number is positive | `.refine(n => n > 0)` | Business rule |
+| Convert cents to dollars | `.transform(n => n/100)` | Display format |
+| Trim whitespace before check | `z.preprocess` | Input cleanup |
+
+**When NOT to use this pattern:**
+- Simple type coercion: use `z.coerce.*`
+- Simple validation: use built-in methods like `.min()`, `.email()`
+
+Reference: [Zod API - transform](https://zod.dev/api#transform)

--- a/.agents/skills/zod/references/refine-transform-coerce.md
+++ b/.agents/skills/zod/references/refine-transform-coerce.md
@@ -16,24 +16,24 @@ import { z } from 'zod'
 
 // coerce: Convert type BEFORE validation
 // Input: unknown -> Output: validated type
-z.coerce.number().parse('42')  // Converts "42" to 42, then validates as number
+z.coerce.number().parse('42') // Converts "42" to 42, then validates as number
 
 // refine: Validate with custom logic, return boolean
 // Input: T -> Output: T (unchanged, but validated)
-z.number().refine((n) => n > 0)  // Validates n > 0, returns n unchanged
+z.number().refine(n => n > 0) // Validates n > 0, returns n unchanged
 
 // transform: Convert to different type AFTER validation
 // Input: T -> Output: U (different type)
-z.string().transform((s) => s.length)  // Validates string, returns length
+z.string().transform(s => s.length) // Validates string, returns length
 ```
 
 **Incorrect (using transform for validation):**
 
 ```typescript
 // Wrong: transform should convert, not validate
-const schema = z.number().transform((n) => {
-  if (n < 0) throw new Error('Must be positive')  // Don't throw in transform
-  return n
+const schema = z.number().transform(n => {
+    if (n < 0) throw new Error('Must be positive') // Don't throw in transform
+    return n
 })
 ```
 
@@ -43,25 +43,24 @@ const schema = z.number().transform((n) => {
 import { z } from 'zod'
 
 // VALIDATION: Use refine - returns boolean, data unchanged
-const positiveNumber = z.number().refine(
-  (n) => n > 0,
-  { message: 'Must be positive' }
-)
+const positiveNumber = z
+    .number()
+    .refine(n => n > 0, { message: 'Must be positive' })
 
-positiveNumber.parse(5)  // 5
-positiveNumber.parse(-1)  // ZodError: Must be positive
+positiveNumber.parse(5) // 5
+positiveNumber.parse(-1) // ZodError: Must be positive
 
 // CONVERSION: Use transform - returns new value
-const stringLength = z.string().transform((s) => s.length)
+const stringLength = z.string().transform(s => s.length)
 
-type StringLength = z.infer<typeof stringLength>  // number
-stringLength.parse('hello')  // 5
+type StringLength = z.infer<typeof stringLength> // number
+stringLength.parse('hello') // 5
 
 // COERCION: Use coerce - converts input type
 const coercedNumber = z.coerce.number()
 
-coercedNumber.parse('42')  // 42 (from string)
-coercedNumber.parse(42)  // 42 (already number)
+coercedNumber.parse('42') // 42 (from string)
+coercedNumber.parse(42) // 42 (already number)
 ```
 
 **Combining methods correctly:**
@@ -69,36 +68,37 @@ coercedNumber.parse(42)  // 42 (already number)
 ```typescript
 // Input: string -> Coerce to number -> Validate positive -> Transform to dollars
 const priceSchema = z.coerce
-  .number()
-  .refine((n) => n >= 0, 'Price cannot be negative')
-  .transform((cents) => `$${(cents / 100).toFixed(2)}`)
+    .number()
+    .refine(n => n >= 0, 'Price cannot be negative')
+    .transform(cents => `$${(cents / 100).toFixed(2)}`)
 
-priceSchema.parse('1999')  // "$19.99"
-priceSchema.parse('-100')  // ZodError: Price cannot be negative
+priceSchema.parse('1999') // "$19.99"
+priceSchema.parse('-100') // ZodError: Price cannot be negative
 ```
 
 **Order of operations:**
 
 ```typescript
 const schema = z
-  .preprocess(val => val, z.string())  // 1. preprocess (before type check)
-  .transform(s => s.trim())             // 2. transform (after type check)
-  .refine(s => s.length > 0)            // 3. refine (custom validation)
-  .transform(s => s.toUpperCase())      // 4. another transform
+    .preprocess(val => val, z.string()) // 1. preprocess (before type check)
+    .transform(s => s.trim()) // 2. transform (after type check)
+    .refine(s => s.length > 0) // 3. refine (custom validation)
+    .transform(s => s.toUpperCase()) // 4. another transform
 
 // Input flows: preprocess -> type check -> transforms/refines in order
 ```
 
 **Use case comparison:**
 
-| Need | Method | Example |
-|------|--------|---------|
-| Convert string to number | `z.coerce.number()` | Form input |
-| Validate number is positive | `.refine(n => n > 0)` | Business rule |
-| Convert cents to dollars | `.transform(n => n/100)` | Display format |
-| Trim whitespace before check | `z.preprocess` | Input cleanup |
+| Need                         | Method                   | Example        |
+| ---------------------------- | ------------------------ | -------------- |
+| Convert string to number     | `z.coerce.number()`      | Form input     |
+| Validate number is positive  | `.refine(n => n > 0)`    | Business rule  |
+| Convert cents to dollars     | `.transform(n => n/100)` | Display format |
+| Trim whitespace before check | `z.preprocess`           | Input cleanup  |
 
 **When NOT to use this pattern:**
+
 - Simple type coercion: use `z.coerce.*`
 - Simple validation: use built-in methods like `.min()`, `.email()`
 

--- a/.agents/skills/zod/references/refine-vs-superrefine.md
+++ b/.agents/skills/zod/references/refine-vs-superrefine.md
@@ -1,0 +1,152 @@
+---
+title: Choose refine() vs superRefine() Correctly
+impact: MEDIUM
+impactDescription: refine() only reports one error; superRefine() enables multiple issues and custom error codes
+tags: refine, superRefine, validation, custom
+---
+
+## Choose refine() vs superRefine() Correctly
+
+`.refine()` is for simple single-condition validation returning boolean. `.superRefine()` gives you a context object to add multiple issues with custom error codes and paths. Choose based on your error reporting needs.
+
+**Incorrect (using refine for multiple checks):**
+
+```typescript
+import { z } from 'zod'
+
+// refine can only report one error at a time
+const passwordSchema = z.string().refine(
+  (password) => {
+    // Checks all conditions but only reports first failure
+    if (password.length < 8) return false  // Only this error shown
+    if (!/[A-Z]/.test(password)) return false
+    if (!/[0-9]/.test(password)) return false
+    return true
+  },
+  { message: 'Password does not meet requirements' }
+)
+
+passwordSchema.parse('weak')
+// Only shows: "Password does not meet requirements"
+// User doesn't know WHICH requirements failed
+```
+
+**Correct (using superRefine for multiple issues):**
+
+```typescript
+import { z } from 'zod'
+
+const passwordSchema = z.string().superRefine((password, ctx) => {
+  if (password.length < 8) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: 'Password must be at least 8 characters',
+    })
+  }
+
+  if (!/[A-Z]/.test(password)) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: 'Password must contain an uppercase letter',
+    })
+  }
+
+  if (!/[0-9]/.test(password)) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: 'Password must contain a number',
+    })
+  }
+
+  if (!/[!@#$%^&*]/.test(password)) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: 'Password must contain a special character',
+    })
+  }
+})
+
+passwordSchema.safeParse('weak')
+// Shows ALL failures:
+// - "Password must be at least 8 characters"
+// - "Password must contain an uppercase letter"
+// - "Password must contain a number"
+// - "Password must contain a special character"
+```
+
+**When to use refine():**
+
+```typescript
+// Simple boolean condition with one error message
+const adultSchema = z.number().refine(
+  (age) => age >= 18,
+  { message: 'Must be 18 or older' }
+)
+
+// Cross-field validation with single outcome
+const formSchema = z.object({
+  password: z.string(),
+  confirmPassword: z.string(),
+}).refine(
+  (data) => data.password === data.confirmPassword,
+  { message: 'Passwords must match', path: ['confirmPassword'] }
+)
+
+// Async validation
+const emailSchema = z.string().email().refine(
+  async (email) => {
+    const exists = await checkEmailExists(email)
+    return !exists
+  },
+  { message: 'Email already registered' }
+)
+```
+
+**When to use superRefine():**
+
+```typescript
+// Multiple independent checks on same value
+// Cross-field validation with multiple possible errors
+// Need custom error codes for i18n or client handling
+// Need to add issues at specific paths
+
+const orderSchema = z.object({
+  items: z.array(z.object({
+    productId: z.string(),
+    quantity: z.number(),
+  })),
+  promoCode: z.string().optional(),
+}).superRefine(async (order, ctx) => {
+  // Check each item's availability
+  for (let i = 0; i < order.items.length; i++) {
+    const item = order.items[i]
+    const available = await checkInventory(item.productId, item.quantity)
+
+    if (!available) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['items', i, 'quantity'],  // Specific path
+        message: `Only ${available} units available`,
+      })
+    }
+  }
+
+  // Validate promo code
+  if (order.promoCode) {
+    const valid = await validatePromoCode(order.promoCode)
+    if (!valid) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['promoCode'],
+        message: 'Invalid or expired promo code',
+      })
+    }
+  }
+})
+```
+
+**When NOT to use this pattern:**
+- Simple single-condition checks (use refine for simplicity)
+- Transform needed instead of validation (use transform)
+
+Reference: [Zod API - refine/superRefine](https://zod.dev/api#refine)

--- a/.agents/skills/zod/references/refine-vs-superrefine.md
+++ b/.agents/skills/zod/references/refine-vs-superrefine.md
@@ -16,14 +16,14 @@ import { z } from 'zod'
 
 // refine can only report one error at a time
 const passwordSchema = z.string().refine(
-  (password) => {
-    // Checks all conditions but only reports first failure
-    if (password.length < 8) return false  // Only this error shown
-    if (!/[A-Z]/.test(password)) return false
-    if (!/[0-9]/.test(password)) return false
-    return true
-  },
-  { message: 'Password does not meet requirements' }
+    password => {
+        // Checks all conditions but only reports first failure
+        if (password.length < 8) return false // Only this error shown
+        if (!/[A-Z]/.test(password)) return false
+        if (!/[0-9]/.test(password)) return false
+        return true
+    },
+    { message: 'Password does not meet requirements' },
 )
 
 passwordSchema.parse('weak')
@@ -37,33 +37,33 @@ passwordSchema.parse('weak')
 import { z } from 'zod'
 
 const passwordSchema = z.string().superRefine((password, ctx) => {
-  if (password.length < 8) {
-    ctx.addIssue({
-      code: z.ZodIssueCode.custom,
-      message: 'Password must be at least 8 characters',
-    })
-  }
+    if (password.length < 8) {
+        ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: 'Password must be at least 8 characters',
+        })
+    }
 
-  if (!/[A-Z]/.test(password)) {
-    ctx.addIssue({
-      code: z.ZodIssueCode.custom,
-      message: 'Password must contain an uppercase letter',
-    })
-  }
+    if (!/[A-Z]/.test(password)) {
+        ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: 'Password must contain an uppercase letter',
+        })
+    }
 
-  if (!/[0-9]/.test(password)) {
-    ctx.addIssue({
-      code: z.ZodIssueCode.custom,
-      message: 'Password must contain a number',
-    })
-  }
+    if (!/[0-9]/.test(password)) {
+        ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: 'Password must contain a number',
+        })
+    }
 
-  if (!/[!@#$%^&*]/.test(password)) {
-    ctx.addIssue({
-      code: z.ZodIssueCode.custom,
-      message: 'Password must contain a special character',
-    })
-  }
+    if (!/[!@#$%^&*]/.test(password)) {
+        ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: 'Password must contain a special character',
+        })
+    }
 })
 
 passwordSchema.safeParse('weak')
@@ -78,28 +78,32 @@ passwordSchema.safeParse('weak')
 
 ```typescript
 // Simple boolean condition with one error message
-const adultSchema = z.number().refine(
-  (age) => age >= 18,
-  { message: 'Must be 18 or older' }
-)
+const adultSchema = z
+    .number()
+    .refine(age => age >= 18, { message: 'Must be 18 or older' })
 
 // Cross-field validation with single outcome
-const formSchema = z.object({
-  password: z.string(),
-  confirmPassword: z.string(),
-}).refine(
-  (data) => data.password === data.confirmPassword,
-  { message: 'Passwords must match', path: ['confirmPassword'] }
-)
+const formSchema = z
+    .object({
+        password: z.string(),
+        confirmPassword: z.string(),
+    })
+    .refine(data => data.password === data.confirmPassword, {
+        message: 'Passwords must match',
+        path: ['confirmPassword'],
+    })
 
 // Async validation
-const emailSchema = z.string().email().refine(
-  async (email) => {
-    const exists = await checkEmailExists(email)
-    return !exists
-  },
-  { message: 'Email already registered' }
-)
+const emailSchema = z
+    .string()
+    .email()
+    .refine(
+        async email => {
+            const exists = await checkEmailExists(email)
+            return !exists
+        },
+        { message: 'Email already registered' },
+    )
 ```
 
 **When to use superRefine():**
@@ -110,42 +114,50 @@ const emailSchema = z.string().email().refine(
 // Need custom error codes for i18n or client handling
 // Need to add issues at specific paths
 
-const orderSchema = z.object({
-  items: z.array(z.object({
-    productId: z.string(),
-    quantity: z.number(),
-  })),
-  promoCode: z.string().optional(),
-}).superRefine(async (order, ctx) => {
-  // Check each item's availability
-  for (let i = 0; i < order.items.length; i++) {
-    const item = order.items[i]
-    const available = await checkInventory(item.productId, item.quantity)
+const orderSchema = z
+    .object({
+        items: z.array(
+            z.object({
+                productId: z.string(),
+                quantity: z.number(),
+            }),
+        ),
+        promoCode: z.string().optional(),
+    })
+    .superRefine(async (order, ctx) => {
+        // Check each item's availability
+        for (let i = 0; i < order.items.length; i++) {
+            const item = order.items[i]
+            const available = await checkInventory(
+                item.productId,
+                item.quantity,
+            )
 
-    if (!available) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        path: ['items', i, 'quantity'],  // Specific path
-        message: `Only ${available} units available`,
-      })
-    }
-  }
+            if (!available) {
+                ctx.addIssue({
+                    code: z.ZodIssueCode.custom,
+                    path: ['items', i, 'quantity'], // Specific path
+                    message: `Only ${available} units available`,
+                })
+            }
+        }
 
-  // Validate promo code
-  if (order.promoCode) {
-    const valid = await validatePromoCode(order.promoCode)
-    if (!valid) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        path: ['promoCode'],
-        message: 'Invalid or expired promo code',
-      })
-    }
-  }
-})
+        // Validate promo code
+        if (order.promoCode) {
+            const valid = await validatePromoCode(order.promoCode)
+            if (!valid) {
+                ctx.addIssue({
+                    code: z.ZodIssueCode.custom,
+                    path: ['promoCode'],
+                    message: 'Invalid or expired promo code',
+                })
+            }
+        }
+    })
 ```
 
 **When NOT to use this pattern:**
+
 - Simple single-condition checks (use refine for simplicity)
 - Transform needed instead of validation (use transform)
 

--- a/.agents/skills/zod/references/schema-avoid-optional-abuse.md
+++ b/.agents/skills/zod/references/schema-avoid-optional-abuse.md
@@ -1,0 +1,93 @@
+---
+title: Avoid Overusing Optional Fields
+impact: CRITICAL
+impactDescription: Excessive optional fields create schemas that accept almost anything; forces null checks throughout codebase
+tags: schema, optional, nullable, required
+---
+
+## Avoid Overusing Optional Fields
+
+Making too many fields optional creates overly permissive schemas that validate almost any input. This pushes validation downstream into business logic, requiring defensive null checks everywhere instead of guaranteeing data shape at the boundary.
+
+**Incorrect (optional abuse):**
+
+```typescript
+import { z } from 'zod'
+
+// Every field optional - almost anything passes
+const userSchema = z.object({
+  id: z.string().optional(),
+  name: z.string().optional(),
+  email: z.string().optional(),
+  role: z.string().optional(),
+})
+
+type User = z.infer<typeof userSchema>
+// { id?: string; name?: string; email?: string; role?: string }
+
+// Empty object passes validation!
+userSchema.parse({})  // ✓ Valid: {}
+
+function greetUser(user: User) {
+  // Forced to add null checks everywhere
+  if (user.name) {
+    console.log(`Hello, ${user.name}`)
+  } else {
+    console.log('Hello, stranger')  // Shouldn't happen if data is clean
+  }
+}
+```
+
+**Correct (explicit required vs optional):**
+
+```typescript
+import { z } from 'zod'
+
+// Required fields are required, optional fields are intentional
+const userSchema = z.object({
+  id: z.string().uuid(),  // Required
+  name: z.string().min(1),  // Required, non-empty
+  email: z.string().email(),  // Required
+  role: z.enum(['admin', 'user', 'guest']),  // Required
+  nickname: z.string().optional(),  // Intentionally optional
+  bio: z.string().nullable(),  // Can be explicitly null
+})
+
+type User = z.infer<typeof userSchema>
+
+// Empty object fails validation
+userSchema.parse({})  // ✗ Throws ZodError
+
+function greetUser(user: User) {
+  // user.name is guaranteed to exist
+  console.log(`Hello, ${user.name}`)
+
+  // Only optional fields need checks
+  if (user.nickname) {
+    console.log(`Also known as: ${user.nickname}`)
+  }
+}
+```
+
+**Use `.partial()` for update schemas:**
+
+```typescript
+// Base schema with required fields
+const userSchema = z.object({
+  id: z.string().uuid(),
+  name: z.string().min(1),
+  email: z.string().email(),
+})
+
+// All fields optional for PATCH updates
+const updateUserSchema = userSchema.partial()
+
+// Only specific fields optional
+const createUserSchema = userSchema.partial({ id: true })
+```
+
+**When NOT to use this pattern:**
+- When modeling partial updates (PATCH endpoints)
+- When fields genuinely may not exist (legacy data, external APIs)
+
+Reference: [Zod API - optional](https://zod.dev/api#optional)

--- a/.agents/skills/zod/references/schema-avoid-optional-abuse.md
+++ b/.agents/skills/zod/references/schema-avoid-optional-abuse.md
@@ -16,25 +16,25 @@ import { z } from 'zod'
 
 // Every field optional - almost anything passes
 const userSchema = z.object({
-  id: z.string().optional(),
-  name: z.string().optional(),
-  email: z.string().optional(),
-  role: z.string().optional(),
+    id: z.string().optional(),
+    name: z.string().optional(),
+    email: z.string().optional(),
+    role: z.string().optional(),
 })
 
 type User = z.infer<typeof userSchema>
 // { id?: string; name?: string; email?: string; role?: string }
 
 // Empty object passes validation!
-userSchema.parse({})  // ✓ Valid: {}
+userSchema.parse({}) // ✓ Valid: {}
 
 function greetUser(user: User) {
-  // Forced to add null checks everywhere
-  if (user.name) {
-    console.log(`Hello, ${user.name}`)
-  } else {
-    console.log('Hello, stranger')  // Shouldn't happen if data is clean
-  }
+    // Forced to add null checks everywhere
+    if (user.name) {
+        console.log(`Hello, ${user.name}`)
+    } else {
+        console.log('Hello, stranger') // Shouldn't happen if data is clean
+    }
 }
 ```
 
@@ -45,27 +45,27 @@ import { z } from 'zod'
 
 // Required fields are required, optional fields are intentional
 const userSchema = z.object({
-  id: z.string().uuid(),  // Required
-  name: z.string().min(1),  // Required, non-empty
-  email: z.string().email(),  // Required
-  role: z.enum(['admin', 'user', 'guest']),  // Required
-  nickname: z.string().optional(),  // Intentionally optional
-  bio: z.string().nullable(),  // Can be explicitly null
+    id: z.string().uuid(), // Required
+    name: z.string().min(1), // Required, non-empty
+    email: z.string().email(), // Required
+    role: z.enum(['admin', 'user', 'guest']), // Required
+    nickname: z.string().optional(), // Intentionally optional
+    bio: z.string().nullable(), // Can be explicitly null
 })
 
 type User = z.infer<typeof userSchema>
 
 // Empty object fails validation
-userSchema.parse({})  // ✗ Throws ZodError
+userSchema.parse({}) // ✗ Throws ZodError
 
 function greetUser(user: User) {
-  // user.name is guaranteed to exist
-  console.log(`Hello, ${user.name}`)
+    // user.name is guaranteed to exist
+    console.log(`Hello, ${user.name}`)
 
-  // Only optional fields need checks
-  if (user.nickname) {
-    console.log(`Also known as: ${user.nickname}`)
-  }
+    // Only optional fields need checks
+    if (user.nickname) {
+        console.log(`Also known as: ${user.nickname}`)
+    }
 }
 ```
 
@@ -74,9 +74,9 @@ function greetUser(user: User) {
 ```typescript
 // Base schema with required fields
 const userSchema = z.object({
-  id: z.string().uuid(),
-  name: z.string().min(1),
-  email: z.string().email(),
+    id: z.string().uuid(),
+    name: z.string().min(1),
+    email: z.string().email(),
 })
 
 // All fields optional for PATCH updates
@@ -87,6 +87,7 @@ const createUserSchema = userSchema.partial({ id: true })
 ```
 
 **When NOT to use this pattern:**
+
 - When modeling partial updates (PATCH endpoints)
 - When fields genuinely may not exist (legacy data, external APIs)
 

--- a/.agents/skills/zod/references/schema-coercion-for-form-data.md
+++ b/.agents/skills/zod/references/schema-coercion-for-form-data.md
@@ -1,0 +1,88 @@
+---
+title: Use Coercion for Form and Query Data
+impact: CRITICAL
+impactDescription: Form data and query params are always strings; without coercion, z.number() rejects "42" and z.boolean() rejects "true"
+tags: schema, coerce, forms, query-params
+---
+
+## Use Coercion for Form and Query Data
+
+HTML forms and URL query parameters always transmit data as strings. Using `z.number()` on form data will fail because `"42"` is not a number. Use `z.coerce.number()` to automatically convert strings to the correct type.
+
+**Incorrect (no coercion for form data):**
+
+```typescript
+import { z } from 'zod'
+
+const searchSchema = z.object({
+  query: z.string(),
+  page: z.number(),  // Expects actual number
+  limit: z.number(),
+  showDeleted: z.boolean(),  // Expects actual boolean
+})
+
+// Form data / query params are strings
+const formData = new URLSearchParams('query=test&page=1&limit=10&showDeleted=true')
+const params = Object.fromEntries(formData)
+// { query: 'test', page: '1', limit: '10', showDeleted: 'true' }
+
+searchSchema.parse(params)
+// ZodError: Expected number, received string at "page"
+// ZodError: Expected number, received string at "limit"
+// ZodError: Expected boolean, received string at "showDeleted"
+```
+
+**Correct (using coercion):**
+
+```typescript
+import { z } from 'zod'
+
+const searchSchema = z.object({
+  query: z.string(),
+  page: z.coerce.number().int().positive().default(1),
+  limit: z.coerce.number().int().min(1).max(100).default(10),
+  showDeleted: z.coerce.boolean().default(false),
+})
+
+// Form data / query params are strings
+const formData = new URLSearchParams('query=test&page=1&limit=10&showDeleted=true')
+const params = Object.fromEntries(formData)
+
+const result = searchSchema.parse(params)
+// { query: 'test', page: 1, limit: 10, showDeleted: true }
+// Types are correct: number, number, boolean
+```
+
+**Available coercion types:**
+
+```typescript
+z.coerce.string()  // Converts anything to string via String(value)
+z.coerce.number()  // Converts via Number(value), NaN fails validation
+z.coerce.boolean()  // Truthy/falsy conversion
+z.coerce.bigint()  // Converts via BigInt(value)
+z.coerce.date()  // Converts via new Date(value)
+```
+
+**Coercion edge cases:**
+
+```typescript
+// z.coerce.number() behavior
+z.coerce.number().parse("42")  // 42
+z.coerce.number().parse("")  // 0 (empty string becomes 0!)
+z.coerce.number().parse("abc")  // ZodError (NaN fails)
+
+// z.coerce.boolean() behavior
+z.coerce.boolean().parse("true")  // true
+z.coerce.boolean().parse("false")  // true! (non-empty string is truthy)
+z.coerce.boolean().parse("")  // false
+z.coerce.boolean().parse("0")  // true! (non-empty string)
+
+// For strict boolean parsing from strings:
+const strictBooleanSchema = z.enum(['true', 'false']).transform(v => v === 'true')
+```
+
+**When NOT to use this pattern:**
+- When receiving JSON payloads (already typed correctly)
+- When you want strict type checking without conversion
+
+Reference: [Zod API - Coercion](https://zod.dev/api#coercion)

--- a/.agents/skills/zod/references/schema-coercion-for-form-data.md
+++ b/.agents/skills/zod/references/schema-coercion-for-form-data.md
@@ -15,14 +15,16 @@ HTML forms and URL query parameters always transmit data as strings. Using `z.nu
 import { z } from 'zod'
 
 const searchSchema = z.object({
-  query: z.string(),
-  page: z.number(),  // Expects actual number
-  limit: z.number(),
-  showDeleted: z.boolean(),  // Expects actual boolean
+    query: z.string(),
+    page: z.number(), // Expects actual number
+    limit: z.number(),
+    showDeleted: z.boolean(), // Expects actual boolean
 })
 
 // Form data / query params are strings
-const formData = new URLSearchParams('query=test&page=1&limit=10&showDeleted=true')
+const formData = new URLSearchParams(
+    'query=test&page=1&limit=10&showDeleted=true',
+)
 const params = Object.fromEntries(formData)
 // { query: 'test', page: '1', limit: '10', showDeleted: 'true' }
 
@@ -38,14 +40,16 @@ searchSchema.parse(params)
 import { z } from 'zod'
 
 const searchSchema = z.object({
-  query: z.string(),
-  page: z.coerce.number().int().positive().default(1),
-  limit: z.coerce.number().int().min(1).max(100).default(10),
-  showDeleted: z.coerce.boolean().default(false),
+    query: z.string(),
+    page: z.coerce.number().int().positive().default(1),
+    limit: z.coerce.number().int().min(1).max(100).default(10),
+    showDeleted: z.coerce.boolean().default(false),
 })
 
 // Form data / query params are strings
-const formData = new URLSearchParams('query=test&page=1&limit=10&showDeleted=true')
+const formData = new URLSearchParams(
+    'query=test&page=1&limit=10&showDeleted=true',
+)
 const params = Object.fromEntries(formData)
 
 const result = searchSchema.parse(params)
@@ -56,32 +60,35 @@ const result = searchSchema.parse(params)
 **Available coercion types:**
 
 ```typescript
-z.coerce.string()  // Converts anything to string via String(value)
-z.coerce.number()  // Converts via Number(value), NaN fails validation
-z.coerce.boolean()  // Truthy/falsy conversion
-z.coerce.bigint()  // Converts via BigInt(value)
-z.coerce.date()  // Converts via new Date(value)
+z.coerce.string() // Converts anything to string via String(value)
+z.coerce.number() // Converts via Number(value), NaN fails validation
+z.coerce.boolean() // Truthy/falsy conversion
+z.coerce.bigint() // Converts via BigInt(value)
+z.coerce.date() // Converts via new Date(value)
 ```
 
 **Coercion edge cases:**
 
 ```typescript
 // z.coerce.number() behavior
-z.coerce.number().parse("42")  // 42
-z.coerce.number().parse("")  // 0 (empty string becomes 0!)
-z.coerce.number().parse("abc")  // ZodError (NaN fails)
+z.coerce.number().parse('42') // 42
+z.coerce.number().parse('') // 0 (empty string becomes 0!)
+z.coerce.number().parse('abc') // ZodError (NaN fails)
 
 // z.coerce.boolean() behavior
-z.coerce.boolean().parse("true")  // true
-z.coerce.boolean().parse("false")  // true! (non-empty string is truthy)
-z.coerce.boolean().parse("")  // false
-z.coerce.boolean().parse("0")  // true! (non-empty string)
+z.coerce.boolean().parse('true') // true
+z.coerce.boolean().parse('false') // true! (non-empty string is truthy)
+z.coerce.boolean().parse('') // false
+z.coerce.boolean().parse('0') // true! (non-empty string)
 
 // For strict boolean parsing from strings:
-const strictBooleanSchema = z.enum(['true', 'false']).transform(v => v === 'true')
+const strictBooleanSchema = z
+    .enum(['true', 'false'])
+    .transform(v => v === 'true')
 ```
 
 **When NOT to use this pattern:**
+
 - When receiving JSON payloads (already typed correctly)
 - When you want strict type checking without conversion
 

--- a/.agents/skills/zod/references/schema-string-validations.md
+++ b/.agents/skills/zod/references/schema-string-validations.md
@@ -1,0 +1,90 @@
+---
+title: Apply String Validations at Schema Definition
+impact: CRITICAL
+impactDescription: Unvalidated strings allow SQL injection, XSS, and malformed data; validating at schema level catches issues at the boundary
+tags: schema, string, validation, security
+---
+
+## Apply String Validations at Schema Definition
+
+Plain `z.string()` accepts any string including empty strings, extremely long strings, and malicious content. Apply constraints like `min()`, `max()`, `email()`, `url()`, or `regex()` at schema definition to reject invalid data at the boundary.
+
+**Incorrect (no string validations):**
+
+```typescript
+import { z } from 'zod'
+
+const commentSchema = z.object({
+  author: z.string(),  // Empty string passes
+  email: z.string(),  // "not-an-email" passes
+  content: z.string(),  // 10MB string passes, script tags pass
+  website: z.string().optional(),  // "javascript:alert(1)" passes
+})
+
+// All of these pass validation
+commentSchema.parse({
+  author: '',  // Empty - who wrote this?
+  email: 'invalid',  // Not a real email
+  content: '<script>alert("XSS")</script>'.repeat(100000),  // XSS + huge
+  website: 'javascript:void(0)',  // Dangerous URL
+})
+```
+
+**Correct (string validations applied):**
+
+```typescript
+import { z } from 'zod'
+
+const commentSchema = z.object({
+  author: z.string()
+    .min(1, 'Author is required')
+    .max(100, 'Author name too long'),
+
+  email: z.string()
+    .email('Invalid email address'),
+
+  content: z.string()
+    .min(1, 'Comment cannot be empty')
+    .max(5000, 'Comment too long'),
+
+  website: z.string()
+    .url('Invalid URL')
+    .refine(
+      url => url.startsWith('http://') || url.startsWith('https://'),
+      'Only http/https URLs allowed'
+    )
+    .optional(),
+})
+
+// Invalid data is rejected
+commentSchema.parse({
+  author: '',
+  email: 'invalid',
+  content: '',
+})
+// ZodError with all violations listed
+```
+
+**Common string validations:**
+
+```typescript
+z.string().min(1)  // Non-empty (most common need)
+z.string().max(255)  // Database varchar limit
+z.string().length(36)  // Exact length (UUIDs)
+z.string().email()  // Email format
+z.string().url()  // URL format
+z.string().uuid()  // UUID format
+z.string().cuid()  // CUID format
+z.string().regex(/^[a-z0-9-]+$/)  // Custom pattern (slugs)
+z.string().startsWith('https://')  // Prefix check
+z.string().endsWith('.pdf')  // Suffix check
+z.string().includes('@')  // Contains check
+z.string().trim()  // Strips whitespace (transform)
+z.string().toLowerCase()  // Normalizes case (transform)
+```
+
+**When NOT to use this pattern:**
+- When accepting arbitrary user content for display only (sanitize on output instead)
+- When building a passthrough/proxy that shouldn't validate content
+
+Reference: [Zod API - Strings](https://zod.dev/api#strings)

--- a/.agents/skills/zod/references/schema-string-validations.md
+++ b/.agents/skills/zod/references/schema-string-validations.md
@@ -15,18 +15,18 @@ Plain `z.string()` accepts any string including empty strings, extremely long st
 import { z } from 'zod'
 
 const commentSchema = z.object({
-  author: z.string(),  // Empty string passes
-  email: z.string(),  // "not-an-email" passes
-  content: z.string(),  // 10MB string passes, script tags pass
-  website: z.string().optional(),  // "javascript:alert(1)" passes
+    author: z.string(), // Empty string passes
+    email: z.string(), // "not-an-email" passes
+    content: z.string(), // 10MB string passes, script tags pass
+    website: z.string().optional(), // "javascript:alert(1)" passes
 })
 
 // All of these pass validation
 commentSchema.parse({
-  author: '',  // Empty - who wrote this?
-  email: 'invalid',  // Not a real email
-  content: '<script>alert("XSS")</script>'.repeat(100000),  // XSS + huge
-  website: 'javascript:void(0)',  // Dangerous URL
+    author: '', // Empty - who wrote this?
+    email: 'invalid', // Not a real email
+    content: '<script>alert("XSS")</script>'.repeat(100000), // XSS + huge
+    website: 'javascript:void(0)', // Dangerous URL
 })
 ```
 
@@ -36,31 +36,33 @@ commentSchema.parse({
 import { z } from 'zod'
 
 const commentSchema = z.object({
-  author: z.string()
-    .min(1, 'Author is required')
-    .max(100, 'Author name too long'),
+    author: z
+        .string()
+        .min(1, 'Author is required')
+        .max(100, 'Author name too long'),
 
-  email: z.string()
-    .email('Invalid email address'),
+    email: z.string().email('Invalid email address'),
 
-  content: z.string()
-    .min(1, 'Comment cannot be empty')
-    .max(5000, 'Comment too long'),
+    content: z
+        .string()
+        .min(1, 'Comment cannot be empty')
+        .max(5000, 'Comment too long'),
 
-  website: z.string()
-    .url('Invalid URL')
-    .refine(
-      url => url.startsWith('http://') || url.startsWith('https://'),
-      'Only http/https URLs allowed'
-    )
-    .optional(),
+    website: z
+        .string()
+        .url('Invalid URL')
+        .refine(
+            url => url.startsWith('http://') || url.startsWith('https://'),
+            'Only http/https URLs allowed',
+        )
+        .optional(),
 })
 
 // Invalid data is rejected
 commentSchema.parse({
-  author: '',
-  email: 'invalid',
-  content: '',
+    author: '',
+    email: 'invalid',
+    content: '',
 })
 // ZodError with all violations listed
 ```
@@ -68,22 +70,23 @@ commentSchema.parse({
 **Common string validations:**
 
 ```typescript
-z.string().min(1)  // Non-empty (most common need)
-z.string().max(255)  // Database varchar limit
-z.string().length(36)  // Exact length (UUIDs)
-z.string().email()  // Email format
-z.string().url()  // URL format
-z.string().uuid()  // UUID format
-z.string().cuid()  // CUID format
-z.string().regex(/^[a-z0-9-]+$/)  // Custom pattern (slugs)
-z.string().startsWith('https://')  // Prefix check
-z.string().endsWith('.pdf')  // Suffix check
-z.string().includes('@')  // Contains check
-z.string().trim()  // Strips whitespace (transform)
-z.string().toLowerCase()  // Normalizes case (transform)
+z.string().min(1) // Non-empty (most common need)
+z.string().max(255) // Database varchar limit
+z.string().length(36) // Exact length (UUIDs)
+z.string().email() // Email format
+z.string().url() // URL format
+z.string().uuid() // UUID format
+z.string().cuid() // CUID format
+z.string().regex(/^[a-z0-9-]+$/) // Custom pattern (slugs)
+z.string().startsWith('https://') // Prefix check
+z.string().endsWith('.pdf') // Suffix check
+z.string().includes('@') // Contains check
+z.string().trim() // Strips whitespace (transform)
+z.string().toLowerCase() // Normalizes case (transform)
 ```
 
 **When NOT to use this pattern:**
+
 - When accepting arbitrary user content for display only (sanitize on output instead)
 - When building a passthrough/proxy that shouldn't validate content
 

--- a/.agents/skills/zod/references/schema-use-enums.md
+++ b/.agents/skills/zod/references/schema-use-enums.md
@@ -1,0 +1,107 @@
+---
+title: Use Enums for Fixed String Values
+impact: CRITICAL
+impactDescription: Plain strings accept any value including typos; enums restrict to valid values and enable autocomplete
+tags: schema, enum, literal, union
+---
+
+## Use Enums for Fixed String Values
+
+When a field should only accept specific values (status, role, type), use `z.enum()` or `z.literal()` instead of `z.string()`. Plain strings accept any value including typos, while enums provide validation, type safety, and IDE autocomplete.
+
+**Incorrect (plain string for fixed values):**
+
+```typescript
+import { z } from 'zod'
+
+const orderSchema = z.object({
+  id: z.string(),
+  status: z.string(),  // Accepts any string
+  priority: z.string(),  // No constraints
+})
+
+type Order = z.infer<typeof orderSchema>
+// { id: string; status: string; priority: string }
+
+// Typos and invalid values pass validation
+orderSchema.parse({
+  id: '123',
+  status: 'pendng',  // Typo passes
+  priority: 'super-urgent',  // Invalid value passes
+})
+
+function processOrder(order: Order) {
+  if (order.status === 'pending') {  // Might never match due to typos
+    // ...
+  }
+}
+```
+
+**Correct (using z.enum):**
+
+```typescript
+import { z } from 'zod'
+
+const OrderStatus = z.enum(['pending', 'processing', 'shipped', 'delivered'])
+const Priority = z.enum(['low', 'medium', 'high'])
+
+const orderSchema = z.object({
+  id: z.string(),
+  status: OrderStatus,
+  priority: Priority,
+})
+
+type Order = z.infer<typeof orderSchema>
+// { id: string; status: 'pending' | 'processing' | 'shipped' | 'delivered'; priority: 'low' | 'medium' | 'high' }
+
+// Typos are caught at validation
+orderSchema.parse({
+  id: '123',
+  status: 'pendng',  // ZodError: Invalid enum value
+  priority: 'super-urgent',  // ZodError: Invalid enum value
+})
+
+// Extract enum values for reuse
+OrderStatus.options  // ['pending', 'processing', 'shipped', 'delivered']
+type OrderStatusType = z.infer<typeof OrderStatus>  // 'pending' | 'processing' | ...
+```
+
+**For native TypeScript enums:**
+
+```typescript
+enum Role {
+  Admin = 'admin',
+  User = 'user',
+  Guest = 'guest',
+}
+
+// Use z.nativeEnum for TS enums
+const userSchema = z.object({
+  role: z.nativeEnum(Role),
+})
+```
+
+**For single literal values (discriminated unions):**
+
+```typescript
+const successResponse = z.object({
+  status: z.literal('success'),
+  data: z.unknown(),
+})
+
+const errorResponse = z.object({
+  status: z.literal('error'),
+  message: z.string(),
+})
+
+const response = z.discriminatedUnion('status', [
+  successResponse,
+  errorResponse,
+])
+```
+
+**When NOT to use this pattern:**
+- When the set of valid values is dynamic or user-defined
+- When values come from a database that may have more options
+
+Reference: [Zod API - Enums](https://zod.dev/api#enums)

--- a/.agents/skills/zod/references/schema-use-enums.md
+++ b/.agents/skills/zod/references/schema-use-enums.md
@@ -15,9 +15,9 @@ When a field should only accept specific values (status, role, type), use `z.enu
 import { z } from 'zod'
 
 const orderSchema = z.object({
-  id: z.string(),
-  status: z.string(),  // Accepts any string
-  priority: z.string(),  // No constraints
+    id: z.string(),
+    status: z.string(), // Accepts any string
+    priority: z.string(), // No constraints
 })
 
 type Order = z.infer<typeof orderSchema>
@@ -25,15 +25,16 @@ type Order = z.infer<typeof orderSchema>
 
 // Typos and invalid values pass validation
 orderSchema.parse({
-  id: '123',
-  status: 'pendng',  // Typo passes
-  priority: 'super-urgent',  // Invalid value passes
+    id: '123',
+    status: 'pendng', // Typo passes
+    priority: 'super-urgent', // Invalid value passes
 })
 
 function processOrder(order: Order) {
-  if (order.status === 'pending') {  // Might never match due to typos
-    // ...
-  }
+    if (order.status === 'pending') {
+        // Might never match due to typos
+        // ...
+    }
 }
 ```
 
@@ -46,9 +47,9 @@ const OrderStatus = z.enum(['pending', 'processing', 'shipped', 'delivered'])
 const Priority = z.enum(['low', 'medium', 'high'])
 
 const orderSchema = z.object({
-  id: z.string(),
-  status: OrderStatus,
-  priority: Priority,
+    id: z.string(),
+    status: OrderStatus,
+    priority: Priority,
 })
 
 type Order = z.infer<typeof orderSchema>
@@ -56,28 +57,28 @@ type Order = z.infer<typeof orderSchema>
 
 // Typos are caught at validation
 orderSchema.parse({
-  id: '123',
-  status: 'pendng',  // ZodError: Invalid enum value
-  priority: 'super-urgent',  // ZodError: Invalid enum value
+    id: '123',
+    status: 'pendng', // ZodError: Invalid enum value
+    priority: 'super-urgent', // ZodError: Invalid enum value
 })
 
 // Extract enum values for reuse
-OrderStatus.options  // ['pending', 'processing', 'shipped', 'delivered']
-type OrderStatusType = z.infer<typeof OrderStatus>  // 'pending' | 'processing' | ...
+OrderStatus.options // ['pending', 'processing', 'shipped', 'delivered']
+type OrderStatusType = z.infer<typeof OrderStatus> // 'pending' | 'processing' | ...
 ```
 
 **For native TypeScript enums:**
 
 ```typescript
 enum Role {
-  Admin = 'admin',
-  User = 'user',
-  Guest = 'guest',
+    Admin = 'admin',
+    User = 'user',
+    Guest = 'guest',
 }
 
 // Use z.nativeEnum for TS enums
 const userSchema = z.object({
-  role: z.nativeEnum(Role),
+    role: z.nativeEnum(Role),
 })
 ```
 
@@ -85,22 +86,23 @@ const userSchema = z.object({
 
 ```typescript
 const successResponse = z.object({
-  status: z.literal('success'),
-  data: z.unknown(),
+    status: z.literal('success'),
+    data: z.unknown(),
 })
 
 const errorResponse = z.object({
-  status: z.literal('error'),
-  message: z.string(),
+    status: z.literal('error'),
+    message: z.string(),
 })
 
 const response = z.discriminatedUnion('status', [
-  successResponse,
-  errorResponse,
+    successResponse,
+    errorResponse,
 ])
 ```
 
 **When NOT to use this pattern:**
+
 - When the set of valid values is dynamic or user-defined
 - When values come from a database that may have more options
 

--- a/.agents/skills/zod/references/schema-use-primitives-correctly.md
+++ b/.agents/skills/zod/references/schema-use-primitives-correctly.md
@@ -1,0 +1,61 @@
+---
+title: Use Primitive Schemas Correctly
+impact: CRITICAL
+impactDescription: Incorrect primitive selection causes validation to pass on wrong types; using z.any() or z.unknown() loses all type safety
+tags: schema, primitives, types, basics
+---
+
+## Use Primitive Schemas Correctly
+
+Zod provides specific schemas for each primitive type. Using the wrong schema (e.g., `z.string()` when you need `z.number()`) or falling back to `z.any()` defeats the purpose of validation entirely, allowing corrupt data through.
+
+**Incorrect (wrong primitive or any):**
+
+```typescript
+import { z } from 'zod'
+
+// Using any loses all type safety
+const userSchema = z.object({
+  id: z.any(),  // Accepts anything - no validation
+  age: z.string(),  // Wrong type - age should be number
+  active: z.any(),  // Should be boolean
+})
+
+// This passes validation but data is wrong
+userSchema.parse({ id: null, age: "twenty", active: "yes" })
+// Result: { id: null, age: "twenty", active: "yes" }
+```
+
+**Correct (specific primitives):**
+
+```typescript
+import { z } from 'zod'
+
+const userSchema = z.object({
+  id: z.string().uuid(),  // Specific format validation
+  age: z.number().int().positive(),  // Correct type with constraints
+  active: z.boolean(),  // Exact boolean type
+})
+
+// Now invalid data is rejected
+userSchema.parse({ id: null, age: "twenty", active: "yes" })
+// Throws ZodError with specific field errors
+```
+
+**Available primitive schemas:**
+- `z.string()` - strings with optional regex, min, max, email, url, uuid
+- `z.number()` - numbers with optional int, positive, negative, min, max
+- `z.bigint()` - BigInt values
+- `z.boolean()` - true/false only
+- `z.date()` - Date objects
+- `z.symbol()` - Symbol type
+- `z.undefined()` - undefined only
+- `z.null()` - null only
+- `z.void()` - undefined (for function returns)
+- `z.never()` - no valid value
+
+**When NOT to use this pattern:**
+- When you genuinely need to accept any value (rare - consider `z.unknown()` instead)
+- When migrating legacy code incrementally (use `z.any()` temporarily, then fix)
+
+Reference: [Zod Primitives](https://zod.dev/api#primitives)

--- a/.agents/skills/zod/references/schema-use-primitives-correctly.md
+++ b/.agents/skills/zod/references/schema-use-primitives-correctly.md
@@ -16,13 +16,13 @@ import { z } from 'zod'
 
 // Using any loses all type safety
 const userSchema = z.object({
-  id: z.any(),  // Accepts anything - no validation
-  age: z.string(),  // Wrong type - age should be number
-  active: z.any(),  // Should be boolean
+    id: z.any(), // Accepts anything - no validation
+    age: z.string(), // Wrong type - age should be number
+    active: z.any(), // Should be boolean
 })
 
 // This passes validation but data is wrong
-userSchema.parse({ id: null, age: "twenty", active: "yes" })
+userSchema.parse({ id: null, age: 'twenty', active: 'yes' })
 // Result: { id: null, age: "twenty", active: "yes" }
 ```
 
@@ -32,17 +32,18 @@ userSchema.parse({ id: null, age: "twenty", active: "yes" })
 import { z } from 'zod'
 
 const userSchema = z.object({
-  id: z.string().uuid(),  // Specific format validation
-  age: z.number().int().positive(),  // Correct type with constraints
-  active: z.boolean(),  // Exact boolean type
+    id: z.string().uuid(), // Specific format validation
+    age: z.number().int().positive(), // Correct type with constraints
+    active: z.boolean(), // Exact boolean type
 })
 
 // Now invalid data is rejected
-userSchema.parse({ id: null, age: "twenty", active: "yes" })
+userSchema.parse({ id: null, age: 'twenty', active: 'yes' })
 // Throws ZodError with specific field errors
 ```
 
 **Available primitive schemas:**
+
 - `z.string()` - strings with optional regex, min, max, email, url, uuid
 - `z.number()` - numbers with optional int, positive, negative, min, max
 - `z.bigint()` - BigInt values
@@ -55,6 +56,7 @@ userSchema.parse({ id: null, age: "twenty", active: "yes" })
 - `z.never()` - no valid value
 
 **When NOT to use this pattern:**
+
 - When you genuinely need to accept any value (rare - consider `z.unknown()` instead)
 - When migrating legacy code incrementally (use `z.any()` temporarily, then fix)
 

--- a/.agents/skills/zod/references/schema-use-unknown-not-any.md
+++ b/.agents/skills/zod/references/schema-use-unknown-not-any.md
@@ -1,0 +1,88 @@
+---
+title: Use z.unknown() Instead of z.any()
+impact: CRITICAL
+impactDescription: z.any() bypasses TypeScript's type system entirely; z.unknown() forces type narrowing before use
+tags: schema, unknown, any, type-safety
+---
+
+## Use z.unknown() Instead of z.any()
+
+`z.any()` infers to `any` type, disabling TypeScript's type checking for that value. `z.unknown()` infers to `unknown`, which forces you to narrow the type before using it. This preserves type safety while still allowing any input.
+
+**Incorrect (using z.any):**
+
+```typescript
+import { z } from 'zod'
+
+const eventSchema = z.object({
+  type: z.string(),
+  payload: z.any(),  // Infers to 'any'
+})
+
+type Event = z.infer<typeof eventSchema>
+// { type: string; payload: any }
+
+function handleEvent(event: Event) {
+  // No type error - TypeScript allows anything
+  console.log(event.payload.foo.bar.baz)  // Runtime crash if structure is wrong
+}
+```
+
+**Correct (using z.unknown):**
+
+```typescript
+import { z } from 'zod'
+
+const eventSchema = z.object({
+  type: z.string(),
+  payload: z.unknown(),  // Infers to 'unknown'
+})
+
+type Event = z.infer<typeof eventSchema>
+// { type: string; payload: unknown }
+
+function handleEvent(event: Event) {
+  // TypeScript error: Object is of type 'unknown'
+  console.log(event.payload.foo)  // Won't compile
+
+  // Must narrow type first
+  if (typeof event.payload === 'object' && event.payload !== null) {
+    // Now TypeScript knows it's an object
+  }
+}
+```
+
+**Better approach with discriminated unions:**
+
+```typescript
+import { z } from 'zod'
+
+const userCreatedSchema = z.object({
+  type: z.literal('user.created'),
+  payload: z.object({
+    userId: z.string(),
+    email: z.string().email(),
+  }),
+})
+
+const orderPlacedSchema = z.object({
+  type: z.literal('order.placed'),
+  payload: z.object({
+    orderId: z.string(),
+    amount: z.number(),
+  }),
+})
+
+const eventSchema = z.discriminatedUnion('type', [
+  userCreatedSchema,
+  orderPlacedSchema,
+])
+
+// Full type safety for each event type
+```
+
+**When NOT to use this pattern:**
+- When you're consuming a third-party API where you truly don't know the shape
+- When prototyping and will add proper types later
+
+Reference: [Zod API - unknown](https://zod.dev/api#unknown)

--- a/.agents/skills/zod/references/schema-use-unknown-not-any.md
+++ b/.agents/skills/zod/references/schema-use-unknown-not-any.md
@@ -15,16 +15,16 @@ tags: schema, unknown, any, type-safety
 import { z } from 'zod'
 
 const eventSchema = z.object({
-  type: z.string(),
-  payload: z.any(),  // Infers to 'any'
+    type: z.string(),
+    payload: z.any(), // Infers to 'any'
 })
 
 type Event = z.infer<typeof eventSchema>
 // { type: string; payload: any }
 
 function handleEvent(event: Event) {
-  // No type error - TypeScript allows anything
-  console.log(event.payload.foo.bar.baz)  // Runtime crash if structure is wrong
+    // No type error - TypeScript allows anything
+    console.log(event.payload.foo.bar.baz) // Runtime crash if structure is wrong
 }
 ```
 
@@ -34,21 +34,21 @@ function handleEvent(event: Event) {
 import { z } from 'zod'
 
 const eventSchema = z.object({
-  type: z.string(),
-  payload: z.unknown(),  // Infers to 'unknown'
+    type: z.string(),
+    payload: z.unknown(), // Infers to 'unknown'
 })
 
 type Event = z.infer<typeof eventSchema>
 // { type: string; payload: unknown }
 
 function handleEvent(event: Event) {
-  // TypeScript error: Object is of type 'unknown'
-  console.log(event.payload.foo)  // Won't compile
+    // TypeScript error: Object is of type 'unknown'
+    console.log(event.payload.foo) // Won't compile
 
-  // Must narrow type first
-  if (typeof event.payload === 'object' && event.payload !== null) {
-    // Now TypeScript knows it's an object
-  }
+    // Must narrow type first
+    if (typeof event.payload === 'object' && event.payload !== null) {
+        // Now TypeScript knows it's an object
+    }
 }
 ```
 
@@ -58,30 +58,31 @@ function handleEvent(event: Event) {
 import { z } from 'zod'
 
 const userCreatedSchema = z.object({
-  type: z.literal('user.created'),
-  payload: z.object({
-    userId: z.string(),
-    email: z.string().email(),
-  }),
+    type: z.literal('user.created'),
+    payload: z.object({
+        userId: z.string(),
+        email: z.string().email(),
+    }),
 })
 
 const orderPlacedSchema = z.object({
-  type: z.literal('order.placed'),
-  payload: z.object({
-    orderId: z.string(),
-    amount: z.number(),
-  }),
+    type: z.literal('order.placed'),
+    payload: z.object({
+        orderId: z.string(),
+        amount: z.number(),
+    }),
 })
 
 const eventSchema = z.discriminatedUnion('type', [
-  userCreatedSchema,
-  orderPlacedSchema,
+    userCreatedSchema,
+    orderPlacedSchema,
 ])
 
 // Full type safety for each event type
 ```
 
 **When NOT to use this pattern:**
+
 - When you're consuming a third-party API where you truly don't know the shape
 - When prototyping and will add proper types later
 

--- a/.agents/skills/zod/references/type-branded-types.md
+++ b/.agents/skills/zod/references/type-branded-types.md
@@ -1,0 +1,102 @@
+---
+title: Use Branded Types for Domain Safety
+impact: HIGH
+impactDescription: Plain string IDs are interchangeable, allowing userId where orderId is expected; branded types catch these bugs at compile time
+tags: type, brand, domain, nominal
+---
+
+## Use Branded Types for Domain Safety
+
+Plain strings and numbers are interchangeable in TypeScript's structural type system—a `userId` can be passed where an `orderId` is expected. Zod's `.brand()` creates nominal types that prevent mixing up semantically different values.
+
+**Incorrect (plain IDs are interchangeable):**
+
+```typescript
+import { z } from 'zod'
+
+const userIdSchema = z.string().uuid()
+const orderIdSchema = z.string().uuid()
+
+type UserId = z.infer<typeof userIdSchema>  // string
+type OrderId = z.infer<typeof orderIdSchema>  // string - same type!
+
+async function getOrder(orderId: OrderId) {
+  return db.orders.findUnique({ where: { id: orderId } })
+}
+
+const userId: UserId = '550e8400-e29b-41d4-a716-446655440000'
+getOrder(userId)  // No error! TypeScript allows this bug
+// Runtime: queries orders table with user ID, returns nothing or wrong data
+```
+
+**Correct (using branded types):**
+
+```typescript
+import { z } from 'zod'
+
+const userIdSchema = z.string().uuid().brand<'UserId'>()
+const orderIdSchema = z.string().uuid().brand<'OrderId'>()
+
+type UserId = z.infer<typeof userIdSchema>
+// string & { __brand: 'UserId' }
+
+type OrderId = z.infer<typeof orderIdSchema>
+// string & { __brand: 'OrderId' }
+
+async function getOrder(orderId: OrderId) {
+  return db.orders.findUnique({ where: { id: orderId } })
+}
+
+const userId = userIdSchema.parse('550e8400-e29b-41d4-a716-446655440000')
+getOrder(userId)  // TypeScript error: Argument of type 'UserId' is not assignable to parameter of type 'OrderId'
+
+const orderId = orderIdSchema.parse('660e8400-e29b-41d4-a716-446655440001')
+getOrder(orderId)  // Works correctly
+```
+
+**Common branded types:**
+
+```typescript
+// IDs for different entities
+const UserId = z.string().uuid().brand<'UserId'>()
+const ProductId = z.string().uuid().brand<'ProductId'>()
+const OrderId = z.string().uuid().brand<'OrderId'>()
+
+// Email (validated and branded)
+const Email = z.string().email().brand<'Email'>()
+
+// Positive numbers
+const PositiveInt = z.number().int().positive().brand<'PositiveInt'>()
+
+// Money amounts (in cents)
+const Cents = z.number().int().nonnegative().brand<'Cents'>()
+
+// Slugs
+const Slug = z.string().regex(/^[a-z0-9-]+$/).brand<'Slug'>()
+```
+
+**Using with object schemas:**
+
+```typescript
+const User = z.object({
+  id: z.string().uuid().brand<'UserId'>(),
+  email: z.string().email().brand<'Email'>(),
+  referredBy: z.string().uuid().brand<'UserId'>().optional(),
+})
+
+type User = z.infer<typeof User>
+
+function sendReferralBonus(
+  referrerId: z.infer<typeof User>['id'],
+  refereeId: z.infer<typeof User>['id']
+) {
+  // Can't accidentally swap these - both are UserId but distinct values
+}
+```
+
+**When NOT to use this pattern:**
+- Simple applications without ID confusion risk
+- When interoperating with external systems that expect plain strings
+- Performance-critical paths (brand adds tiny overhead)
+
+Reference: [Zod API - brand](https://zod.dev/api#brand)

--- a/.agents/skills/zod/references/type-branded-types.md
+++ b/.agents/skills/zod/references/type-branded-types.md
@@ -17,15 +17,15 @@ import { z } from 'zod'
 const userIdSchema = z.string().uuid()
 const orderIdSchema = z.string().uuid()
 
-type UserId = z.infer<typeof userIdSchema>  // string
-type OrderId = z.infer<typeof orderIdSchema>  // string - same type!
+type UserId = z.infer<typeof userIdSchema> // string
+type OrderId = z.infer<typeof orderIdSchema> // string - same type!
 
 async function getOrder(orderId: OrderId) {
-  return db.orders.findUnique({ where: { id: orderId } })
+    return db.orders.findUnique({ where: { id: orderId } })
 }
 
 const userId: UserId = '550e8400-e29b-41d4-a716-446655440000'
-getOrder(userId)  // No error! TypeScript allows this bug
+getOrder(userId) // No error! TypeScript allows this bug
 // Runtime: queries orders table with user ID, returns nothing or wrong data
 ```
 
@@ -44,14 +44,14 @@ type OrderId = z.infer<typeof orderIdSchema>
 // string & { __brand: 'OrderId' }
 
 async function getOrder(orderId: OrderId) {
-  return db.orders.findUnique({ where: { id: orderId } })
+    return db.orders.findUnique({ where: { id: orderId } })
 }
 
 const userId = userIdSchema.parse('550e8400-e29b-41d4-a716-446655440000')
-getOrder(userId)  // TypeScript error: Argument of type 'UserId' is not assignable to parameter of type 'OrderId'
+getOrder(userId) // TypeScript error: Argument of type 'UserId' is not assignable to parameter of type 'OrderId'
 
 const orderId = orderIdSchema.parse('660e8400-e29b-41d4-a716-446655440001')
-getOrder(orderId)  // Works correctly
+getOrder(orderId) // Works correctly
 ```
 
 **Common branded types:**
@@ -72,29 +72,33 @@ const PositiveInt = z.number().int().positive().brand<'PositiveInt'>()
 const Cents = z.number().int().nonnegative().brand<'Cents'>()
 
 // Slugs
-const Slug = z.string().regex(/^[a-z0-9-]+$/).brand<'Slug'>()
+const Slug = z
+    .string()
+    .regex(/^[a-z0-9-]+$/)
+    .brand<'Slug'>()
 ```
 
 **Using with object schemas:**
 
 ```typescript
 const User = z.object({
-  id: z.string().uuid().brand<'UserId'>(),
-  email: z.string().email().brand<'Email'>(),
-  referredBy: z.string().uuid().brand<'UserId'>().optional(),
+    id: z.string().uuid().brand<'UserId'>(),
+    email: z.string().email().brand<'Email'>(),
+    referredBy: z.string().uuid().brand<'UserId'>().optional(),
 })
 
 type User = z.infer<typeof User>
 
 function sendReferralBonus(
-  referrerId: z.infer<typeof User>['id'],
-  refereeId: z.infer<typeof User>['id']
+    referrerId: z.infer<typeof User>['id'],
+    refereeId: z.infer<typeof User>['id'],
 ) {
-  // Can't accidentally swap these - both are UserId but distinct values
+    // Can't accidentally swap these - both are UserId but distinct values
 }
 ```
 
 **When NOT to use this pattern:**
+
 - Simple applications without ID confusion risk
 - When interoperating with external systems that expect plain strings
 - Performance-critical paths (brand adds tiny overhead)

--- a/.agents/skills/zod/references/type-enable-strict-mode.md
+++ b/.agents/skills/zod/references/type-enable-strict-mode.md
@@ -1,0 +1,130 @@
+---
+title: Enable TypeScript Strict Mode
+impact: HIGH
+impactDescription: Without strict mode, Zod's type inference is unreliable; undefined and null slip through, defeating the purpose of validation
+tags: type, typescript, strict, configuration
+---
+
+## Enable TypeScript Strict Mode
+
+Zod requires TypeScript's strict mode to work correctly. Without it, `undefined` sneaks into types, `null` checks are bypassed, and type inference becomes unreliable. This undermines the type safety that Zod provides.
+
+**Incorrect (strict mode disabled):**
+
+```json
+// tsconfig.json
+{
+  "compilerOptions": {
+    "strict": false
+  }
+}
+```
+
+```typescript
+import { z } from 'zod'
+
+const userSchema = z.object({
+  name: z.string(),
+  email: z.string().email(),
+})
+
+type User = z.infer<typeof userSchema>
+// With strict:false, type might include undefined implicitly
+
+function processUser(user: User) {
+  // No error even if user.name could be undefined
+  console.log(user.name.toUpperCase())  // Potential runtime crash
+}
+
+// TypeScript allows calling with undefined
+processUser(undefined as any)  // No warning
+```
+
+**Correct (strict mode enabled):**
+
+```json
+// tsconfig.json
+{
+  "compilerOptions": {
+    "strict": true
+  }
+}
+```
+
+```typescript
+import { z } from 'zod'
+
+const userSchema = z.object({
+  name: z.string(),
+  email: z.string().email(),
+})
+
+type User = z.infer<typeof userSchema>
+// { name: string; email: string } - no implicit undefined
+
+function processUser(user: User) {
+  // TypeScript knows name is always string
+  console.log(user.name.toUpperCase())  // Safe
+}
+
+// TypeScript catches potential undefined
+processUser(undefined as any)  // Error with strict null checks
+```
+
+**Minimum strict settings for Zod:**
+
+```json
+// tsconfig.json
+{
+  "compilerOptions": {
+    // Full strict mode (recommended)
+    "strict": true,
+
+    // Or at minimum, enable these:
+    "strictNullChecks": true,
+    "noImplicitAny": true
+  }
+}
+```
+
+**Common errors when strict mode is disabled:**
+
+```typescript
+// Without strictNullChecks
+const schema = z.string().optional()
+type MaybeString = z.infer<typeof schema>
+// Should be: string | undefined
+// Without strict: just string (undefined is implicit)
+
+// Without noImplicitAny
+const schema = z.object({ name: z.string() })
+schema.parse(data)  // data could be 'any', bypassing validation
+```
+
+**Migrating to strict mode:**
+
+```typescript
+// If enabling strict breaks existing code, fix issues incrementally
+// Common fixes:
+
+// 1. Add null checks
+if (user.name !== undefined) {
+  console.log(user.name.toUpperCase())
+}
+
+// 2. Add explicit types
+function processData(data: unknown) {  // Was implicit any
+  const validated = schema.parse(data)
+}
+
+// 3. Handle optional fields
+const user: User = {
+  name: 'John',
+  email: 'john@example.com',  // Now required, was optional without strict
+}
+```
+
+**When NOT to use this pattern:**
+- Never - always enable strict mode for Zod projects
+
+Reference: [Zod Requirements](https://zod.dev/#requirements)

--- a/.agents/skills/zod/references/type-enable-strict-mode.md
+++ b/.agents/skills/zod/references/type-enable-strict-mode.md
@@ -14,9 +14,9 @@ Zod requires TypeScript's strict mode to work correctly. Without it, `undefined`
 ```json
 // tsconfig.json
 {
-  "compilerOptions": {
-    "strict": false
-  }
+    "compilerOptions": {
+        "strict": false
+    }
 }
 ```
 
@@ -24,20 +24,20 @@ Zod requires TypeScript's strict mode to work correctly. Without it, `undefined`
 import { z } from 'zod'
 
 const userSchema = z.object({
-  name: z.string(),
-  email: z.string().email(),
+    name: z.string(),
+    email: z.string().email(),
 })
 
 type User = z.infer<typeof userSchema>
 // With strict:false, type might include undefined implicitly
 
 function processUser(user: User) {
-  // No error even if user.name could be undefined
-  console.log(user.name.toUpperCase())  // Potential runtime crash
+    // No error even if user.name could be undefined
+    console.log(user.name.toUpperCase()) // Potential runtime crash
 }
 
 // TypeScript allows calling with undefined
-processUser(undefined as any)  // No warning
+processUser(undefined as any) // No warning
 ```
 
 **Correct (strict mode enabled):**
@@ -45,9 +45,9 @@ processUser(undefined as any)  // No warning
 ```json
 // tsconfig.json
 {
-  "compilerOptions": {
-    "strict": true
-  }
+    "compilerOptions": {
+        "strict": true
+    }
 }
 ```
 
@@ -55,20 +55,20 @@ processUser(undefined as any)  // No warning
 import { z } from 'zod'
 
 const userSchema = z.object({
-  name: z.string(),
-  email: z.string().email(),
+    name: z.string(),
+    email: z.string().email(),
 })
 
 type User = z.infer<typeof userSchema>
 // { name: string; email: string } - no implicit undefined
 
 function processUser(user: User) {
-  // TypeScript knows name is always string
-  console.log(user.name.toUpperCase())  // Safe
+    // TypeScript knows name is always string
+    console.log(user.name.toUpperCase()) // Safe
 }
 
 // TypeScript catches potential undefined
-processUser(undefined as any)  // Error with strict null checks
+processUser(undefined as any) // Error with strict null checks
 ```
 
 **Minimum strict settings for Zod:**
@@ -76,14 +76,14 @@ processUser(undefined as any)  // Error with strict null checks
 ```json
 // tsconfig.json
 {
-  "compilerOptions": {
-    // Full strict mode (recommended)
-    "strict": true,
+    "compilerOptions": {
+        // Full strict mode (recommended)
+        "strict": true,
 
-    // Or at minimum, enable these:
-    "strictNullChecks": true,
-    "noImplicitAny": true
-  }
+        // Or at minimum, enable these:
+        "strictNullChecks": true,
+        "noImplicitAny": true
+    }
 }
 ```
 
@@ -98,7 +98,7 @@ type MaybeString = z.infer<typeof schema>
 
 // Without noImplicitAny
 const schema = z.object({ name: z.string() })
-schema.parse(data)  // data could be 'any', bypassing validation
+schema.parse(data) // data could be 'any', bypassing validation
 ```
 
 **Migrating to strict mode:**
@@ -109,22 +109,24 @@ schema.parse(data)  // data could be 'any', bypassing validation
 
 // 1. Add null checks
 if (user.name !== undefined) {
-  console.log(user.name.toUpperCase())
+    console.log(user.name.toUpperCase())
 }
 
 // 2. Add explicit types
-function processData(data: unknown) {  // Was implicit any
-  const validated = schema.parse(data)
+function processData(data: unknown) {
+    // Was implicit any
+    const validated = schema.parse(data)
 }
 
 // 3. Handle optional fields
 const user: User = {
-  name: 'John',
-  email: 'john@example.com',  // Now required, was optional without strict
+    name: 'John',
+    email: 'john@example.com', // Now required, was optional without strict
 }
 ```
 
 **When NOT to use this pattern:**
+
 - Never - always enable strict mode for Zod projects
 
 Reference: [Zod Requirements](https://zod.dev/#requirements)

--- a/.agents/skills/zod/references/type-export-schemas-and-types.md
+++ b/.agents/skills/zod/references/type-export-schemas-and-types.md
@@ -1,0 +1,116 @@
+---
+title: Export Both Schemas and Inferred Types
+impact: HIGH
+impactDescription: Exporting only schemas forces consumers to derive types themselves; exporting both reduces boilerplate and improves DX
+tags: type, export, module, organization
+---
+
+## Export Both Schemas and Inferred Types
+
+When defining schemas in shared modules, export both the schema and its inferred type. This saves consumers from writing `z.infer<typeof schema>` repeatedly and makes imports cleaner.
+
+**Incorrect (exporting only schema):**
+
+```typescript
+// schemas/user.ts
+import { z } from 'zod'
+
+export const userSchema = z.object({
+  id: z.string().uuid(),
+  email: z.string().email(),
+  name: z.string(),
+  role: z.enum(['admin', 'user']),
+})
+
+// Every consumer must derive the type
+// api/users.ts
+import { userSchema } from '@/schemas/user'
+import type { z } from 'zod'
+
+type User = z.infer<typeof userSchema>  // Repeated everywhere
+
+// components/UserCard.tsx
+import { userSchema } from '@/schemas/user'
+import type { z } from 'zod'
+
+type User = z.infer<typeof userSchema>  // Same boilerplate again
+```
+
+**Correct (exporting schema and type):**
+
+```typescript
+// schemas/user.ts
+import { z } from 'zod'
+
+export const userSchema = z.object({
+  id: z.string().uuid(),
+  email: z.string().email(),
+  name: z.string(),
+  role: z.enum(['admin', 'user']),
+})
+
+export type User = z.infer<typeof userSchema>
+
+// For schemas with transforms, export both
+export const apiUserSchema = z.object({
+  id: z.string(),
+  created_at: z.string().transform(s => new Date(s)),
+})
+
+export type ApiUserInput = z.input<typeof apiUserSchema>
+export type ApiUser = z.infer<typeof apiUserSchema>
+```
+
+```typescript
+// api/users.ts - clean import
+import { userSchema, type User } from '@/schemas/user'
+
+async function getUser(id: string): Promise<User> {
+  const data = await db.users.findUnique({ where: { id } })
+  return userSchema.parse(data)
+}
+
+// components/UserCard.tsx - just the type
+import type { User } from '@/schemas/user'
+
+function UserCard({ user }: { user: User }) {
+  return <div>{user.name}</div>
+}
+```
+
+**Organizing schema exports:**
+
+```typescript
+// schemas/index.ts - barrel file for schemas
+export { userSchema, type User, type UserInput } from './user'
+export { orderSchema, type Order } from './order'
+export { productSchema, type Product } from './product'
+
+// Usage
+import { userSchema, type User, type Order } from '@/schemas'
+```
+
+**With enums, export the enum values too:**
+
+```typescript
+// schemas/user.ts
+export const UserRole = z.enum(['admin', 'user', 'guest'])
+export type UserRole = z.infer<typeof UserRole>
+
+export const userSchema = z.object({
+  id: z.string(),
+  role: UserRole,
+})
+
+export type User = z.infer<typeof userSchema>
+
+// Access enum values
+UserRole.options  // ['admin', 'user', 'guest']
+UserRole.enum.admin  // 'admin'
+```
+
+**When NOT to use this pattern:**
+- Internal schemas that won't be used outside the module
+- Transient schemas used only for validation (not as types)
+
+Reference: [Zod API - Type Inference](https://zod.dev/api#type-inference)

--- a/.agents/skills/zod/references/type-export-schemas-and-types.md
+++ b/.agents/skills/zod/references/type-export-schemas-and-types.md
@@ -16,10 +16,10 @@ When defining schemas in shared modules, export both the schema and its inferred
 import { z } from 'zod'
 
 export const userSchema = z.object({
-  id: z.string().uuid(),
-  email: z.string().email(),
-  name: z.string(),
-  role: z.enum(['admin', 'user']),
+    id: z.string().uuid(),
+    email: z.string().email(),
+    name: z.string(),
+    role: z.enum(['admin', 'user']),
 })
 
 // Every consumer must derive the type
@@ -27,13 +27,13 @@ export const userSchema = z.object({
 import { userSchema } from '@/schemas/user'
 import type { z } from 'zod'
 
-type User = z.infer<typeof userSchema>  // Repeated everywhere
+type User = z.infer<typeof userSchema> // Repeated everywhere
 
 // components/UserCard.tsx
 import { userSchema } from '@/schemas/user'
 import type { z } from 'zod'
 
-type User = z.infer<typeof userSchema>  // Same boilerplate again
+type User = z.infer<typeof userSchema> // Same boilerplate again
 ```
 
 **Correct (exporting schema and type):**
@@ -43,18 +43,18 @@ type User = z.infer<typeof userSchema>  // Same boilerplate again
 import { z } from 'zod'
 
 export const userSchema = z.object({
-  id: z.string().uuid(),
-  email: z.string().email(),
-  name: z.string(),
-  role: z.enum(['admin', 'user']),
+    id: z.string().uuid(),
+    email: z.string().email(),
+    name: z.string(),
+    role: z.enum(['admin', 'user']),
 })
 
 export type User = z.infer<typeof userSchema>
 
 // For schemas with transforms, export both
 export const apiUserSchema = z.object({
-  id: z.string(),
-  created_at: z.string().transform(s => new Date(s)),
+    id: z.string(),
+    created_at: z.string().transform(s => new Date(s)),
 })
 
 export type ApiUserInput = z.input<typeof apiUserSchema>
@@ -98,18 +98,19 @@ export const UserRole = z.enum(['admin', 'user', 'guest'])
 export type UserRole = z.infer<typeof UserRole>
 
 export const userSchema = z.object({
-  id: z.string(),
-  role: UserRole,
+    id: z.string(),
+    role: UserRole,
 })
 
 export type User = z.infer<typeof userSchema>
 
 // Access enum values
-UserRole.options  // ['admin', 'user', 'guest']
-UserRole.enum.admin  // 'admin'
+UserRole.options // ['admin', 'user', 'guest']
+UserRole.enum.admin // 'admin'
 ```
 
 **When NOT to use this pattern:**
+
 - Internal schemas that won't be used outside the module
 - Transient schemas used only for validation (not as types)
 

--- a/.agents/skills/zod/references/type-input-vs-output.md
+++ b/.agents/skills/zod/references/type-input-vs-output.md
@@ -1,0 +1,116 @@
+---
+title: Distinguish z.input from z.infer for Transforms
+impact: HIGH
+impactDescription: Using wrong type with transforms causes TypeScript errors; z.input captures pre-transform shape, z.infer captures post-transform
+tags: type, input, output, transform
+---
+
+## Distinguish z.input from z.infer for Transforms
+
+When schemas use `.transform()`, the input and output types differ. `z.infer` (same as `z.output`) gives the post-transform type, while `z.input` gives the pre-transform type. Using the wrong one causes confusing TypeScript errors.
+
+**Incorrect (using infer for input type):**
+
+```typescript
+import { z } from 'zod'
+
+const dateSchema = z.string().transform(s => new Date(s))
+
+type DateOutput = z.infer<typeof dateSchema>
+// Date (post-transform)
+
+// Wrong! Expecting Date but should accept string
+function handleDate(input: DateOutput) {
+  return dateSchema.parse(input)  // Error: Argument of type 'Date' is not assignable to type 'string'
+}
+
+// Caller passes string, but type says Date
+handleDate('2024-01-15')  // TypeScript error
+```
+
+**Correct (using z.input for pre-transform type):**
+
+```typescript
+import { z } from 'zod'
+
+const dateSchema = z.string().transform(s => new Date(s))
+
+// Input type = what parse() accepts
+type DateInput = z.input<typeof dateSchema>
+// string (pre-transform)
+
+// Output type = what parse() returns
+type DateOutput = z.output<typeof dateSchema>
+// Date (post-transform)
+
+// Use input type for function parameters
+function handleDate(input: DateInput) {
+  const parsed = dateSchema.parse(input)  // parsed is Date
+  return parsed
+}
+
+handleDate('2024-01-15')  // Works - string input
+```
+
+**Complex example with object transforms:**
+
+```typescript
+const apiUserSchema = z.object({
+  id: z.string(),
+  created_at: z.string().transform(s => new Date(s)),
+  tags: z.string().transform(s => s.split(',')),
+  is_active: z.union([z.boolean(), z.literal(1), z.literal(0)])
+    .transform(v => Boolean(v)),
+})
+
+// What the API sends
+type ApiUserInput = z.input<typeof apiUserSchema>
+// {
+//   id: string
+//   created_at: string
+//   tags: string
+//   is_active: boolean | 1 | 0
+// }
+
+// What your code works with
+type ApiUser = z.infer<typeof apiUserSchema>
+// {
+//   id: string
+//   created_at: Date
+//   tags: string[]
+//   is_active: boolean
+// }
+
+// API response handler
+function handleApiResponse(rawData: ApiUserInput) {
+  const user = apiUserSchema.parse(rawData)
+  // user.created_at is Date
+  // user.tags is string[]
+  // user.is_active is boolean
+  return user
+}
+```
+
+**Using with function types:**
+
+```typescript
+const formSchema = z.object({
+  amount: z.string().transform(s => parseFloat(s)),
+  quantity: z.string().transform(s => parseInt(s, 10)),
+})
+
+type FormInput = z.input<typeof formSchema>
+type FormOutput = z.output<typeof formSchema>
+
+// Form handler receives raw strings
+type FormHandler = (input: FormInput) => Promise<void>
+
+// Business logic receives parsed values
+type OrderProcessor = (order: FormOutput) => Promise<void>
+```
+
+**When NOT to use this pattern:**
+- Schemas without transforms (input and output are identical)
+- When you only work with validated data (just use z.infer)
+
+Reference: [Zod - Type Inference](https://zod.dev/api#type-inference)

--- a/.agents/skills/zod/references/type-input-vs-output.md
+++ b/.agents/skills/zod/references/type-input-vs-output.md
@@ -21,11 +21,11 @@ type DateOutput = z.infer<typeof dateSchema>
 
 // Wrong! Expecting Date but should accept string
 function handleDate(input: DateOutput) {
-  return dateSchema.parse(input)  // Error: Argument of type 'Date' is not assignable to type 'string'
+    return dateSchema.parse(input) // Error: Argument of type 'Date' is not assignable to type 'string'
 }
 
 // Caller passes string, but type says Date
-handleDate('2024-01-15')  // TypeScript error
+handleDate('2024-01-15') // TypeScript error
 ```
 
 **Correct (using z.input for pre-transform type):**
@@ -45,22 +45,23 @@ type DateOutput = z.output<typeof dateSchema>
 
 // Use input type for function parameters
 function handleDate(input: DateInput) {
-  const parsed = dateSchema.parse(input)  // parsed is Date
-  return parsed
+    const parsed = dateSchema.parse(input) // parsed is Date
+    return parsed
 }
 
-handleDate('2024-01-15')  // Works - string input
+handleDate('2024-01-15') // Works - string input
 ```
 
 **Complex example with object transforms:**
 
 ```typescript
 const apiUserSchema = z.object({
-  id: z.string(),
-  created_at: z.string().transform(s => new Date(s)),
-  tags: z.string().transform(s => s.split(',')),
-  is_active: z.union([z.boolean(), z.literal(1), z.literal(0)])
-    .transform(v => Boolean(v)),
+    id: z.string(),
+    created_at: z.string().transform(s => new Date(s)),
+    tags: z.string().transform(s => s.split(',')),
+    is_active: z
+        .union([z.boolean(), z.literal(1), z.literal(0)])
+        .transform(v => Boolean(v)),
 })
 
 // What the API sends
@@ -83,11 +84,11 @@ type ApiUser = z.infer<typeof apiUserSchema>
 
 // API response handler
 function handleApiResponse(rawData: ApiUserInput) {
-  const user = apiUserSchema.parse(rawData)
-  // user.created_at is Date
-  // user.tags is string[]
-  // user.is_active is boolean
-  return user
+    const user = apiUserSchema.parse(rawData)
+    // user.created_at is Date
+    // user.tags is string[]
+    // user.is_active is boolean
+    return user
 }
 ```
 
@@ -95,8 +96,8 @@ function handleApiResponse(rawData: ApiUserInput) {
 
 ```typescript
 const formSchema = z.object({
-  amount: z.string().transform(s => parseFloat(s)),
-  quantity: z.string().transform(s => parseInt(s, 10)),
+    amount: z.string().transform(s => parseFloat(s)),
+    quantity: z.string().transform(s => parseInt(s, 10)),
 })
 
 type FormInput = z.input<typeof formSchema>
@@ -110,6 +111,7 @@ type OrderProcessor = (order: FormOutput) => Promise<void>
 ```
 
 **When NOT to use this pattern:**
+
 - Schemas without transforms (input and output are identical)
 - When you only work with validated data (just use z.infer)
 

--- a/.agents/skills/zod/references/type-use-z-infer.md
+++ b/.agents/skills/zod/references/type-use-z-infer.md
@@ -1,0 +1,110 @@
+---
+title: Use z.infer Instead of Manual Types
+impact: HIGH
+impactDescription: Manual type definitions drift from schemas over time; z.infer guarantees types match validation exactly
+tags: type, infer, typescript, dry
+---
+
+## Use z.infer Instead of Manual Types
+
+Defining TypeScript types separately from Zod schemas creates duplication that inevitably drifts. When you update a schema, you must remember to update the type—and you will forget. Use `z.infer<typeof schema>` to derive types from schemas automatically.
+
+**Incorrect (manual type definitions):**
+
+```typescript
+import { z } from 'zod'
+
+// Manual type definition
+interface User {
+  id: string
+  name: string
+  email: string
+  age: number
+}
+
+// Separate schema
+const userSchema = z.object({
+  id: z.string().uuid(),
+  name: z.string().min(1),
+  email: z.string().email(),
+  age: z.number().int().positive(),
+  role: z.enum(['admin', 'user']),  // Added to schema, forgot to add to interface!
+})
+
+// Type and schema are now out of sync
+function createUser(user: User) {
+  const validated = userSchema.parse(user)  // Has role
+  saveToDb(user)  // Missing role - TypeScript doesn't warn
+}
+```
+
+**Correct (using z.infer):**
+
+```typescript
+import { z } from 'zod'
+
+// Schema is the single source of truth
+const userSchema = z.object({
+  id: z.string().uuid(),
+  name: z.string().min(1),
+  email: z.string().email(),
+  age: z.number().int().positive(),
+  role: z.enum(['admin', 'user']),
+})
+
+// Type is always in sync with schema
+type User = z.infer<typeof userSchema>
+// { id: string; name: string; email: string; age: number; role: 'admin' | 'user' }
+
+function createUser(user: User) {
+  // user.role exists because type is derived from schema
+  const validated = userSchema.parse(user)
+  saveToDb(validated)
+}
+```
+
+**Input vs Output types with transforms:**
+
+```typescript
+const userSchema = z.object({
+  name: z.string(),
+  createdAt: z.string().transform(s => new Date(s)),  // String in, Date out
+})
+
+// z.infer gives output type (after transforms)
+type User = z.infer<typeof userSchema>
+// { name: string; createdAt: Date }
+
+// z.input gives input type (before transforms)
+type UserInput = z.input<typeof userSchema>
+// { name: string; createdAt: string }
+
+// Use input type for function parameters accepting raw data
+function processUser(input: UserInput) {
+  const user = userSchema.parse(input)  // user is User type
+  return user.createdAt.getTime()  // Date methods available
+}
+```
+
+**Naming convention:**
+
+```typescript
+// Schema named with Schema suffix
+const UserSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+})
+
+// Type named without suffix
+type User = z.infer<typeof UserSchema>
+
+// Alternative: lowercase schema, uppercase type
+const userSchema = z.object({/*...*/})
+type User = z.infer<typeof userSchema>
+```
+
+**When NOT to use this pattern:**
+- When you need a type that's different from the validation schema
+- When interfacing with external types you don't control
+
+Reference: [Zod - Type Inference](https://zod.dev/api#type-inference)

--- a/.agents/skills/zod/references/type-use-z-infer.md
+++ b/.agents/skills/zod/references/type-use-z-infer.md
@@ -16,25 +16,25 @@ import { z } from 'zod'
 
 // Manual type definition
 interface User {
-  id: string
-  name: string
-  email: string
-  age: number
+    id: string
+    name: string
+    email: string
+    age: number
 }
 
 // Separate schema
 const userSchema = z.object({
-  id: z.string().uuid(),
-  name: z.string().min(1),
-  email: z.string().email(),
-  age: z.number().int().positive(),
-  role: z.enum(['admin', 'user']),  // Added to schema, forgot to add to interface!
+    id: z.string().uuid(),
+    name: z.string().min(1),
+    email: z.string().email(),
+    age: z.number().int().positive(),
+    role: z.enum(['admin', 'user']), // Added to schema, forgot to add to interface!
 })
 
 // Type and schema are now out of sync
 function createUser(user: User) {
-  const validated = userSchema.parse(user)  // Has role
-  saveToDb(user)  // Missing role - TypeScript doesn't warn
+    const validated = userSchema.parse(user) // Has role
+    saveToDb(user) // Missing role - TypeScript doesn't warn
 }
 ```
 
@@ -45,11 +45,11 @@ import { z } from 'zod'
 
 // Schema is the single source of truth
 const userSchema = z.object({
-  id: z.string().uuid(),
-  name: z.string().min(1),
-  email: z.string().email(),
-  age: z.number().int().positive(),
-  role: z.enum(['admin', 'user']),
+    id: z.string().uuid(),
+    name: z.string().min(1),
+    email: z.string().email(),
+    age: z.number().int().positive(),
+    role: z.enum(['admin', 'user']),
 })
 
 // Type is always in sync with schema
@@ -57,9 +57,9 @@ type User = z.infer<typeof userSchema>
 // { id: string; name: string; email: string; age: number; role: 'admin' | 'user' }
 
 function createUser(user: User) {
-  // user.role exists because type is derived from schema
-  const validated = userSchema.parse(user)
-  saveToDb(validated)
+    // user.role exists because type is derived from schema
+    const validated = userSchema.parse(user)
+    saveToDb(validated)
 }
 ```
 
@@ -67,8 +67,8 @@ function createUser(user: User) {
 
 ```typescript
 const userSchema = z.object({
-  name: z.string(),
-  createdAt: z.string().transform(s => new Date(s)),  // String in, Date out
+    name: z.string(),
+    createdAt: z.string().transform(s => new Date(s)), // String in, Date out
 })
 
 // z.infer gives output type (after transforms)
@@ -81,8 +81,8 @@ type UserInput = z.input<typeof userSchema>
 
 // Use input type for function parameters accepting raw data
 function processUser(input: UserInput) {
-  const user = userSchema.parse(input)  // user is User type
-  return user.createdAt.getTime()  // Date methods available
+    const user = userSchema.parse(input) // user is User type
+    return user.createdAt.getTime() // Date methods available
 }
 ```
 
@@ -91,19 +91,22 @@ function processUser(input: UserInput) {
 ```typescript
 // Schema named with Schema suffix
 const UserSchema = z.object({
-  id: z.string(),
-  name: z.string(),
+    id: z.string(),
+    name: z.string(),
 })
 
 // Type named without suffix
 type User = z.infer<typeof UserSchema>
 
 // Alternative: lowercase schema, uppercase type
-const userSchema = z.object({/*...*/})
+const userSchema = z.object({
+    /*...*/
+})
 type User = z.infer<typeof userSchema>
 ```
 
 **When NOT to use this pattern:**
+
 - When you need a type that's different from the validation schema
 - When interfacing with external types you don't control
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,8 +30,8 @@ jobs:
                       sudo -u bot env CI=true pnpm install --frozen-lockfile
 
                       echo "Generando build..."
-                      sudo -u bot pnpx prisma migrate deploy
-                      sudo -u bot pnpx prisma generate
+                      sudo -u bot pnpm exec prisma migrate deploy
+                      sudo -u bot pnpm exec prisma generate
                       sudo -u bot pnpm run build
 
                       echo "Reiniciando servicio..."

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,6 +30,8 @@ jobs:
                       sudo -u bot env CI=true pnpm install --frozen-lockfile
 
                       echo "Generando build..."
+                      sudo -u bot pnpx prisma migrate deploy
+                      sudo -u bot pnpx prisma generate
                       sudo -u bot pnpm run build
 
                       echo "Reiniciando servicio..."

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,42 @@
+name: Test Web
+
+on:
+    pull_request:
+        branches:
+            - main
+
+jobs:
+    build:
+        runs-on: ubuntu-latest
+
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v4
+
+            - name: Setup Node.js
+              uses: actions/setup-node@v4
+              with:
+                  node-version: 24.14.0
+
+            - name: Setup pnpm
+              uses: pnpm/action-setup@v4
+              with:
+                  version: 11.5.2
+                  run_install: false
+
+            - name: Verify pnpm
+              run: pnpm --version
+
+            - name: Install dependencies
+              run: pnpm install --frozen-lockfile
+              env:
+                  CI: true
+
+            - name: Lint
+              run: pnpm run lint
+
+            - name: Check formatting
+              run: pnpm run format:check
+
+            - name: Build
+              run: pnpm run build

--- a/docs/06-oauth-y-autenticacion.md
+++ b/docs/06-oauth-y-autenticacion.md
@@ -125,10 +125,10 @@ sequenceDiagram
 
 Los scopes se solicitan en `GET /auth/authorize` usando el parámetro `scope` con valores separados por espacio. El servidor valida que todos los scopes pedidos existan y estén permitidos por `Client.scopes`.
 
-| Scope | Qué habilita en `/auth/me` |
-| --- | --- |
-| `openid` | Claims de identidad del access token: `sub`, `iss`, `aud`, `exp`. |
-| `identify` | Información general del usuario del sistema: `id`, `rank`, `created_at` y `discord_user`. |
+| Scope       | Qué habilita en `/auth/me`                                                                                            |
+| ----------- | --------------------------------------------------------------------------------------------------------------------- |
+| `openid`    | Claims de identidad del access token: `sub`, `iss`, `aud`, `exp`.                                                     |
+| `identify`  | Información general del usuario del sistema: `id`, `rank`, `created_at` y `discord_user`.                             |
 | `minecraft` | Información del jugador vinculado: `mc_player` con `digs`, `nickname`, `uuid`, `rank`, `user_id`, `medias` y `roles`. |
 
 Ejemplo:

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,14 +5,14 @@ Esta carpeta centraliza documentación **en español** del bot.
 ## Índice
 
 1. [`01-arquitectura-general.md`](./01-arquitectura-general.md)
-   - Visión global del sistema, componentes y flujo de arranque.
+    - Visión global del sistema, componentes y flujo de arranque.
 2. [`02-webhooks-y-seguridad.md`](./02-webhooks-y-seguridad.md)
-   - Cómo funcionan los webhooks (`/webhooks/digs`, `/webhooks/link` y `/webhooks/join`) y por qué existe su capa de seguridad.
+    - Cómo funcionan los webhooks (`/webhooks/digs`, `/webhooks/link` y `/webhooks/join`) y por qué existe su capa de seguridad.
 3. [`03-sistema-posts-blog.md`](./03-sistema-posts-blog.md)
-   - Diseño del panel de publicaciones, borradores, publicación y obsolescencia.
+    - Diseño del panel de publicaciones, borradores, publicación y obsolescencia.
 4. [`04-inactividad-y-estadisticas.md`](./04-inactividad-y-estadisticas.md)
-   - Flujo completo del sistema de inactividad (panel, comandos, scheduler, snapshots).
+    - Flujo completo del sistema de inactividad (panel, comandos, scheduler, snapshots).
 5. [`05-mapa-de-archivos.md`](./05-mapa-de-archivos.md)
-   - Mapa por archivo del repositorio: qué hace cada archivo, para qué existe y en qué parte del sistema encaja.
+    - Mapa por archivo del repositorio: qué hace cada archivo, para qué existe y en qué parte del sistema encaja.
 6. [`06-oauth-y-autenticacion.md`](./06-oauth-y-autenticacion.md)
-   - Sistema OAuth 2.0 con PKCE, integración Discord y gestión de sesiones.
+    - Sistema OAuth 2.0 con PKCE, integración Discord y gestión de sesiones.

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
         "lint": "eslint .",
         "build": "prisma generate && tsc",
         "dev": "node --watch src/index.ts",
-        "db:copy-prod": "prisma migrate reset && prisma generate && node scripts/copydb.ts"
+        "db:copy-prod": "prisma migrate reset && prisma generate && node scripts/copydb.ts",
+        "format:check": "prettier --check ."
     },
     "imports": {
         "#/*": "./src/*"

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
         "eslint-plugin-import": "2.32.0",
         "globals": "17.5.0",
         "pino-pretty": "13.1.3",
+        "prettier": "3.8.3",
         "prisma": "7.8.0",
         "typescript": "6.0.3",
         "typescript-eslint": "8.59.1"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -111,6 +111,9 @@ importers:
       pino-pretty:
         specifier: 13.1.3
         version: 13.1.3
+      prettier:
+        specifier: ^3.8.3
+        version: 3.8.3
       prisma:
         specifier: 7.8.0
         version: 7.8.0(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)
@@ -1898,6 +1901,11 @@ packages:
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
+
+  prettier@3.8.3:
+    resolution: {integrity: sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==}
+    engines: {node: '>=14'}
+    hasBin: true
 
   prisma@7.8.0:
     resolution: {integrity: sha512-yfN4yrw7HV9kEJhoy1+jgah0jafEIQsf7uWouSsM8MvJtlubsk+kM7AIBWZ8+GJl74Yj3c+nbYqBkMOxtsZ3Lw==}
@@ -4506,6 +4514,8 @@ snapshots:
   postgres@3.4.7: {}
 
   prelude-ls@1.2.1: {}
+
+  prettier@3.8.3: {}
 
   prisma@7.8.0(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4996 +1,6620 @@
 lockfileVersion: '9.0'
 
 settings:
-  autoInstallPeers: true
-  excludeLinksFromLockfile: false
+    autoInstallPeers: true
+    excludeLinksFromLockfile: false
 
 overrides:
-  eslint-plugin-import>eslint: 10.2.1
+    eslint-plugin-import>eslint: 10.2.1
 
 importers:
-
-  .:
-    dependencies:
-      '@aws-sdk/client-s3':
-        specifier: 3.1039.0
-        version: 3.1039.0
-      '@aws-sdk/lib-storage':
-        specifier: 3.1038.0
-        version: 3.1038.0(@aws-sdk/client-s3@3.1039.0)
-      '@eliyya/flagged-bitfield':
-        specifier: ^1.1.1
-        version: 1.1.1
-      '@js-temporal/polyfill':
-        specifier: 0.5.1
-        version: 0.5.1
-      '@prisma/adapter-pg':
-        specifier: 7.8.0
-        version: 7.8.0
-      '@prisma/client':
-        specifier: 7.8.0
-        version: 7.8.0(prisma@7.8.0(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3))(typescript@6.0.3)
-      '@triskcraft/api-types':
-        specifier: ^1.2.1
-        version: 1.2.1
-      argon2:
-        specifier: 0.44.0
-        version: 0.44.0
-      busboy:
-        specifier: 1.6.0
-        version: 1.6.0
-      cookie-parser:
-        specifier: 1.4.7
-        version: 1.4.7
-      cors:
-        specifier: 2.8.6
-        version: 2.8.6
-      discord.js:
-        specifier: 14.26.3
-        version: 14.26.3
-      express:
-        specifier: 5.2.1
-        version: 5.2.1
-      jose:
-        specifier: 6.2.3
-        version: 6.2.3
-      luxon:
-        specifier: 3.7.2
-        version: 3.7.2
-      neverthrow:
-        specifier: 8.2.0
-        version: 8.2.0
-      pg:
-        specifier: 8.20.0
-        version: 8.20.0
-      pino:
-        specifier: 10.3.1
-        version: 10.3.1
-      zod:
-        specifier: 4.3.6
-        version: 4.3.6
-    devDependencies:
-      '@eslint/js':
-        specifier: 10.0.1
-        version: 10.0.1(eslint@10.2.1(jiti@2.7.0))
-      '@eslint/json':
-        specifier: 1.2.0
-        version: 1.2.0
-      '@types/busboy':
-        specifier: 1.5.4
-        version: 1.5.4
-      '@types/cookie-parser':
-        specifier: 1.4.10
-        version: 1.4.10(@types/express@5.0.6)
-      '@types/cors':
-        specifier: 2.8.19
-        version: 2.8.19
-      '@types/express':
-        specifier: 5.0.6
-        version: 5.0.6
-      '@types/luxon':
-        specifier: 3.7.1
-        version: 3.7.1
-      '@types/multer':
-        specifier: 2.1.0
-        version: 2.1.0
-      '@types/node':
-        specifier: 25.6.0
-        version: 25.6.0
-      eslint:
-        specifier: 10.2.1
-        version: 10.2.1(jiti@2.7.0)
-      eslint-config-prettier:
-        specifier: 10.1.8
-        version: 10.1.8(eslint@10.2.1(jiti@2.7.0))
-      eslint-plugin-import:
-        specifier: 2.32.0
-        version: 2.32.0(@typescript-eslint/parser@8.59.1(eslint@10.2.1(jiti@2.7.0))(typescript@6.0.3))(eslint@10.2.1(jiti@2.7.0))
-      globals:
-        specifier: 17.5.0
-        version: 17.5.0
-      pino-pretty:
-        specifier: 13.1.3
-        version: 13.1.3
-      prettier:
-        specifier: 3.8.3
-        version: 3.8.3
-      prisma:
-        specifier: 7.8.0
-        version: 7.8.0(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)
-      typescript:
-        specifier: 6.0.3
-        version: 6.0.3
-      typescript-eslint:
-        specifier: 8.59.1
-        version: 8.59.1(eslint@10.2.1(jiti@2.7.0))(typescript@6.0.3)
+    .:
+        dependencies:
+            '@aws-sdk/client-s3':
+                specifier: 3.1039.0
+                version: 3.1039.0
+            '@aws-sdk/lib-storage':
+                specifier: 3.1038.0
+                version: 3.1038.0(@aws-sdk/client-s3@3.1039.0)
+            '@eliyya/flagged-bitfield':
+                specifier: ^1.1.1
+                version: 1.1.1
+            '@js-temporal/polyfill':
+                specifier: 0.5.1
+                version: 0.5.1
+            '@prisma/adapter-pg':
+                specifier: 7.8.0
+                version: 7.8.0
+            '@prisma/client':
+                specifier: 7.8.0
+                version: 7.8.0(prisma@7.8.0(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3))(typescript@6.0.3)
+            '@triskcraft/api-types':
+                specifier: ^1.2.1
+                version: 1.2.1
+            argon2:
+                specifier: 0.44.0
+                version: 0.44.0
+            busboy:
+                specifier: 1.6.0
+                version: 1.6.0
+            cookie-parser:
+                specifier: 1.4.7
+                version: 1.4.7
+            cors:
+                specifier: 2.8.6
+                version: 2.8.6
+            discord.js:
+                specifier: 14.26.3
+                version: 14.26.3
+            express:
+                specifier: 5.2.1
+                version: 5.2.1
+            jose:
+                specifier: 6.2.3
+                version: 6.2.3
+            luxon:
+                specifier: 3.7.2
+                version: 3.7.2
+            neverthrow:
+                specifier: 8.2.0
+                version: 8.2.0
+            pg:
+                specifier: 8.20.0
+                version: 8.20.0
+            pino:
+                specifier: 10.3.1
+                version: 10.3.1
+            zod:
+                specifier: 4.3.6
+                version: 4.3.6
+        devDependencies:
+            '@eslint/js':
+                specifier: 10.0.1
+                version: 10.0.1(eslint@10.2.1(jiti@2.7.0))
+            '@eslint/json':
+                specifier: 1.2.0
+                version: 1.2.0
+            '@types/busboy':
+                specifier: 1.5.4
+                version: 1.5.4
+            '@types/cookie-parser':
+                specifier: 1.4.10
+                version: 1.4.10(@types/express@5.0.6)
+            '@types/cors':
+                specifier: 2.8.19
+                version: 2.8.19
+            '@types/express':
+                specifier: 5.0.6
+                version: 5.0.6
+            '@types/luxon':
+                specifier: 3.7.1
+                version: 3.7.1
+            '@types/multer':
+                specifier: 2.1.0
+                version: 2.1.0
+            '@types/node':
+                specifier: 25.6.0
+                version: 25.6.0
+            eslint:
+                specifier: 10.2.1
+                version: 10.2.1(jiti@2.7.0)
+            eslint-config-prettier:
+                specifier: 10.1.8
+                version: 10.1.8(eslint@10.2.1(jiti@2.7.0))
+            eslint-plugin-import:
+                specifier: 2.32.0
+                version: 2.32.0(@typescript-eslint/parser@8.59.1(eslint@10.2.1(jiti@2.7.0))(typescript@6.0.3))(eslint@10.2.1(jiti@2.7.0))
+            globals:
+                specifier: 17.5.0
+                version: 17.5.0
+            pino-pretty:
+                specifier: 13.1.3
+                version: 13.1.3
+            prettier:
+                specifier: 3.8.3
+                version: 3.8.3
+            prisma:
+                specifier: 7.8.0
+                version: 7.8.0(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)
+            typescript:
+                specifier: 6.0.3
+                version: 6.0.3
+            typescript-eslint:
+                specifier: 8.59.1
+                version: 8.59.1(eslint@10.2.1(jiti@2.7.0))(typescript@6.0.3)
 
 packages:
-
-  '@aws-crypto/crc32@5.2.0':
-    resolution: {integrity: sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==}
-    engines: {node: '>=16.0.0'}
-
-  '@aws-crypto/crc32c@5.2.0':
-    resolution: {integrity: sha512-+iWb8qaHLYKrNvGRbiYRHSdKRWhto5XlZUEBwDjYNf+ly5SVYG6zEoYIdxvf5R3zyeP16w4PLBn3rH1xc74Rag==}
-
-  '@aws-crypto/sha1-browser@5.2.0':
-    resolution: {integrity: sha512-OH6lveCFfcDjX4dbAvCFSYUjJZjDr/3XJ3xHtjn3Oj5b9RjojQo8npoLeA/bNwkOkrSQ0wgrHzXk4tDRxGKJeg==}
-
-  '@aws-crypto/sha256-browser@5.2.0':
-    resolution: {integrity: sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==}
-
-  '@aws-crypto/sha256-js@5.2.0':
-    resolution: {integrity: sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==}
-    engines: {node: '>=16.0.0'}
-
-  '@aws-crypto/supports-web-crypto@5.2.0':
-    resolution: {integrity: sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==}
-
-  '@aws-crypto/util@5.2.0':
-    resolution: {integrity: sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==}
-
-  '@aws-sdk/checksums@3.1000.2':
-    resolution: {integrity: sha512-PIha+kauTbp6IRmOpYktPTrlfrrSqDVixvhO/EUOFOf62DPX81CaJoHJreuA1m9HYpSKyXf99BKjU1dvJPeUfw==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/client-s3@3.1039.0':
-    resolution: {integrity: sha512-PVH9v0pHYBQnBADSR/m88NgcuJcYqPXfpmkcME66vRF75Y4swwbEVVFbTBFuvxu0YcZiLFXu3lw0FDK00vEa3A==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/core@3.974.18':
-    resolution: {integrity: sha512-JDYCPI0j7zGrzXTDFsLB346cxss7J/AxH7+O0MzWlqppJBEyB9Qe6TQXRL6iwLUo/xZkNv9KFmBL2hqElmwW0g==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/credential-provider-env@3.972.44':
-    resolution: {integrity: sha512-3hKJVrZ7bqXzDAXCQp+OaQ1ASN+vWstaNuEH418wQVl//cRZhqhfR9Bjk1qIWmgUGe8/D3gdO73PgidRj378EQ==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/credential-provider-http@3.972.46':
-    resolution: {integrity: sha512-VhwC9pGAZHhiQ2xSViyOPDFqvr9aRxGCAXZtADsUhU3R65nad7y//CwynE6mQnWNR+suRlqE79W36IVayL+m1g==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/credential-provider-ini@3.972.50':
-    resolution: {integrity: sha512-09Xi6ovxiK42+De/qBGF71sT5F2bWgYM+1fFyDwSOpy1xpsQ5R/naIu7MVDpH6Dic36QNc8dAv4KADtMGK2JYg==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/credential-provider-login@3.972.49':
-    resolution: {integrity: sha512-EfJF/1Fh9mI4pZyoheU2RY9xUhTcugIZNkD63+orXMkYj/QXacJNbKVDUK90Yv5hE+aX+rt9J/EZ9Qr3vKOa7g==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/credential-provider-node@3.972.52':
-    resolution: {integrity: sha512-7QX+PbyiWBEOVipJq8Nke/TqXT6lAPLE7fvTaopa39/IVWuLfS+Fzdy71sZJONf/mLGgmtj6aU17+REw3+aRrw==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/credential-provider-process@3.972.44':
-    resolution: {integrity: sha512-V+UUhZpRP7QDRhi+qgBDisM9tUBnYmMje8Bk77A6MZsfeGeGdMsQXmaHP1CDYFcept0o/Rz5g2Y0TMeVlG9dzg==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/credential-provider-sso@3.972.49':
-    resolution: {integrity: sha512-9QqOYGuh5tZ76OzaT68kwI78AH+5lS/uZGGvkfxb3fc8FzRrIz2jOufNTliEBEeSAwmgK2rWLNsK+IB3zbtNPA==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/credential-provider-web-identity@3.972.49':
-    resolution: {integrity: sha512-IYx1lN38MnnPXv+NBLpuATu0cZakbZ321TAfjW+aVkw7HIJF38YnEwdeEO55MSl3pl7hIX1IvvnD6EmnAzmAJw==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/lib-storage@3.1038.0':
-    resolution: {integrity: sha512-FEGuFSUL9gNfyWf4KcOgzhLiqQgSSvpML3YPnJbj8k2nSKdgyRznXxg8zd4W+NKoVehtNqXwFBvMXeHyOYlOrg==}
-    engines: {node: '>=20.0.0'}
-    peerDependencies:
-      '@aws-sdk/client-s3': ^3.1038.0
-
-  '@aws-sdk/middleware-bucket-endpoint@3.972.21':
-    resolution: {integrity: sha512-9hkf6r6GIovTMi3gl/9TZLokp4R27PrZ1t0yejQqDZ49bLGiVmRnbklU2uMjtuot9yBskIquvinEoYGpZ0wMKw==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/middleware-expect-continue@3.972.17':
-    resolution: {integrity: sha512-MzrvtvWEedwi4sg0DXT9SOiP8dFTfopnPBaOpQQcchMasCpZ/3v1EWzEi2RIAb8UiQKPQWzNvUARlGmlWuyZzQ==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/middleware-flexible-checksums@3.974.27':
-    resolution: {integrity: sha512-bZqezPLdllFC4VAeV/f+EIc/hz56ab3TD/+4zNCgOgmG5ZHAE5dMHrX1gtTwdcQXbPr3KR7x3zTC3zuCTE6+ng==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/middleware-host-header@3.972.19':
-    resolution: {integrity: sha512-08DkRJIr+RlzPhctrCv2zKLGW4RiF7IfgkhF6zvVRCtZkZ3yeojHG1wX/g4k5ujYdQxtEz4ifR48ZlC1eIwSmg==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/middleware-location-constraint@3.972.14':
-    resolution: {integrity: sha512-FcHrGhxZCFbWvkZ6VXSbjzAthO79NSvnjzHTvH6ai1ncyXJgZiqepgAwCUq1MxakIAHwjid+WJvkMUmQtyGtuA==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/middleware-logger@3.972.18':
-    resolution: {integrity: sha512-BRt6kXBrm5PSvTNr9aApq9qavKIVhInDRiNC9K7lGi7OT2yJW2ELnawElZWxImktLsKYDdiF94SM0lxoffJKUw==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/middleware-recursion-detection@3.972.20':
-    resolution: {integrity: sha512-hHEA/yuAcFk51MvQveT42OTv6w5EZ/hX/nWjy1p3a8sX5QQJQY6c/Wq5Wkh5V9xxveFg1Zjchp/op43Npx945w==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/middleware-sdk-s3@3.972.48':
-    resolution: {integrity: sha512-MRTqx8wD/T3REt6LTT3/yN8rrp6+xIHrbUekkDYJTYWVch70mwtdJBovR4qKJz1jIPlbN+9R/Sn6R04BfsglzA==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/middleware-ssec@3.972.14':
-    resolution: {integrity: sha512-T29abTnUuKa0Wt3DjXcx5vK/0OkNruLhiP9rbo668nxGXpyeulpxT3gpN22j/51MPFi8dAsgtz4Bpya1NT4EhQ==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/middleware-user-agent@3.972.48':
-    resolution: {integrity: sha512-DGvRUTu8IVQ+/918JHLb5xebJLK+8y4r+Spe4xj8OkyYieOpG/UxTCa8UpuzV5hxX3LCgK0MtklGN0qsYhXqIQ==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/nested-clients@3.997.17':
-    resolution: {integrity: sha512-lDRgraoTfKRawUyc176Ow93mrNrOho/x+EoK4C+lKU+vKkHWhNhzvSMVAx0WEJUJoeQxxDN5ZdKMfiGEyNejig==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/region-config-resolver@3.972.22':
-    resolution: {integrity: sha512-4dB88prnKR5YkD/o5gQLnHVii44xo3tjn2COy5UWcZvOl7TJK90kiHH6QR2kaC4hFH3KkXZKpPR0gEbUhXp3TA==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/signature-v4-multi-region@3.996.32':
-    resolution: {integrity: sha512-llvApLcsWtmRFhG2wT3WIp1CmDeRaIYutqty1ZZXoMzK7TiJ6MOLOimk9eXUS8PwgG4ew4pa4QAbt0lfhn++1w==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/token-providers@3.1063.0':
-    resolution: {integrity: sha512-nYDaWWdzjKiDP5xj8k4oUgcYd4WPgzfAOgdU5vJsaqH/07Dfvm7ffisHCFJ+NEl7kUC9JEIUxh0kznvenbo3NQ==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/types@3.973.11':
-    resolution: {integrity: sha512-YjS0qFuECClRh4qhEyW8XagW0fwEPBeZ1cfsW/gU73Kh/ExFILxbzxOfPCmzF/2DwEvhvsHYt0b0qnvStwKYrg==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/util-endpoints@3.996.17':
-    resolution: {integrity: sha512-2bp/vOZcxPXnsRtAGj6famUxlJ7lzGlCHgeCLufDeZUtHWneqeA70lxRNuhx6JNWOfzrJwweb099Xf4WGzP1bw==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/util-locate-window@3.965.6':
-    resolution: {integrity: sha512-ZfHjfwSzeXj+Lg9AK5ZNmeDkXev6V+w2tn1t4kgDdRtUaRCthepTQiFwbD06EF9oNGH4LaLg+Mb6U16Ypv5bSw==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/util-user-agent-browser@3.972.19':
-    resolution: {integrity: sha512-7Eu2HD1IHHktBorfwGUL6xrzcPPZ4lnu6TkNTcrpKaPPpeQ/hNuoO1UNw8NTKp68LwLuxfC5BZ7esoVBGBRuSg==}
-
-  '@aws-sdk/util-user-agent-node@3.973.34':
-    resolution: {integrity: sha512-smIFIUsRPSiRIBdUpXu+Y9VvtnIJQBQLU5KS0D4tOIjLKuq/3W7v7jpKdfETw1mxfQqynsvBE1+L1JsZDR4vnw==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/xml-builder@3.972.28':
-    resolution: {integrity: sha512-lI/l3c/vPvsxmspzV63NfS3x9q4CkMmdhJy4QiM+NThAufVkDvi/PZZQ6xETnICL0UD7jI808pY83gllf86RFg==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws/lambda-invoke-store@0.2.4':
-    resolution: {integrity: sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==}
-    engines: {node: '>=18.0.0'}
-
-  '@discordjs/builders@1.14.1':
-    resolution: {integrity: sha512-gSKkhXLqs96TCzk66VZuHHl8z2bQMJFGwrXC0f33ngK+FLNau4hU1PYny3DNJfNdSH+gVMzE85/d5FQ2BpcNwQ==}
-    engines: {node: '>=16.11.0'}
-
-  '@discordjs/collection@1.5.3':
-    resolution: {integrity: sha512-SVb428OMd3WO1paV3rm6tSjM4wC+Kecaa1EUGX7vc6/fddvw/6lg90z4QtCqm21zvVe92vMMDt9+DkIvjXImQQ==}
-    engines: {node: '>=16.11.0'}
-
-  '@discordjs/collection@2.1.1':
-    resolution: {integrity: sha512-LiSusze9Tc7qF03sLCujF5iZp7K+vRNEDBZ86FT9aQAv3vxMLihUvKvpsCWiQ2DJq1tVckopKm1rxomgNUc9hg==}
-    engines: {node: '>=18'}
-
-  '@discordjs/formatters@0.6.2':
-    resolution: {integrity: sha512-y4UPwWhH6vChKRkGdMB4odasUbHOUwy7KL+OVwF86PvT6QVOwElx+TiI1/6kcmcEe+g5YRXJFiXSXUdabqZOvQ==}
-    engines: {node: '>=16.11.0'}
-
-  '@discordjs/rest@2.6.1':
-    resolution: {integrity: sha512-wwQdgjeaoYFiaG+atbqx6aJDpqW7JHAo0HrQkBTbYzM3/PJ3GweQIpgElNcGZ26DCUOXMyawYd0YF7vtr+fZXg==}
-    engines: {node: '>=18'}
-
-  '@discordjs/util@1.2.0':
-    resolution: {integrity: sha512-3LKP7F2+atl9vJFhaBjn4nOaSWahZ/yWjOvA4e5pnXkt2qyXRCHLxoBQy81GFtLGCq7K9lPm9R517M1U+/90Qg==}
-    engines: {node: '>=18'}
-
-  '@discordjs/ws@1.2.3':
-    resolution: {integrity: sha512-wPlQDxEmlDg5IxhJPuxXr3Vy9AjYq5xCvFWGJyD7w7Np8ZGu+Mc+97LCoEc/+AYCo2IDpKioiH0/c/mj5ZR9Uw==}
-    engines: {node: '>=16.11.0'}
-
-  '@electric-sql/pglite-socket@0.1.1':
-    resolution: {integrity: sha512-p2hoXw3Z3LQHwTeikdZNsFBOvXGqKY2hk51BBw+8NKND8eoH+8LFOtW9Z8CQKmTJ2qqGYu82ipqiyFZOTTXNfw==}
-    hasBin: true
-    peerDependencies:
-      '@electric-sql/pglite': 0.4.1
-
-  '@electric-sql/pglite-tools@0.3.1':
-    resolution: {integrity: sha512-C+T3oivmy9bpQvSxVqXA1UDY8cB9Eb9vZHL9zxWwEUfDixbXv4G3r2LjoTdR33LD8aomR3O9ZXEO3XEwr/cUCA==}
-    peerDependencies:
-      '@electric-sql/pglite': 0.4.1
-
-  '@electric-sql/pglite@0.4.1':
-    resolution: {integrity: sha512-mZ9NzzUSYPOCnxHH1oAHPRzoMFJHY472raDKwXl/+6oPbpdJ7g8LsCN4FSaIIfkiCKHhb3iF/Zqo3NYxaIhU7Q==}
-
-  '@eliyya/flagged-bitfield@1.1.1':
-    resolution: {integrity: sha512-E7oOtJGwGiCn2y5Zc87eLFXFV8B21/PrWlroD2KYPDu3d3qR4tKCTFyhYXKJqr9D2q4FbYpC4OtBdvkvvtCO/Q==}
-
-  '@epic-web/invariant@1.0.0':
-    resolution: {integrity: sha512-lrTPqgvfFQtR/eY/qkIzp98OGdNJu0m5ji3q/nJI8v3SXkRKEnWiOxMmbvcSoAIzv/cGiuvRy57k4suKQSAdwA==}
-
-  '@eslint-community/eslint-utils@4.9.1':
-    resolution: {integrity: sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
-
-  '@eslint-community/regexpp@4.12.2':
-    resolution: {integrity: sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==}
-    engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
-
-  '@eslint/config-array@0.23.5':
-    resolution: {integrity: sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA==}
-    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
-
-  '@eslint/config-helpers@0.5.5':
-    resolution: {integrity: sha512-eIJYKTCECbP/nsKaaruF6LW967mtbQbsw4JTtSVkUQc9MneSkbrgPJAbKl9nWr0ZeowV8BfsarBmPpBzGelA2w==}
-    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
-
-  '@eslint/core@1.2.1':
-    resolution: {integrity: sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==}
-    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
-
-  '@eslint/js@10.0.1':
-    resolution: {integrity: sha512-zeR9k5pd4gxjZ0abRoIaxdc7I3nDktoXZk2qOv9gCNWx3mVwEn32VRhyLaRsDiJjTs0xq/T8mfPtyuXu7GWBcA==}
-    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
-    peerDependencies:
-      eslint: ^10.0.0
-    peerDependenciesMeta:
-      eslint:
-        optional: true
-
-  '@eslint/json@1.2.0':
-    resolution: {integrity: sha512-CEFEyNgvzu8zn5QwVYDg3FaG+ZKUeUsNYitFpMYJAqoAlnw68EQgNbUfheSmexZr4n0wZPrAkPLuvsLaXO6wRw==}
-    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
-
-  '@eslint/object-schema@3.0.5':
-    resolution: {integrity: sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw==}
-    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
-
-  '@eslint/plugin-kit@0.6.1':
-    resolution: {integrity: sha512-iH1B076HoAshH1mLpHMgwdGeTs0CYwL0SPMkGuSebZrwBp16v415e9NZXg2jtrqPVQjf6IANe2Vtlr5KswtcZQ==}
-    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
-
-  '@eslint/plugin-kit@0.7.2':
-    resolution: {integrity: sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A==}
-    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
-
-  '@hono/node-server@1.19.11':
-    resolution: {integrity: sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==}
-    engines: {node: '>=18.14.1'}
-    peerDependencies:
-      hono: ^4
-
-  '@humanfs/core@0.19.2':
-    resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
-    engines: {node: '>=18.18.0'}
-
-  '@humanfs/node@0.16.8':
-    resolution: {integrity: sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==}
-    engines: {node: '>=18.18.0'}
-
-  '@humanfs/types@0.15.0':
-    resolution: {integrity: sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==}
-    engines: {node: '>=18.18.0'}
-
-  '@humanwhocodes/module-importer@1.0.1':
-    resolution: {integrity: sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==}
-    engines: {node: '>=12.22'}
-
-  '@humanwhocodes/momoa@3.3.10':
-    resolution: {integrity: sha512-KWiFQpSAqEIyrTXko3hFNLeQvSK8zXlJQzhhxsyVn58WFRYXST99b3Nqnu+ttOtjds2Pl2grUHGpe2NzhPynuQ==}
-    engines: {node: '>=18'}
-
-  '@humanwhocodes/retry@0.4.3':
-    resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
-    engines: {node: '>=18.18'}
-
-  '@js-temporal/polyfill@0.5.1':
-    resolution: {integrity: sha512-hloP58zRVCRSpgDxmqCWJNlizAlUgJFqG2ypq79DCvyv9tHjRYMDOcPFjzfl/A1/YxDvRCZz8wvZvmapQnKwFQ==}
-    engines: {node: '>=12'}
-
-  '@kurkle/color@0.3.4':
-    resolution: {integrity: sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==}
-
-  '@nodable/entities@2.1.1':
-    resolution: {integrity: sha512-Pig3HxDIoMgjdEH8OCf/dkcTmLFjJRjWuq8jSnklu284/TKOPibSRERmOykiwmyXTtv61mP+44f3GMx0tLAyjg==}
-
-  '@phc/format@1.0.0':
-    resolution: {integrity: sha512-m7X9U6BG2+J+R1lSOdCiITLLrxm+cWlNI3HUFA92oLO77ObGNzaKdh8pMLqdZcshtkKuV84olNNXDfMc4FezBQ==}
-    engines: {node: '>=10'}
-
-  '@pinojs/redact@0.4.0':
-    resolution: {integrity: sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==}
-
-  '@prisma/adapter-pg@7.8.0':
-    resolution: {integrity: sha512-ygb3UkerK3v8MDpXVgCISdRNDozpxh6+JVJgiIGbSr5KBgz10LLf5ejUskPGoXlsIjxsOu6nuy1JVQr2EKGSlg==}
-
-  '@prisma/client-runtime-utils@7.8.0':
-    resolution: {integrity: sha512-5NQZztQ0oY/ADFkmd9gPuweH5A1/CCY8YQPorLLO0Mu6a87mY5gsnDkzmFmIHs9NFaLnZojzgddFVN4RpKYrdw==}
-
-  '@prisma/client@7.8.0':
-    resolution: {integrity: sha512-HFp3Dawv/3sU3JtlPha90IB+48lS7zHiH4LKZPjmcE8YH5P9DOXGPvo8dqOtO7MqLDd1p2hOWMcFlRT1DMblHw==}
-    engines: {node: ^20.19 || ^22.12 || >=24.0}
-    peerDependencies:
-      prisma: '*'
-      typescript: '>=5.4.0'
-    peerDependenciesMeta:
-      prisma:
-        optional: true
-      typescript:
-        optional: true
-
-  '@prisma/config@7.8.0':
-    resolution: {integrity: sha512-HFESzd9rx2ZQxlK+TL7tu1HPvCqrHiL6LCxYykI2c34mvaUuIVVl3lYuicJD/MNnzgPnyeBEMlK4WTomJCV5jw==}
-
-  '@prisma/debug@7.2.0':
-    resolution: {integrity: sha512-YSGTiSlBAVJPzX4ONZmMotL+ozJwQjRmZweQNIq/ER0tQJKJynNkRB3kyvt37eOfsbMCXk3gnLF6J9OJ4QWftw==}
-
-  '@prisma/debug@7.8.0':
-    resolution: {integrity: sha512-p+QZReysDUqXC+mk17q9a+Y/qzh4c2KYliDK30buYUyfrGeTGSyfmc0AIrJRhZJrLHhRiJa9Au/J72h3C+szvA==}
-
-  '@prisma/dev@0.24.3':
-    resolution: {integrity: sha512-ffHlQuKXZiaDt9Go0OnCTdJZrHxK0k7omJKNV86/VjpsXu5EIHZLK0T7JSWgvNlJwh56kW9JFu9v0qJciFzepg==}
-
-  '@prisma/driver-adapter-utils@7.8.0':
-    resolution: {integrity: sha512-/Q13o0ZT0rjc1Xk0Q9KhZYwuq2EW/vSbWUBKfgEKkaCuB/Sg6bqnjmTZqC5cD4d6y1vfFAEwBRzfzoSMIVJ55A==}
-
-  '@prisma/engines-version@7.8.0-6.3c6e192761c0362d496ed980de936e2f3cebcd3a':
-    resolution: {integrity: sha512-fJPQxCkLgA5EayWaW8eArgCvjJ+N+Kz3VyeNKMEeYiQC4alNkxRKFVAGxv/ZUzuJISKqdw+zGeDbS6mn6RCPOA==}
-
-  '@prisma/engines@7.8.0':
-    resolution: {integrity: sha512-jx3rCnNNrt5uzbkKlegtQ2GZHxSlihMCzutgT/BP6UIDF1r9tDI39hV/0T/cHZgzJ3ELbuQPXlVZy+Y1n0pcgw==}
-
-  '@prisma/fetch-engine@7.8.0':
-    resolution: {integrity: sha512-gwB0Euiz/DDRyxFRpLXYlK3RfaZUj1c5dAYMuhZYfApg7arknJlcb9bIsOHDppJmbqYaVA+yBIiFMDBfprsNPQ==}
-
-  '@prisma/get-platform@7.2.0':
-    resolution: {integrity: sha512-k1V0l0Td1732EHpAfi2eySTezyllok9dXb6UQanajkJQzPUGi3vO2z7jdkz67SypFTdmbnyGYxvEvYZdZsMAVA==}
-
-  '@prisma/get-platform@7.8.0':
-    resolution: {integrity: sha512-WlxgRGnolL8VH2EmkH1R/DkKNr/mVdS3G2h42IZFFZ3eUrH9OT6t73kIOSlkkrv50wG123Iq8d96ufv5LlZktw==}
-
-  '@prisma/query-plan-executor@7.2.0':
-    resolution: {integrity: sha512-EOZmNzcV8uJ0mae3DhTsiHgoNCuu1J9mULQpGCh62zN3PxPTd+qI9tJvk5jOst8WHKQNwJWR3b39t0XvfBB0WQ==}
-
-  '@prisma/streams-local@0.1.2':
-    resolution: {integrity: sha512-l49yTxKKF2odFxaAXTmwmkBKL3+bVQ1tFOooGifu4xkdb9NMNLxHj27XAhTylWZod8I+ISGM5erU1xcl/oBCtg==}
-    engines: {bun: '>=1.3.6', node: '>=22.0.0'}
-
-  '@prisma/studio-core@0.27.3':
-    resolution: {integrity: sha512-AADjNFPdsrglxHQVTmHFqv6DuKQZ5WY4p5/gVFY017twvNrSwpLJ9lqUbYYxEu2W7nbvVxTZA8deJ8LseNALsw==}
-    engines: {node: ^20.19 || ^22.12 || >=24.0, pnpm: '8'}
-    peerDependencies:
-      '@types/react': ^18.0.0 || ^19.0.0
-      react: ^18.0.0 || ^19.0.0
-      react-dom: ^18.0.0 || ^19.0.0
-
-  '@radix-ui/primitive@1.1.3':
-    resolution: {integrity: sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==}
-
-  '@radix-ui/react-compose-refs@1.1.2':
-    resolution: {integrity: sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==}
-    peerDependencies:
-      '@types/react': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-
-  '@radix-ui/react-primitive@2.1.3':
-    resolution: {integrity: sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==}
-    peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
-  '@radix-ui/react-slot@1.2.3':
-    resolution: {integrity: sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==}
-    peerDependencies:
-      '@types/react': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-
-  '@radix-ui/react-toggle@1.1.10':
-    resolution: {integrity: sha512-lS1odchhFTeZv3xwHH31YPObmJn8gOg7Lq12inrr0+BH/l3Tsq32VfjqH1oh80ARM3mlkfMic15n0kg4sD1poQ==}
-    peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
-  '@radix-ui/react-use-controllable-state@1.2.2':
-    resolution: {integrity: sha512-BjasUjixPFdS+NKkypcyyN5Pmg83Olst0+c6vGov0diwTEo6mgdqVR6hxcEgFuh4QrAs7Rc+9KuGJ9TVCj0Zzg==}
-    peerDependencies:
-      '@types/react': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-
-  '@radix-ui/react-use-effect-event@0.0.2':
-    resolution: {integrity: sha512-Qp8WbZOBe+blgpuUT+lw2xheLP8q0oatc9UpmiemEICxGvFLYmHm9QowVZGHtJlGbS6A6yJ3iViad/2cVjnOiA==}
-    peerDependencies:
-      '@types/react': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-
-  '@radix-ui/react-use-layout-effect@1.1.1':
-    resolution: {integrity: sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==}
-    peerDependencies:
-      '@types/react': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-
-  '@rollup/rollup-linux-x64-gnu@4.61.1':
-    resolution: {integrity: sha512-bVWIOIk6pV01p4CdUbPP7CJ/434z+OooYjDuFcR+44N35YvKUC66G8MGnvcWx5mWKW3g61J+t74l3Kj15Kwn2Q==}
-    cpu: [x64]
-    os: [linux]
-    libc: [glibc]
-
-  '@rtsao/scc@1.1.0':
-    resolution: {integrity: sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==}
-
-  '@sapphire/async-queue@1.5.5':
-    resolution: {integrity: sha512-cvGzxbba6sav2zZkH8GPf2oGk9yYoD5qrNWdu9fRehifgnFZJMV+nuy2nON2roRO4yQQ+v7MK/Pktl/HgfsUXg==}
-    engines: {node: '>=v14.0.0', npm: '>=7.0.0'}
-
-  '@sapphire/shapeshift@4.0.0':
-    resolution: {integrity: sha512-d9dUmWVA7MMiKobL3VpLF8P2aeanRTu6ypG2OIaEv/ZHH/SUQ2iHOVyi5wAPjQ+HmnMuL0whK9ez8I/raWbtIg==}
-    engines: {node: '>=v16'}
-
-  '@sapphire/snowflake@3.5.3':
-    resolution: {integrity: sha512-jjmJywLAFoWeBi1W7994zZyiNWPIiqRRNAmSERxyg93xRGzNYvGjlZ0gR6x0F4gPRi2+0O6S71kOZYyr3cxaIQ==}
-    engines: {node: '>=v14.0.0', npm: '>=7.0.0'}
-
-  '@sapphire/snowflake@3.5.5':
-    resolution: {integrity: sha512-xzvBr1Q1c4lCe7i6sRnrofxeO1QTP/LKQ6A6qy0iB4x5yfiSfARMEQEghojzTNALDTcv8En04qYNIco9/K9eZQ==}
-    engines: {node: '>=v14.0.0', npm: '>=7.0.0'}
-
-  '@smithy/config-resolver@4.5.6':
-    resolution: {integrity: sha512-AXbvUX9aNY2qCLOMCikpl1Df5w2CNFEqbEb6XafG81FJbAbB8avIT7BOx1KDqiO86J/38qKQ3YuakfAfY3iBkQ==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/core@3.24.6':
-    resolution: {integrity: sha512-wBXDRup6UU97VKyaiRo8AssnfStPtG0oAAfpq/bC0a1YYau8pM86YB4kM6ccoVi1mS8l/UHbn9oDM+7uozr/ug==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/credential-provider-imds@4.3.8':
-    resolution: {integrity: sha512-5cAM+KZC02sTqDt6NaLXyu50M/GNMd1eTzDVR8Lb0BBsVtu7RWHo47VPPEEv1vt3Yub6uzr+M5FHC+GtoT0USg==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/eventstream-serde-browser@4.3.6':
-    resolution: {integrity: sha512-BQao/dBhLCJqo953N1hadkcF3M/9G+i6qIgnMupfdpBQomwyhfV7Xfc5jjpCkm8HxfzaWAGrM/2nNnzronFqVQ==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/eventstream-serde-config-resolver@4.4.6':
-    resolution: {integrity: sha512-OUoNRXJGZMM4ivoU7QIzOvCLbavD1YnadNEairrtYhTi+gmGhyn3c2wToL9CxEs4Cw2Ab/KeQM39T1K+/e9YdQ==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/eventstream-serde-node@4.3.6':
-    resolution: {integrity: sha512-M6FeKRMi3oecpTy4EL5n1hLPWydw+xInFYQIzjbGYGBnFtW7IlJjnXrKr/Ev1GpMtmw44QCmrl8+ACEFPmRsIg==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/fetch-http-handler@5.4.6':
-    resolution: {integrity: sha512-FEwEYJ1jlBKdhe9TPzfghEi1bP55ZeEImlDkEa62bBBYzUcnB6RUCyuiS2mqKt6ZVjUbBgcNhzfIctH+Hevx9g==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/hash-blob-browser@4.3.6':
-    resolution: {integrity: sha512-/8D8rOFs2VEwvHwsx68sb6nE7XfVr2wbJTbC1YuKBHPhHeMnOt7IHxr7CoT5wBWujdV4fjVoLPn1BXXP4Ijlow==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/hash-node@4.3.6':
-    resolution: {integrity: sha512-lIZyQ7gDxURrnfkjalM0lKmDnfZYuPzNBYlkza3czPTQNVYsg4e0o90Zx/RpxhamKKOGsQGCsopp0ULsJqltNQ==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/hash-stream-node@4.3.6':
-    resolution: {integrity: sha512-Ziap41FoxpKqmlO9IE68NeFwPKhUJD4PVNcCQ2tl6IUCPSj0KykIuAPnJNWIQbWXvApwCauhRNlAFdt9KRvDpw==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/invalid-dependency@4.3.6':
-    resolution: {integrity: sha512-jUH1Eth7Sgn4KPBX5OKYDRpNjzul7AzsIhxKXT1rHXPTSfY00/7Kb9RtNil5SDAlPPsxaUiesR/rql2wjackmw==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/is-array-buffer@2.2.0':
-    resolution: {integrity: sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==}
-    engines: {node: '>=14.0.0'}
-
-  '@smithy/md5-js@4.3.6':
-    resolution: {integrity: sha512-LYcuBrO9oiajdRFHyFx3FJAWNKrP89s0grI6mcfpwTAeX2ZJ/9Xyi7Imghh9LT6CIcAy6/k6/MpoUiPNjXr1/w==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/middleware-content-length@4.3.6':
-    resolution: {integrity: sha512-nfpYCrzSFAgfIXmIHFTjOGNeTV3DVF5E5rfi3ZuNfsOjKSpePBOJF3rjyXlWYND0anvxVoqioIwClWCNdKt4Og==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/middleware-endpoint@4.5.6':
-    resolution: {integrity: sha512-zdG5bJZOiM2PRgL2lwcgui6uwZ+s5y6Qsk/rk05Q69sZJT6oi1x+v8Kn++V/q9VY94EgOtEe5kivpu+eGau0wQ==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/middleware-retry@4.6.6':
-    resolution: {integrity: sha512-MWppaYUlc+W4cU2JZnYuMFeOxCWbKO4A57BWti6aCb7hRBK3+CL6llADGpX084hjImsqr3EvCGewArOj7G81eA==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/middleware-serde@4.3.6':
-    resolution: {integrity: sha512-I3fPVYKKEog3a3qdqt1nttP1NBuQOAlNoQxEp6j5pMogSx0HHfid63difhcDgslV6p1XsTXG6D6ieTe13ycJtQ==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/middleware-stack@4.3.6':
-    resolution: {integrity: sha512-QhNiWfg47Kl4SJHmuQvnlzCtlD1eX1J7d/vuuttIE17Ra2YUKp9Srv5lCwa3OvoYaSNWMKYn0PjGIsfCLMJsEA==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/node-config-provider@4.4.6':
-    resolution: {integrity: sha512-M+gG6eQ0y073mSmNB+erRXJvwpsqsN72ol2w6vcd8FEKeG7pqYK0JvzfVqONkPj2ElBB2pg+cU13I850b//Wag==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/node-http-handler@4.7.7':
-    resolution: {integrity: sha512-ZAFvHXrEk6K180EVhmZVg8GU5pUH5BSFqRs27JW3j1qEFx9YyYwWFx17x/MHcjALYimGAji7qEOlF1++be+G5A==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/protocol-http@5.4.6':
-    resolution: {integrity: sha512-H6S7NyaaL+7qO8kIL7VQ7KyrGnKXdllGzJqvtp3hvDen25UOydKV51qGDVK0UciW125jV3CoLJQy/ihc0OEC6A==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/signature-v4@5.4.6':
-    resolution: {integrity: sha512-Ojg4B6oIDlIr1R86xCDJt1zJWnYa0VINmqdjfe9qxWjdRivHalZ3iSlQgVqYbW0MdpFOC5XfHEWsnbmdnpIILQ==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/smithy-client@4.13.6':
-    resolution: {integrity: sha512-tAf35/JW/DvMlACcazcoIOKOV0JBqyOvxjPTEME9W+m9wLcE0G1rwADc7Ntu38rY5C9OH8jZjpo4tbtjmIjEBQ==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/types@4.14.3':
-    resolution: {integrity: sha512-YupL0ZWmFtJexUN2cHzkvvF/b9pKrtAIfT1o7/oY/Ppu8IYeZ+lDPM5vZdQJaSeA132dJCqojjGC9NhXeF71VQ==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/url-parser@4.3.6':
-    resolution: {integrity: sha512-9MRJzwUrlswwHogOR7raDcykuzojZn74qGdQdbEQLVaixlvJuMiIT0g/CejKcmAIgrUVs8brBrnGtmYmBc0iuA==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/util-base64@4.4.6':
-    resolution: {integrity: sha512-V6ApAGvCQnb7Wy1Sy60AQc+7UOEaNQxvAXBLdMi5Zzm66cmX0srvfAxDmg7BGuJ+9H9ez0PPWS/AeFgWxwGavA==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/util-body-length-browser@4.3.6':
-    resolution: {integrity: sha512-+3vGcNHuvzuFLVWL9/wJgucOuQWufhuGhb3oxVDj9SWFGtwkOmtC2nFUwVC2IJoPe45uhs6TAb8bgE4IXDSPzA==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/util-body-length-node@4.3.6':
-    resolution: {integrity: sha512-T15zTQJ/xKYdS0/3CFckhz1QBbhxmhk/xjL6FKvHKgkJPN4E985If2FI9CcV2kh2v0sfiWMfXVEOKFbqgw4m4w==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/util-buffer-from@2.2.0':
-    resolution: {integrity: sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==}
-    engines: {node: '>=14.0.0'}
-
-  '@smithy/util-defaults-mode-browser@4.4.6':
-    resolution: {integrity: sha512-dRCZKu05AL7KQWrVuRJPotfjCRnvGkCjV56XNP067CRfyTtvgi/Ygu44qrBKb814Hsa52bWwDJ+Vt3pd04BjPA==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/util-defaults-mode-node@4.3.6':
-    resolution: {integrity: sha512-tTR8tayMoa0WeRhtMH7j3WpHUtggBXjh7rBdf7j6POYI69R85gpWBW6B32kaJRnlQU8+0gOGAzJj50S7SU1Egw==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/util-endpoints@3.5.6':
-    resolution: {integrity: sha512-kaB41eVUYC7ajVWUsZRqagxwRaa3VupjQ/Z2Z2v/Vffh/gJ/fFOS25s6mTyR2Lw1FrnBbRWo1iShR9BhekpPeQ==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/util-middleware@4.3.6':
-    resolution: {integrity: sha512-TrAgOcL63TRi7G92arTzq0n+VDrmZifwP1I1T9y2xU3lJpybsHdm33S2d3xaFfG0c8zJNIF9yYRqLSe6rbhH/A==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/util-retry@4.4.6':
-    resolution: {integrity: sha512-E/kFnvWQL6rIPr0Ucjk8oDgJSkKx2bv0nJkJ/cB3ywys7xCqeL1AXP9liHjgYONdQ+MKw/xT06IQK3vgbtu2Ww==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/util-stream@4.6.6':
-    resolution: {integrity: sha512-g+hQ45sPnaIDU4CnaG8EufmeWwziQlcpIvPG6hVY7v65RcUgasM63J/WNfSsXEcZ1zFu9rS/r/qqfDxkIrQtDw==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/util-utf8@2.3.0':
-    resolution: {integrity: sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==}
-    engines: {node: '>=14.0.0'}
-
-  '@smithy/util-utf8@4.3.6':
-    resolution: {integrity: sha512-tAa4sePYB7mlJzdYbdBqdv37KwFKWixmM/r3ihcI0HFOVjf+a5oGvtcLXcGm4S1bY4DFsLAIOHgjubtp+oRufw==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/util-waiter@4.4.6':
-    resolution: {integrity: sha512-oTt3OP9NcJkrySCSCCdSbP6XLSMNgOmt/ulaiYtb0Ng6tfEWtXQ1mwfyqmLd+GapmDUjbU2mgkf7QIq9H4ij/g==}
-    engines: {node: '>=18.0.0'}
-
-  '@standard-schema/spec@1.1.0':
-    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
-
-  '@triskcraft/api-types@1.2.1':
-    resolution: {integrity: sha512-WP0gPDxW60apUrdQ9y7FkZTzJgwI5nGPPSoR+eEa4Ec7EcfbgEOyZN+MUUd4u5kHWDKa4u/4th1YIMs5l48CZg==}
-    engines: {node: '>=24.14'}
-
-  '@types/body-parser@1.19.6':
-    resolution: {integrity: sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==}
-
-  '@types/busboy@1.5.4':
-    resolution: {integrity: sha512-kG7WrUuAKK0NoyxfQHsVE6j1m01s6kMma64E+OZenQABMQyTJop1DumUWcLwAQ2JzpefU7PDYoRDKl8uZosFjw==}
-
-  '@types/connect@3.4.38':
-    resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
-
-  '@types/cookie-parser@1.4.10':
-    resolution: {integrity: sha512-B4xqkqfZ8Wek+rCOeRxsjMS9OgvzebEzzLYw7NHYuvzb7IdxOkI0ZHGgeEBX4PUM7QGVvNSK60T3OvWj3YfBRg==}
-    peerDependencies:
-      '@types/express': '*'
-
-  '@types/cors@2.8.19':
-    resolution: {integrity: sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==}
-
-  '@types/esrecurse@4.3.1':
-    resolution: {integrity: sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==}
-
-  '@types/estree@1.0.9':
-    resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
-
-  '@types/express-serve-static-core@5.1.1':
-    resolution: {integrity: sha512-v4zIMr/cX7/d2BpAEX3KNKL/JrT1s43s96lLvvdTmza1oEvDudCqK9aF/djc/SWgy8Yh0h30TZx5VpzqFCxk5A==}
-
-  '@types/express@5.0.6':
-    resolution: {integrity: sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==}
-
-  '@types/http-errors@2.0.5':
-    resolution: {integrity: sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==}
-
-  '@types/json-schema@7.0.15':
-    resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
-
-  '@types/json5@0.0.29':
-    resolution: {integrity: sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==}
-
-  '@types/luxon@3.7.1':
-    resolution: {integrity: sha512-H3iskjFIAn5SlJU7OuxUmTEpebK6TKB8rxZShDslBMZJ5u9S//KM1sbdAisiSrqwLQncVjnpi2OK2J51h+4lsg==}
-
-  '@types/multer@2.1.0':
-    resolution: {integrity: sha512-zYZb0+nJhOHtPpGDb3vqPjwpdeGlGC157VpkqNQL+UU2qwoacoQ7MpsAmUptI/0Oa127X32JzWDqQVEXp2RcIA==}
-
-  '@types/node@25.6.0':
-    resolution: {integrity: sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==}
-
-  '@types/pg@8.20.0':
-    resolution: {integrity: sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==}
-
-  '@types/qs@6.15.1':
-    resolution: {integrity: sha512-GZHUBZR9hckSUhrxmp1nG6NwdpM9fCunJwyThLW1X3AyHgd9IlHb6VANpQQqDr2o/qQp6McZ3y/IA2rVzKzSbw==}
-
-  '@types/range-parser@1.2.7':
-    resolution: {integrity: sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==}
-
-  '@types/react@19.2.17':
-    resolution: {integrity: sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==}
-
-  '@types/send@1.2.1':
-    resolution: {integrity: sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==}
-
-  '@types/serve-static@2.2.0':
-    resolution: {integrity: sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ==}
-
-  '@types/ws@8.18.1':
-    resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
-
-  '@typescript-eslint/eslint-plugin@8.59.1':
-    resolution: {integrity: sha512-BOziFIfE+6osHO9FoJG4zjoHUcvI7fTNBSpdAwrNH0/TLvzjsk2oo8XSSOT2HhqUyhZPfHv4UOffoJ9oEEQ7Ag==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      '@typescript-eslint/parser': ^8.59.1
-      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
-      typescript: '>=4.8.4 <6.1.0'
-
-  '@typescript-eslint/parser@8.59.1':
-    resolution: {integrity: sha512-HDQH9O/47Dxi1ceDhBXdaldtf/WV9yRYMjbjCuNk3qnaTD564qwv61Y7+gTxwxRKzSrgO5uhtw584igXVuuZkA==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
-      typescript: '>=4.8.4 <6.1.0'
-
-  '@typescript-eslint/project-service@8.59.1':
-    resolution: {integrity: sha512-+MuHQlHiEr00Of/IQbE/MmEoi44znZHbR/Pz7Opq4HryUOlRi+/44dro9Ycy8Fyo+/024IWtw8m4JUMCGTYxDg==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      typescript: '>=4.8.4 <6.1.0'
-
-  '@typescript-eslint/scope-manager@8.59.1':
-    resolution: {integrity: sha512-LwuHQI4pDOYVKvmH2dkaJo6YZCSgouVgnS/z7yBPKBMvgtBvyLqiLy9Z6b7+m/TRcX1NFYUqZetI5Y+aT4GEfg==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  '@typescript-eslint/tsconfig-utils@8.59.1':
-    resolution: {integrity: sha512-/0nEyPbX7gRsk0Uwfe4ALwwgxuA66d/l2mhRDNlAvaj4U3juhUtJNq0DsY8M2AYwwb9rEq2hrC3IcIcEt++iJA==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      typescript: '>=4.8.4 <6.1.0'
-
-  '@typescript-eslint/type-utils@8.59.1':
-    resolution: {integrity: sha512-klWPBR2ciQHS3f++ug/mVnWKPjBUo7icEL3FAO1lhAR1Z1i5NQYZ1EannMSRYcq5qCv5wNALlXr6fksRHyYl7w==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
-      typescript: '>=4.8.4 <6.1.0'
-
-  '@typescript-eslint/types@8.59.1':
-    resolution: {integrity: sha512-ZDCjgccSdYPw5Bxh+my4Z0lJU96ZDN7jbBzvmEn0FZx3RtU1C7VWl6NbDx94bwY3V5YsgwRzJPOgeY2Q/nLG8A==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  '@typescript-eslint/typescript-estree@8.59.1':
-    resolution: {integrity: sha512-OUd+vJS05sSkOip+BkZ/2NS8RMxrAAJemsC6vU3kmfLyeaJT0TftHkV9mcx2107MmsBVXXexhVu4F0TZXyMl4g==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      typescript: '>=4.8.4 <6.1.0'
-
-  '@typescript-eslint/utils@8.59.1':
-    resolution: {integrity: sha512-3pIeoXhCeYH9FSCBI8P3iNwJlGuzPlYKkTlen2O9T1DSeeg8UG8jstq6BLk+Mda0qup7mgk4z4XL4OzRaxZ8LA==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
-      typescript: '>=4.8.4 <6.1.0'
-
-  '@typescript-eslint/visitor-keys@8.59.1':
-    resolution: {integrity: sha512-LdDNl6C5iJExcM0Yh0PwAIBb9PrSiCsWamF/JyEZawm3kFDnRoaq3LGE4bpyRao/fWeGKKyw7icx0YxrLFC5Cg==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  '@vladfrangu/async_event_emitter@2.4.7':
-    resolution: {integrity: sha512-Xfe6rpCTxSxfbswi/W/Pz7zp1WWSNn4A0eW4mLkQUewCrXXtMj31lCg+iQyTkh/CkusZSq9eDflu7tjEDXUY6g==}
-    engines: {node: '>=v14.0.0', npm: '>=7.0.0'}
-
-  accepts@2.0.0:
-    resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
-    engines: {node: '>= 0.6'}
-
-  acorn-jsx@5.3.2:
-    resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
-    peerDependencies:
-      acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
-
-  acorn@8.16.0:
-    resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
-    engines: {node: '>=0.4.0'}
-    hasBin: true
-
-  ajv@6.15.0:
-    resolution: {integrity: sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==}
-
-  ajv@8.20.0:
-    resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
-
-  argon2@0.44.0:
-    resolution: {integrity: sha512-zHPGN3S55sihSQo0dBbK0A5qpi2R31z7HZDZnry3ifOyj8bZZnpZND2gpmhnRGO1V/d555RwBqIK5W4Mrmv3ig==}
-    engines: {node: '>=16.17.0'}
-
-  array-buffer-byte-length@1.0.2:
-    resolution: {integrity: sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==}
-    engines: {node: '>= 0.4'}
-
-  array-includes@3.1.9:
-    resolution: {integrity: sha512-FmeCCAenzH0KH381SPT5FZmiA/TmpndpcaShhfgEN9eCVjnFBqq3l1xrI42y8+PPLI6hypzou4GXw00WHmPBLQ==}
-    engines: {node: '>= 0.4'}
-
-  array.prototype.findlastindex@1.2.6:
-    resolution: {integrity: sha512-F/TKATkzseUExPlfvmwQKGITM3DGTK+vkAsCZoDc5daVygbJBnjEUCbgkAvVFsgfXfX4YIqZ/27G3k3tdXrTxQ==}
-    engines: {node: '>= 0.4'}
-
-  array.prototype.flat@1.3.3:
-    resolution: {integrity: sha512-rwG/ja1neyLqCuGZ5YYrznA62D4mZXg0i1cIskIUKSiqF3Cje9/wXAls9B9s1Wa2fomMsIv8czB8jZcPmxCXFg==}
-    engines: {node: '>= 0.4'}
-
-  array.prototype.flatmap@1.3.3:
-    resolution: {integrity: sha512-Y7Wt51eKJSyi80hFrJCePGGNo5ktJCslFuboqJsbf57CCPcm5zztluPlc4/aD8sWsKvlwatezpV4U1efk8kpjg==}
-    engines: {node: '>= 0.4'}
-
-  arraybuffer.prototype.slice@1.0.4:
-    resolution: {integrity: sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==}
-    engines: {node: '>= 0.4'}
-
-  async-function@1.0.0:
-    resolution: {integrity: sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==}
-    engines: {node: '>= 0.4'}
-
-  atomic-sleep@1.0.0:
-    resolution: {integrity: sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==}
-    engines: {node: '>=8.0.0'}
-
-  available-typed-arrays@1.0.7:
-    resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
-    engines: {node: '>= 0.4'}
-
-  aws-ssl-profiles@1.1.2:
-    resolution: {integrity: sha512-NZKeq9AfyQvEeNlN0zSYAaWrmBffJh3IELMZfRpJVWgrpEbtEpnjvzqBPf+mxoI287JohRDoa+/nsfqqiZmF6g==}
-    engines: {node: '>= 6.0.0'}
-
-  balanced-match@1.0.2:
-    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
-
-  balanced-match@4.0.4:
-    resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
-    engines: {node: 18 || 20 || >=22}
-
-  base64-js@1.5.1:
-    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
-
-  better-result@2.9.2:
-    resolution: {integrity: sha512-WIFoBPCdnTOdk9inkE1ZRvCZ4P0CpSkAiLlchC65N7n9DcjZ3NhqkBOlafzpOVnO8ixyi37kicmSJ3ENhPZl7Q==}
-
-  body-parser@2.2.2:
-    resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
-    engines: {node: '>=18'}
-
-  bowser@2.14.1:
-    resolution: {integrity: sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==}
-
-  brace-expansion@1.1.15:
-    resolution: {integrity: sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==}
-
-  brace-expansion@5.0.6:
-    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
-    engines: {node: 18 || 20 || >=22}
-
-  buffer@5.6.0:
-    resolution: {integrity: sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==}
-
-  busboy@1.6.0:
-    resolution: {integrity: sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==}
-    engines: {node: '>=10.16.0'}
-
-  bytes@3.1.2:
-    resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
-    engines: {node: '>= 0.8'}
-
-  c12@3.3.4:
-    resolution: {integrity: sha512-cM0ApFQSBXuourJejzwv/AuPRvAxordTyParRVcHjjtXirtkzM0uK2L9TTn9s0cXZbG7E55jCivRQzoxYmRAlA==}
-    peerDependencies:
-      magicast: '*'
-    peerDependenciesMeta:
-      magicast:
-        optional: true
-
-  call-bind-apply-helpers@1.0.2:
-    resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
-    engines: {node: '>= 0.4'}
-
-  call-bind@1.0.9:
-    resolution: {integrity: sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==}
-    engines: {node: '>= 0.4'}
-
-  call-bound@1.0.4:
-    resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
-    engines: {node: '>= 0.4'}
-
-  chart.js@4.5.1:
-    resolution: {integrity: sha512-GIjfiT9dbmHRiYi6Nl2yFCq7kkwdkp1W/lp2J99rX0yo9tgJGn3lKQATztIjb5tVtevcBtIdICNWqlq5+E8/Pw==}
-    engines: {pnpm: '>=8'}
-
-  chokidar@5.0.0:
-    resolution: {integrity: sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==}
-    engines: {node: '>= 20.19.0'}
-
-  colorette@2.0.20:
-    resolution: {integrity: sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==}
-
-  concat-map@0.0.1:
-    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
-
-  confbox@0.2.4:
-    resolution: {integrity: sha512-ysOGlgTFbN2/Y6Cg3Iye8YKulHw+R2fNXHrgSmXISQdMnomY6eNDprVdW9R5xBguEqI954+S6709UyiO7B+6OQ==}
-
-  content-disposition@1.1.0:
-    resolution: {integrity: sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==}
-    engines: {node: '>=18'}
-
-  content-type@1.0.5:
-    resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
-    engines: {node: '>= 0.6'}
-
-  content-type@2.0.0:
-    resolution: {integrity: sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==}
-    engines: {node: '>=18'}
-
-  cookie-parser@1.4.7:
-    resolution: {integrity: sha512-nGUvgXnotP3BsjiLX2ypbQnWoGUPIIfHQNZkkC668ntrzGWEZVW70HDEB1qnNGMicPje6EttlIgzo51YSwNQGw==}
-    engines: {node: '>= 0.8.0'}
-
-  cookie-signature@1.0.6:
-    resolution: {integrity: sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==}
-
-  cookie-signature@1.2.2:
-    resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
-    engines: {node: '>=6.6.0'}
-
-  cookie@0.7.2:
-    resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
-    engines: {node: '>= 0.6'}
-
-  cors@2.8.6:
-    resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
-    engines: {node: '>= 0.10'}
-
-  cross-env@10.1.0:
-    resolution: {integrity: sha512-GsYosgnACZTADcmEyJctkJIoqAhHjttw7RsFrVoJNXbsWWqaq6Ym+7kZjq6mS45O0jij6vtiReppKQEtqWy6Dw==}
-    engines: {node: '>=20'}
-    hasBin: true
-
-  cross-spawn@7.0.6:
-    resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
-    engines: {node: '>= 8'}
-
-  csstype@3.2.3:
-    resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
-
-  data-view-buffer@1.0.2:
-    resolution: {integrity: sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==}
-    engines: {node: '>= 0.4'}
-
-  data-view-byte-length@1.0.2:
-    resolution: {integrity: sha512-tuhGbE6CfTM9+5ANGf+oQb72Ky/0+s3xKUpHvShfiz2RxMFgFPjsXuRLBVMtvMs15awe45SRb83D6wH4ew6wlQ==}
-    engines: {node: '>= 0.4'}
-
-  data-view-byte-offset@1.0.1:
-    resolution: {integrity: sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==}
-    engines: {node: '>= 0.4'}
-
-  dateformat@4.6.3:
-    resolution: {integrity: sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==}
-
-  debug@3.2.7:
-    resolution: {integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==}
-    peerDependencies:
-      supports-color: '*'
-    peerDependenciesMeta:
-      supports-color:
-        optional: true
-
-  debug@4.4.3:
-    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
-    engines: {node: '>=6.0'}
-    peerDependencies:
-      supports-color: '*'
-    peerDependenciesMeta:
-      supports-color:
-        optional: true
-
-  deep-is@0.1.4:
-    resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
-
-  deepmerge-ts@7.1.5:
-    resolution: {integrity: sha512-HOJkrhaYsweh+W+e74Yn7YStZOilkoPb6fycpwNLKzSPtruFs48nYis0zy5yJz1+ktUhHxoRDJ27RQAWLIJVJw==}
-    engines: {node: '>=16.0.0'}
-
-  define-data-property@1.1.4:
-    resolution: {integrity: sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==}
-    engines: {node: '>= 0.4'}
-
-  define-properties@1.2.1:
-    resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
-    engines: {node: '>= 0.4'}
-
-  defu@6.1.7:
-    resolution: {integrity: sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==}
-
-  denque@2.1.0:
-    resolution: {integrity: sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==}
-    engines: {node: '>=0.10'}
-
-  depd@2.0.0:
-    resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
-    engines: {node: '>= 0.8'}
-
-  destr@2.0.5:
-    resolution: {integrity: sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA==}
-
-  discord-api-types@0.38.48:
-    resolution: {integrity: sha512-WFUE/2o0lBlLeCQonQ+Pu2RqHAqbytBJ2RlXR91gzk05InSS6k9ShzzLYoymrA4c2oRgRKGE7/VqQJNNdGWSxQ==}
-
-  discord.js@14.26.3:
-    resolution: {integrity: sha512-XEKtYn28YFsiJ5l4fLRyikdbo6RD5oFyqfVHQlvXz2104JhH/E8slN28dbky05w3DCrJcNVWvhVvcJCTSl/KIg==}
-    engines: {node: '>=18'}
-
-  doctrine@2.1.0:
-    resolution: {integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==}
-    engines: {node: '>=0.10.0'}
-
-  dotenv@17.4.2:
-    resolution: {integrity: sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==}
-    engines: {node: '>=12'}
-
-  dunder-proto@1.0.1:
-    resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
-    engines: {node: '>= 0.4'}
-
-  ee-first@1.1.1:
-    resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
-
-  effect@3.20.0:
-    resolution: {integrity: sha512-qMLfDJscrNG8p/aw+IkT9W7fgj50Z4wG5bLBy0Txsxz8iUHjDIkOgO3SV0WZfnQbNG2VJYb0b+rDLMrhM4+Krw==}
-
-  empathic@2.0.0:
-    resolution: {integrity: sha512-i6UzDscO/XfAcNYD75CfICkmfLedpyPDdozrLMmQc5ORaQcdMoc21OnlEylMIqI7U8eniKrPMxxtj8k0vhmJhA==}
-    engines: {node: '>=14'}
-
-  encodeurl@2.0.0:
-    resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
-    engines: {node: '>= 0.8'}
-
-  end-of-stream@1.4.5:
-    resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
-
-  env-paths@3.0.0:
-    resolution: {integrity: sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
-
-  es-abstract@1.24.2:
-    resolution: {integrity: sha512-2FpH9Q5i2RRwyEP1AylXe6nYLR5OhaJTZwmlcP0dL/+JCbgg7yyEo/sEK6HeGZRf3dFpWwThaRHVApXSkW3xeg==}
-    engines: {node: '>= 0.4'}
-
-  es-define-property@1.0.1:
-    resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
-    engines: {node: '>= 0.4'}
-
-  es-errors@1.3.0:
-    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
-    engines: {node: '>= 0.4'}
-
-  es-object-atoms@1.1.2:
-    resolution: {integrity: sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==}
-    engines: {node: '>= 0.4'}
-
-  es-set-tostringtag@2.1.0:
-    resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
-    engines: {node: '>= 0.4'}
-
-  es-shim-unscopables@1.1.0:
-    resolution: {integrity: sha512-d9T8ucsEhh8Bi1woXCf+TIKDIROLG5WCkxg8geBCbvk22kzwC5G2OnXVMO6FUsvQlgUUXQ2itephWDLqDzbeCw==}
-    engines: {node: '>= 0.4'}
-
-  es-to-primitive@1.3.0:
-    resolution: {integrity: sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==}
-    engines: {node: '>= 0.4'}
-
-  escape-html@1.0.3:
-    resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
-
-  escape-string-regexp@4.0.0:
-    resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
-    engines: {node: '>=10'}
-
-  eslint-config-prettier@10.1.8:
-    resolution: {integrity: sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==}
-    hasBin: true
-    peerDependencies:
-      eslint: '>=7.0.0'
-
-  eslint-import-resolver-node@0.3.10:
-    resolution: {integrity: sha512-tRrKqFyCaKict5hOd244sL6EQFNycnMQnBe+j8uqGNXYzsImGbGUU4ibtoaBmv5FLwJwcFJNeg1GeVjQfbMrDQ==}
-
-  eslint-module-utils@2.13.0:
-    resolution: {integrity: sha512-bLohSkT6469rRs8czj0tLTD8vaeIS/whvPRJVjDr7IuoTT1k5DYDERlNycjDj/HkOlvQdYurmfZ/g3fG5bgeLQ==}
-    engines: {node: '>=4'}
-    peerDependencies:
-      '@typescript-eslint/parser': '*'
-      eslint: '*'
-      eslint-import-resolver-node: '*'
-      eslint-import-resolver-typescript: '*'
-      eslint-import-resolver-webpack: '*'
-    peerDependenciesMeta:
-      '@typescript-eslint/parser':
-        optional: true
-      eslint:
-        optional: true
-      eslint-import-resolver-node:
-        optional: true
-      eslint-import-resolver-typescript:
-        optional: true
-      eslint-import-resolver-webpack:
-        optional: true
-
-  eslint-plugin-import@2.32.0:
-    resolution: {integrity: sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==}
-    engines: {node: '>=4'}
-    peerDependencies:
-      '@typescript-eslint/parser': '*'
-      eslint: 10.2.1
-    peerDependenciesMeta:
-      '@typescript-eslint/parser':
-        optional: true
-
-  eslint-scope@9.1.2:
-    resolution: {integrity: sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==}
-    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
-
-  eslint-visitor-keys@3.4.3:
-    resolution: {integrity: sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-
-  eslint-visitor-keys@5.0.1:
-    resolution: {integrity: sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==}
-    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
-
-  eslint@10.2.1:
-    resolution: {integrity: sha512-wiyGaKsDgqXvF40P8mDwiUp/KQjE1FdrIEJsM8PZ3XCiniTMXS3OHWWUe5FI5agoCnr8x4xPrTDZuxsBlNHl+Q==}
-    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
-    hasBin: true
-    peerDependencies:
-      jiti: '*'
-    peerDependenciesMeta:
-      jiti:
-        optional: true
-
-  espree@11.2.0:
-    resolution: {integrity: sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==}
-    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
-
-  esquery@1.7.0:
-    resolution: {integrity: sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==}
-    engines: {node: '>=0.10'}
-
-  esrecurse@4.3.0:
-    resolution: {integrity: sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==}
-    engines: {node: '>=4.0'}
-
-  estraverse@5.3.0:
-    resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
-    engines: {node: '>=4.0'}
-
-  esutils@2.0.3:
-    resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
-    engines: {node: '>=0.10.0'}
-
-  etag@1.8.1:
-    resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
-    engines: {node: '>= 0.6'}
-
-  events@3.3.0:
-    resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
-    engines: {node: '>=0.8.x'}
-
-  express@5.2.1:
-    resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
-    engines: {node: '>= 18'}
-
-  exsolve@1.0.8:
-    resolution: {integrity: sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==}
-
-  fast-check@3.23.2:
-    resolution: {integrity: sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A==}
-    engines: {node: '>=8.0.0'}
-
-  fast-copy@4.0.3:
-    resolution: {integrity: sha512-58apWr0GUiDFM8+3afrO6eYwJBn9ZAhDOzG3L+/9llab/haCARS2UIfffmOurYLwbgDRs8n0rfr6qAAPEAuAQw==}
-
-  fast-deep-equal@3.1.3:
-    resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
-
-  fast-json-stable-stringify@2.1.0:
-    resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
-
-  fast-levenshtein@2.0.6:
-    resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
-
-  fast-safe-stringify@2.1.1:
-    resolution: {integrity: sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==}
-
-  fast-uri@3.1.2:
-    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
-
-  fast-xml-builder@1.2.0:
-    resolution: {integrity: sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==}
-
-  fast-xml-parser@5.7.3:
-    resolution: {integrity: sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg==}
-    hasBin: true
-
-  fdir@6.5.0:
-    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
-    engines: {node: '>=12.0.0'}
-    peerDependencies:
-      picomatch: ^3 || ^4
-    peerDependenciesMeta:
-      picomatch:
-        optional: true
-
-  file-entry-cache@8.0.0:
-    resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
-    engines: {node: '>=16.0.0'}
-
-  finalhandler@2.1.1:
-    resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
-    engines: {node: '>= 18.0.0'}
-
-  find-up@5.0.0:
-    resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
-    engines: {node: '>=10'}
-
-  flat-cache@4.0.1:
-    resolution: {integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==}
-    engines: {node: '>=16'}
-
-  flatted@3.4.2:
-    resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
-
-  for-each@0.3.5:
-    resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
-    engines: {node: '>= 0.4'}
-
-  foreground-child@3.3.1:
-    resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
-    engines: {node: '>=14'}
-
-  forwarded@0.2.0:
-    resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
-    engines: {node: '>= 0.6'}
-
-  fresh@2.0.0:
-    resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
-    engines: {node: '>= 0.8'}
-
-  function-bind@1.1.2:
-    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
-
-  function.prototype.name@1.1.8:
-    resolution: {integrity: sha512-e5iwyodOHhbMr/yNrc7fDYG4qlbIvI5gajyzPnb5TCwyhjApznQh1BMFou9b30SevY43gCJKXycoCBjMbsuW0Q==}
-    engines: {node: '>= 0.4'}
-
-  functions-have-names@1.2.3:
-    resolution: {integrity: sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==}
-
-  generate-function@2.3.1:
-    resolution: {integrity: sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==}
-
-  generator-function@2.0.1:
-    resolution: {integrity: sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==}
-    engines: {node: '>= 0.4'}
-
-  get-intrinsic@1.3.0:
-    resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
-    engines: {node: '>= 0.4'}
-
-  get-port-please@3.2.0:
-    resolution: {integrity: sha512-I9QVvBw5U/hw3RmWpYKRumUeaDgxTPd401x364rLmWBJcOQ753eov1eTgzDqRG9bqFIfDc7gfzcQEWrUri3o1A==}
-
-  get-proto@1.0.1:
-    resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
-    engines: {node: '>= 0.4'}
-
-  get-symbol-description@1.1.0:
-    resolution: {integrity: sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg==}
-    engines: {node: '>= 0.4'}
-
-  giget@3.2.0:
-    resolution: {integrity: sha512-GvHTWcykIR/fP8cj8dMpuMMkvaeJfPvYnhq0oW+chSeIr+ldX21ifU2Ms6KBoyKZQZmVaUAAhQ2EZ68KJF8a7A==}
-    hasBin: true
-
-  glob-parent@6.0.2:
-    resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
-    engines: {node: '>=10.13.0'}
-
-  globals@17.5.0:
-    resolution: {integrity: sha512-qoV+HK2yFl/366t2/Cb3+xxPUo5BuMynomoDmiaZBIdbs+0pYbjfZU+twLhGKp4uCZ/+NbtpVepH5bGCxRyy2g==}
-    engines: {node: '>=18'}
-
-  globalthis@1.0.4:
-    resolution: {integrity: sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==}
-    engines: {node: '>= 0.4'}
-
-  gopd@1.2.0:
-    resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
-    engines: {node: '>= 0.4'}
-
-  graceful-fs@4.2.11:
-    resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
-
-  grammex@3.1.12:
-    resolution: {integrity: sha512-6ufJOsSA7LcQehIJNCO7HIBykfM7DXQual0Ny780/DEcJIpBlHRvcqEBWGPYd7hrXL2GJ3oJI1MIhaXjWmLQOQ==}
-
-  graphmatch@1.1.1:
-    resolution: {integrity: sha512-5ykVn/EXM1hF0XCaWh05VbYvEiOL2lY1kBxZtaYsyvjp7cmWOU1XsAdfQBwClraEofXDT197lFbXOEVMHpvQOg==}
-
-  has-bigints@1.1.0:
-    resolution: {integrity: sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==}
-    engines: {node: '>= 0.4'}
-
-  has-property-descriptors@1.0.2:
-    resolution: {integrity: sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==}
-
-  has-proto@1.2.0:
-    resolution: {integrity: sha512-KIL7eQPfHQRC8+XluaIw7BHUwwqL19bQn4hzNgdr+1wXoU0KKj6rufu47lhY7KbJR2C6T6+PfyN0Ea7wkSS+qQ==}
-    engines: {node: '>= 0.4'}
-
-  has-symbols@1.1.0:
-    resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
-    engines: {node: '>= 0.4'}
-
-  has-tostringtag@1.0.2:
-    resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
-    engines: {node: '>= 0.4'}
-
-  hasown@2.0.4:
-    resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
-    engines: {node: '>= 0.4'}
-
-  help-me@5.0.0:
-    resolution: {integrity: sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg==}
-
-  hono@4.12.23:
-    resolution: {integrity: sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA==}
-    engines: {node: '>=16.9.0'}
-
-  http-errors@2.0.1:
-    resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
-    engines: {node: '>= 0.8'}
-
-  http-status-codes@2.3.0:
-    resolution: {integrity: sha512-RJ8XvFvpPM/Dmc5SV+dC4y5PCeOhT3x1Hq0NU3rjGeg5a/CqlhZ7uudknPwZFz4aeAXDcbAyaeP7GAo9lvngtA==}
-
-  iconv-lite@0.7.2:
-    resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
-    engines: {node: '>=0.10.0'}
-
-  ieee754@1.2.1:
-    resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
-
-  ignore@5.3.2:
-    resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
-    engines: {node: '>= 4'}
-
-  ignore@7.0.5:
-    resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
-    engines: {node: '>= 4'}
-
-  imurmurhash@0.1.4:
-    resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
-    engines: {node: '>=0.8.19'}
-
-  inherits@2.0.4:
-    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
-
-  internal-slot@1.1.0:
-    resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
-    engines: {node: '>= 0.4'}
-
-  ipaddr.js@1.9.1:
-    resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
-    engines: {node: '>= 0.10'}
-
-  is-array-buffer@3.0.5:
-    resolution: {integrity: sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==}
-    engines: {node: '>= 0.4'}
-
-  is-async-function@2.1.1:
-    resolution: {integrity: sha512-9dgM/cZBnNvjzaMYHVoxxfPj2QXt22Ev7SuuPrs+xav0ukGB0S6d4ydZdEiM48kLx5kDV+QBPrpVnFyefL8kkQ==}
-    engines: {node: '>= 0.4'}
-
-  is-bigint@1.1.0:
-    resolution: {integrity: sha512-n4ZT37wG78iz03xPRKJrHTdZbe3IicyucEtdRsV5yglwc3GyUfbAfpSeD0FJ41NbUNSt5wbhqfp1fS+BgnvDFQ==}
-    engines: {node: '>= 0.4'}
-
-  is-boolean-object@1.2.2:
-    resolution: {integrity: sha512-wa56o2/ElJMYqjCjGkXri7it5FbebW5usLw/nPmCMs5DeZ7eziSYZhSmPRn0txqeW4LnAmQQU7FgqLpsEFKM4A==}
-    engines: {node: '>= 0.4'}
-
-  is-callable@1.2.7:
-    resolution: {integrity: sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==}
-    engines: {node: '>= 0.4'}
-
-  is-core-module@2.16.2:
-    resolution: {integrity: sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==}
-    engines: {node: '>= 0.4'}
-
-  is-data-view@1.0.2:
-    resolution: {integrity: sha512-RKtWF8pGmS87i2D6gqQu/l7EYRlVdfzemCJN/P3UOs//x1QE7mfhvzHIApBTRf7axvT6DMGwSwBXYCT0nfB9xw==}
-    engines: {node: '>= 0.4'}
-
-  is-date-object@1.1.0:
-    resolution: {integrity: sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==}
-    engines: {node: '>= 0.4'}
-
-  is-extglob@2.1.1:
-    resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
-    engines: {node: '>=0.10.0'}
-
-  is-finalizationregistry@1.1.1:
-    resolution: {integrity: sha512-1pC6N8qWJbWoPtEjgcL2xyhQOP491EQjeUo3qTKcmV8YSDDJrOepfG8pcC7h/QgnQHYSv0mJ3Z/ZWxmatVrysg==}
-    engines: {node: '>= 0.4'}
-
-  is-generator-function@1.1.2:
-    resolution: {integrity: sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==}
-    engines: {node: '>= 0.4'}
-
-  is-glob@4.0.3:
-    resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
-    engines: {node: '>=0.10.0'}
-
-  is-map@2.0.3:
-    resolution: {integrity: sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==}
-    engines: {node: '>= 0.4'}
-
-  is-negative-zero@2.0.3:
-    resolution: {integrity: sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==}
-    engines: {node: '>= 0.4'}
-
-  is-number-object@1.1.1:
-    resolution: {integrity: sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==}
-    engines: {node: '>= 0.4'}
-
-  is-promise@4.0.0:
-    resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
-
-  is-property@1.0.2:
-    resolution: {integrity: sha512-Ks/IoX00TtClbGQr4TWXemAnktAQvYB7HzcCxDGqEZU6oCmb2INHuOoKxbtR+HFkmYWBKv/dOZtGRiAjDhj92g==}
-
-  is-regex@1.2.1:
-    resolution: {integrity: sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==}
-    engines: {node: '>= 0.4'}
-
-  is-set@2.0.3:
-    resolution: {integrity: sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg==}
-    engines: {node: '>= 0.4'}
-
-  is-shared-array-buffer@1.0.4:
-    resolution: {integrity: sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A==}
-    engines: {node: '>= 0.4'}
-
-  is-string@1.1.1:
-    resolution: {integrity: sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA==}
-    engines: {node: '>= 0.4'}
-
-  is-symbol@1.1.1:
-    resolution: {integrity: sha512-9gGx6GTtCQM73BgmHQXfDmLtfjjTUDSyoxTCbp5WtoixAhfgsDirWIcVQ/IHpvI5Vgd5i/J5F7B9cN/WlVbC/w==}
-    engines: {node: '>= 0.4'}
-
-  is-typed-array@1.1.15:
-    resolution: {integrity: sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==}
-    engines: {node: '>= 0.4'}
-
-  is-weakmap@2.0.2:
-    resolution: {integrity: sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==}
-    engines: {node: '>= 0.4'}
-
-  is-weakref@1.1.1:
-    resolution: {integrity: sha512-6i9mGWSlqzNMEqpCp93KwRS1uUOodk2OJ6b+sq7ZPDSy2WuI5NFIxp/254TytR8ftefexkWn5xNiHUNpPOfSew==}
-    engines: {node: '>= 0.4'}
-
-  is-weakset@2.0.4:
-    resolution: {integrity: sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ==}
-    engines: {node: '>= 0.4'}
-
-  isarray@2.0.5:
-    resolution: {integrity: sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==}
-
-  isexe@2.0.0:
-    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
-
-  jiti@2.7.0:
-    resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
-    hasBin: true
-
-  jose@6.2.3:
-    resolution: {integrity: sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==}
-
-  joycon@3.1.1:
-    resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
-    engines: {node: '>=10'}
-
-  jsbi@4.3.2:
-    resolution: {integrity: sha512-9fqMSQbhJykSeii05nxKl4m6Eqn2P6rOlYiS+C5Dr/HPIU/7yZxu5qzbs40tgaFORiw2Amd0mirjxatXYMkIew==}
-
-  json-buffer@3.0.1:
-    resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
-
-  json-schema-traverse@0.4.1:
-    resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
-
-  json-schema-traverse@1.0.0:
-    resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
-
-  json-stable-stringify-without-jsonify@1.0.1:
-    resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
-
-  json5@1.0.2:
-    resolution: {integrity: sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==}
-    hasBin: true
-
-  keyv@4.5.4:
-    resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
-
-  levn@0.4.1:
-    resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
-    engines: {node: '>= 0.8.0'}
-
-  locate-path@6.0.0:
-    resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
-    engines: {node: '>=10'}
-
-  lodash.snakecase@4.1.1:
-    resolution: {integrity: sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw==}
-
-  lodash@4.18.1:
-    resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
-
-  long@5.3.2:
-    resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
-
-  lru.min@1.1.4:
-    resolution: {integrity: sha512-DqC6n3QQ77zdFpCMASA1a3Jlb64Hv2N2DciFGkO/4L9+q/IpIAuRlKOvCXabtRW6cQf8usbmM6BE/TOPysCdIA==}
-    engines: {bun: '>=1.0.0', deno: '>=1.30.0', node: '>=8.0.0'}
-
-  luxon@3.7.2:
-    resolution: {integrity: sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==}
-    engines: {node: '>=12'}
-
-  magic-bytes.js@1.13.0:
-    resolution: {integrity: sha512-afO2mnxW7GDTXMm5/AoN1WuOcdoKhtgXjIvHmobqTD1grNplhGdv3PFOyjCVmrnOZBIT/gD/koDKpYG+0mvHcg==}
-
-  math-intrinsics@1.1.0:
-    resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
-    engines: {node: '>= 0.4'}
-
-  media-typer@1.1.0:
-    resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
-    engines: {node: '>= 0.8'}
-
-  merge-descriptors@2.0.0:
-    resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
-    engines: {node: '>=18'}
-
-  mime-db@1.54.0:
-    resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
-    engines: {node: '>= 0.6'}
-
-  mime-types@3.0.2:
-    resolution: {integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==}
-    engines: {node: '>=18'}
-
-  minimatch@10.2.5:
-    resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
-    engines: {node: 18 || 20 || >=22}
-
-  minimatch@3.1.5:
-    resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
-
-  minimist@1.2.8:
-    resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
-
-  ms@2.1.3:
-    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
-
-  mysql2@3.15.3:
-    resolution: {integrity: sha512-FBrGau0IXmuqg4haEZRBfHNWB5mUARw6hNwPDXXGg0XzVJ50mr/9hb267lvpVMnhZ1FON3qNd4Xfcez1rbFwSg==}
-    engines: {node: '>= 8.0'}
-
-  named-placeholders@1.1.6:
-    resolution: {integrity: sha512-Tz09sEL2EEuv5fFowm419c1+a/jSMiBjI9gHxVLrVdbUkkNUUfjsVYs9pVZu5oCon/kmRh9TfLEObFtkVxmY0w==}
-    engines: {node: '>=8.0.0'}
-
-  natural-compare@1.4.0:
-    resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
-
-  negotiator@1.0.0:
-    resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
-    engines: {node: '>= 0.6'}
-
-  neverthrow@8.2.0:
-    resolution: {integrity: sha512-kOCT/1MCPAxY5iUV3wytNFUMUolzuwd/VF/1KCx7kf6CutrOsTie+84zTGTpgQycjvfLdBBdvBvFLqFD2c0wkQ==}
-    engines: {node: '>=18'}
-
-  node-addon-api@8.8.0:
-    resolution: {integrity: sha512-c5Ko1fZJIJmzhFIkhRN76WTq+fC6tWnGy9CXA0fA+XygsWZmEwG8vmbkNqxMyoaa0Tin4djul49NzdVcJJcjeA==}
-    engines: {node: ^18 || ^20 || >= 21}
-
-  node-exports-info@1.6.0:
-    resolution: {integrity: sha512-pyFS63ptit/P5WqUkt+UUfe+4oevH+bFeIiPPdfb0pFeYEu/1ELnJu5l+5EcTKYL5M7zaAa7S8ddywgXypqKCw==}
-    engines: {node: '>= 0.4'}
-
-  node-gyp-build@4.8.4:
-    resolution: {integrity: sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==}
-    hasBin: true
-
-  object-assign@4.1.1:
-    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
-    engines: {node: '>=0.10.0'}
-
-  object-inspect@1.13.4:
-    resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
-    engines: {node: '>= 0.4'}
-
-  object-keys@1.1.1:
-    resolution: {integrity: sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==}
-    engines: {node: '>= 0.4'}
-
-  object.assign@4.1.7:
-    resolution: {integrity: sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==}
-    engines: {node: '>= 0.4'}
-
-  object.entries@1.1.9:
-    resolution: {integrity: sha512-8u/hfXFRBD1O0hPUjioLhoWFHRmt6tKA4/vZPyckBr18l1KE9uHrFaFaUi8MDRTpi4uak2goyPTSNJLXX2k2Hw==}
-    engines: {node: '>= 0.4'}
-
-  object.fromentries@2.0.8:
-    resolution: {integrity: sha512-k6E21FzySsSK5a21KRADBd/NGneRegFO5pLHfdQLpRDETUNJueLXs3WCzyQ3tFRDYgbq3KHGXfTbi2bs8WQ6rQ==}
-    engines: {node: '>= 0.4'}
-
-  object.groupby@1.0.3:
-    resolution: {integrity: sha512-+Lhy3TQTuzXI5hevh8sBGqbmurHbbIjAi0Z4S63nthVLmLxfbj4T54a4CfZrXIrt9iP4mVAPYMo/v99taj3wjQ==}
-    engines: {node: '>= 0.4'}
-
-  object.values@1.2.1:
-    resolution: {integrity: sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA==}
-    engines: {node: '>= 0.4'}
-
-  ohash@2.0.11:
-    resolution: {integrity: sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==}
-
-  on-exit-leak-free@2.1.2:
-    resolution: {integrity: sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==}
-    engines: {node: '>=14.0.0'}
-
-  on-finished@2.4.1:
-    resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
-    engines: {node: '>= 0.8'}
-
-  once@1.4.0:
-    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
-
-  optionator@0.9.4:
-    resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
-    engines: {node: '>= 0.8.0'}
-
-  own-keys@1.0.1:
-    resolution: {integrity: sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==}
-    engines: {node: '>= 0.4'}
-
-  p-limit@3.1.0:
-    resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
-    engines: {node: '>=10'}
-
-  p-locate@5.0.0:
-    resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
-    engines: {node: '>=10'}
-
-  parseurl@1.3.3:
-    resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
-    engines: {node: '>= 0.8'}
-
-  path-exists@4.0.0:
-    resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
-    engines: {node: '>=8'}
-
-  path-expression-matcher@1.5.0:
-    resolution: {integrity: sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==}
-    engines: {node: '>=14.0.0'}
-
-  path-key@3.1.1:
-    resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
-    engines: {node: '>=8'}
-
-  path-parse@1.0.7:
-    resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
-
-  path-to-regexp@8.4.2:
-    resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==}
-
-  pathe@2.0.3:
-    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
-
-  perfect-debounce@2.1.0:
-    resolution: {integrity: sha512-LjgdTytVFXeUgtHZr9WYViYSM/g8MkcTPYDlPa3cDqMirHjKiSZPYd6DoL7pK8AJQr+uWkQvCjHNdiMqsrJs+g==}
-
-  pg-cloudflare@1.4.0:
-    resolution: {integrity: sha512-Vo7z/6rrQYxpNRylp4Tlob2elzbh+N/MOQbxFVWCxS7oEx6jF53GTJFxK2WWpKuBRkmiin4Mt+xofFDjx09R0A==}
-
-  pg-connection-string@2.13.0:
-    resolution: {integrity: sha512-EMnU9E2fSULdsbErBbMaXJvFeD9B4+nPcM3f+4lsiCR0BHLPrLVjv3DbyM2hgQQviKJaTWIRRTjKjWlHg3p2ig==}
-
-  pg-int8@1.0.1:
-    resolution: {integrity: sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==}
-    engines: {node: '>=4.0.0'}
-
-  pg-pool@3.14.0:
-    resolution: {integrity: sha512-gKtPkFdQPU3DksooVLi9LsjZxrsBUZIpa+7aVx+LV5pNh0KzP4Zleud2po+ConrxbuXGBJ6Hfer6hdgpIBpBaw==}
-    peerDependencies:
-      pg: '>=8.0'
-
-  pg-protocol@1.14.0:
-    resolution: {integrity: sha512-n5taZ1kO3s9ngDTVxsEznOqCyToTgz0FLuPq0B33COy5pPpuWJpY3/2oRBVETuOgzdqRXfWpM9HIhp2LBBT1BA==}
-
-  pg-types@2.2.0:
-    resolution: {integrity: sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==}
-    engines: {node: '>=4'}
-
-  pg@8.20.0:
-    resolution: {integrity: sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==}
-    engines: {node: '>= 16.0.0'}
-    peerDependencies:
-      pg-native: '>=3.0.1'
-    peerDependenciesMeta:
-      pg-native:
-        optional: true
-
-  pgpass@1.0.5:
-    resolution: {integrity: sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==}
-
-  picomatch@4.0.4:
-    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
-    engines: {node: '>=12'}
-
-  pino-abstract-transport@3.0.0:
-    resolution: {integrity: sha512-wlfUczU+n7Hy/Ha5j9a/gZNy7We5+cXp8YL+X+PG8S0KXxw7n/JXA3c46Y0zQznIJ83URJiwy7Lh56WLokNuxg==}
-
-  pino-pretty@13.1.3:
-    resolution: {integrity: sha512-ttXRkkOz6WWC95KeY9+xxWL6AtImwbyMHrL1mSwqwW9u+vLp/WIElvHvCSDg0xO/Dzrggz1zv3rN5ovTRVowKg==}
-    hasBin: true
-
-  pino-std-serializers@7.1.0:
-    resolution: {integrity: sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==}
-
-  pino@10.3.1:
-    resolution: {integrity: sha512-r34yH/GlQpKZbU1BvFFqOjhISRo1MNx1tWYsYvmj6KIRHSPMT2+yHOEb1SG6NMvRoHRF0a07kCOox/9yakl1vg==}
-    hasBin: true
-
-  pkg-types@2.3.1:
-    resolution: {integrity: sha512-y+ichcgc2LrADuhLNAx8DFjVfgz91pRxfZdI3UDhxHvcVEZsenLO+7XaU5vOp0u/7V/wZ+plyuQxtrDlZJ+yeg==}
-
-  possible-typed-array-names@1.1.0:
-    resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
-    engines: {node: '>= 0.4'}
-
-  postgres-array@2.0.0:
-    resolution: {integrity: sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==}
-    engines: {node: '>=4'}
-
-  postgres-array@3.0.4:
-    resolution: {integrity: sha512-nAUSGfSDGOaOAEGwqsRY27GPOea7CNipJPOA7lPbdEpx5Kg3qzdP0AaWC5MlhTWV9s4hFX39nomVZ+C4tnGOJQ==}
-    engines: {node: '>=12'}
-
-  postgres-bytea@1.0.1:
-    resolution: {integrity: sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==}
-    engines: {node: '>=0.10.0'}
-
-  postgres-date@1.0.7:
-    resolution: {integrity: sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==}
-    engines: {node: '>=0.10.0'}
-
-  postgres-interval@1.2.0:
-    resolution: {integrity: sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==}
-    engines: {node: '>=0.10.0'}
-
-  postgres@3.4.7:
-    resolution: {integrity: sha512-Jtc2612XINuBjIl/QTWsV5UvE8UHuNblcO3vVADSrKsrc6RqGX6lOW1cEo3CM2v0XG4Nat8nI+YM7/f26VxXLw==}
-    engines: {node: '>=12'}
-
-  prelude-ls@1.2.1:
-    resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
-    engines: {node: '>= 0.8.0'}
-
-  prettier@3.8.3:
-    resolution: {integrity: sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==}
-    engines: {node: '>=14'}
-    hasBin: true
-
-  prisma@7.8.0:
-    resolution: {integrity: sha512-yfN4yrw7HV9kEJhoy1+jgah0jafEIQsf7uWouSsM8MvJtlubsk+kM7AIBWZ8+GJl74Yj3c+nbYqBkMOxtsZ3Lw==}
-    engines: {node: ^20.19 || ^22.12 || >=24.0}
-    hasBin: true
-    peerDependencies:
-      better-sqlite3: '>=9.0.0'
-      typescript: '>=5.4.0'
-    peerDependenciesMeta:
-      better-sqlite3:
-        optional: true
-      typescript:
-        optional: true
-
-  process-warning@5.0.0:
-    resolution: {integrity: sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==}
-
-  proper-lockfile@4.1.2:
-    resolution: {integrity: sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==}
-
-  proxy-addr@2.0.7:
-    resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
-    engines: {node: '>= 0.10'}
-
-  pump@3.0.4:
-    resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
-
-  punycode@2.3.1:
-    resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
-    engines: {node: '>=6'}
-
-  pure-rand@6.1.0:
-    resolution: {integrity: sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==}
-
-  qs@6.15.2:
-    resolution: {integrity: sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==}
-    engines: {node: '>=0.6'}
-
-  quick-format-unescaped@4.0.4:
-    resolution: {integrity: sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==}
-
-  range-parser@1.2.1:
-    resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
-    engines: {node: '>= 0.6'}
-
-  raw-body@3.0.2:
-    resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
-    engines: {node: '>= 0.10'}
-
-  rc9@3.0.1:
-    resolution: {integrity: sha512-gMDyleLWVE+i6Sgtc0QbbY6pEKqYs97NGi6isHQPqYlLemPoO8dxQ3uGi0f4NiP98c+jMW6cG1Kx9dDwfvqARQ==}
-
-  react-dom@19.2.7:
-    resolution: {integrity: sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==}
-    peerDependencies:
-      react: ^19.2.7
-
-  react@19.2.7:
-    resolution: {integrity: sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==}
-    engines: {node: '>=0.10.0'}
-
-  readable-stream@3.6.2:
-    resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
-    engines: {node: '>= 6'}
-
-  readdirp@5.0.0:
-    resolution: {integrity: sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==}
-    engines: {node: '>= 20.19.0'}
-
-  real-require@0.2.0:
-    resolution: {integrity: sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==}
-    engines: {node: '>= 12.13.0'}
-
-  real-require@1.0.0:
-    resolution: {integrity: sha512-P4nbQYQfePJxRSmY+v/KINxVucm4NF3p3s7pJveMTtom52FR4YGltUQLB8idDXwDDWW+eYrWDFbuzUnjoWHF7g==}
-
-  reflect.getprototypeof@1.0.10:
-    resolution: {integrity: sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==}
-    engines: {node: '>= 0.4'}
-
-  regexp.prototype.flags@1.5.4:
-    resolution: {integrity: sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==}
-    engines: {node: '>= 0.4'}
-
-  remeda@2.33.4:
-    resolution: {integrity: sha512-ygHswjlc/opg2VrtiYvUOPLjxjtdKvjGz1/plDhkG66hjNjFr1xmfrs2ClNFo/E6TyUFiwYNh53bKV26oBoMGQ==}
-
-  require-from-string@2.0.2:
-    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
-    engines: {node: '>=0.10.0'}
-
-  resolve@2.0.0-next.7:
-    resolution: {integrity: sha512-tqt+NBWwyaMgw3zDsnygx4CByWjQEJHOPMdslYhppaQSJUtL/D4JO9CcBBlhPoI8lz9oJIDXkwXfhF4aWqP8xQ==}
-    engines: {node: '>= 0.4'}
-    hasBin: true
-
-  retry@0.12.0:
-    resolution: {integrity: sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==}
-    engines: {node: '>= 4'}
-
-  router@2.2.0:
-    resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
-    engines: {node: '>= 18'}
-
-  safe-array-concat@1.1.4:
-    resolution: {integrity: sha512-wtZlHyOje6OZTGqAoaDKxFkgRtkF9CnHAVnCHKfuj200wAgL+bSJhdsCD2l0Qx/2ekEXjPWcyKkfGb5CPboslg==}
-    engines: {node: '>=0.4'}
-
-  safe-buffer@5.2.1:
-    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
-
-  safe-push-apply@1.0.0:
-    resolution: {integrity: sha512-iKE9w/Z7xCzUMIZqdBsp6pEQvwuEebH4vdpjcDWnyzaI6yl6O9FHvVpmGelvEHNsoY6wGblkxR6Zty/h00WiSA==}
-    engines: {node: '>= 0.4'}
-
-  safe-regex-test@1.1.0:
-    resolution: {integrity: sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==}
-    engines: {node: '>= 0.4'}
-
-  safe-stable-stringify@2.5.0:
-    resolution: {integrity: sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==}
-    engines: {node: '>=10'}
-
-  safer-buffer@2.1.2:
-    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
-
-  scheduler@0.27.0:
-    resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
-
-  secure-json-parse@4.1.0:
-    resolution: {integrity: sha512-l4KnYfEyqYJxDwlNVyRfO2E4NTHfMKAWdUuA8J0yve2Dz/E/PdBepY03RvyJpssIpRFwJoCD55wA+mEDs6ByWA==}
-
-  semver@6.3.1:
-    resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
-    hasBin: true
-
-  semver@7.8.2:
-    resolution: {integrity: sha512-c8jsqUZm3omBOI66G90z1Dyw5z622G8oLG+omfsHBJf3CWQTlOcwOjvOG6wtiNfW6anKm/eA39LMwMtMez2TiQ==}
-    engines: {node: '>=10'}
-    hasBin: true
-
-  send@1.2.1:
-    resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
-    engines: {node: '>= 18'}
-
-  seq-queue@0.0.5:
-    resolution: {integrity: sha512-hr3Wtp/GZIc/6DAGPDcV4/9WoZhjrkXsi5B/07QgX8tsdc6ilr7BFM6PM6rbdAX1kFSDYeZGLipIZZKyQP0O5Q==}
-
-  serve-static@2.2.1:
-    resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
-    engines: {node: '>= 18'}
-
-  set-function-length@1.2.2:
-    resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
-    engines: {node: '>= 0.4'}
-
-  set-function-name@2.0.2:
-    resolution: {integrity: sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==}
-    engines: {node: '>= 0.4'}
-
-  set-proto@1.0.0:
-    resolution: {integrity: sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw==}
-    engines: {node: '>= 0.4'}
-
-  setprototypeof@1.2.0:
-    resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
-
-  shebang-command@2.0.0:
-    resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
-    engines: {node: '>=8'}
-
-  shebang-regex@3.0.0:
-    resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
-    engines: {node: '>=8'}
-
-  side-channel-list@1.0.1:
-    resolution: {integrity: sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==}
-    engines: {node: '>= 0.4'}
-
-  side-channel-map@1.0.1:
-    resolution: {integrity: sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==}
-    engines: {node: '>= 0.4'}
-
-  side-channel-weakmap@1.0.2:
-    resolution: {integrity: sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==}
-    engines: {node: '>= 0.4'}
-
-  side-channel@1.1.0:
-    resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
-    engines: {node: '>= 0.4'}
-
-  signal-exit@3.0.7:
-    resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
-
-  signal-exit@4.1.0:
-    resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
-    engines: {node: '>=14'}
-
-  sonic-boom@4.2.1:
-    resolution: {integrity: sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==}
-
-  split2@4.2.0:
-    resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
-    engines: {node: '>= 10.x'}
-
-  sqlstring@2.3.3:
-    resolution: {integrity: sha512-qC9iz2FlN7DQl3+wjwn3802RTyjCx7sDvfQEXchwa6CWOx07/WVfh91gBmQ9fahw8snwGEWU3xGzOt4tFyHLxg==}
-    engines: {node: '>= 0.6'}
-
-  statuses@2.0.2:
-    resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
-    engines: {node: '>= 0.8'}
-
-  std-env@3.10.0:
-    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
-
-  stop-iteration-iterator@1.1.0:
-    resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
-    engines: {node: '>= 0.4'}
-
-  stream-browserify@3.0.0:
-    resolution: {integrity: sha512-H73RAHsVBapbim0tU2JwwOiXUj+fikfiaoYAKHF3VJfA0pe2BCzkhAHBlLG6REzE+2WNZcxOXjK7lkso+9euLA==}
-
-  streamsearch@1.1.0:
-    resolution: {integrity: sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==}
-    engines: {node: '>=10.0.0'}
-
-  string.prototype.trim@1.2.11:
-    resolution: {integrity: sha512-PwvK7BU+CMTJGYQCTZb5RWXIML92lftJLhQz1tBzgKiqGxJaMlBAa48POXaNAC2s4y8jr3EFqrkF9+44neS46w==}
-    engines: {node: '>= 0.4'}
-
-  string.prototype.trimend@1.0.10:
-    resolution: {integrity: sha512-2+3aDAOmPTmuFwjDnmJG2ctEkQKVki7vOSqaxkv42Mowj1V6PnvuwFCRrR5lChUux1TBskPjfkeTOhqczDMxTw==}
-    engines: {node: '>= 0.4'}
-
-  string.prototype.trimstart@1.0.8:
-    resolution: {integrity: sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==}
-    engines: {node: '>= 0.4'}
-
-  string_decoder@1.3.0:
-    resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
-
-  strip-bom@3.0.0:
-    resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
-    engines: {node: '>=4'}
-
-  strip-json-comments@5.0.3:
-    resolution: {integrity: sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw==}
-    engines: {node: '>=14.16'}
-
-  strnum@2.3.0:
-    resolution: {integrity: sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==}
-
-  supports-preserve-symlinks-flag@1.0.0:
-    resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
-    engines: {node: '>= 0.4'}
-
-  thread-stream@4.2.0:
-    resolution: {integrity: sha512-e2zZ96wSChazBsbENf/Pcm/4swHt2cEKQ92rhUjkL9GCKiTDJIaTBenjE/m9DXi0QBmTMDkFDdOomUy20A1tDQ==}
-    engines: {node: '>=20'}
-
-  tinyglobby@0.2.17:
-    resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
-    engines: {node: '>=12.0.0'}
-
-  toidentifier@1.0.1:
-    resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
-    engines: {node: '>=0.6'}
-
-  ts-api-utils@2.5.0:
-    resolution: {integrity: sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==}
-    engines: {node: '>=18.12'}
-    peerDependencies:
-      typescript: '>=4.8.4'
-
-  ts-mixer@6.0.4:
-    resolution: {integrity: sha512-ufKpbmrugz5Aou4wcr5Wc1UUFWOLhq+Fm6qa6P0w0K5Qw2yhaUoiWszhCVuNQyNwrlGiscHOmqYoAox1PtvgjA==}
-
-  tsconfig-paths@3.15.0:
-    resolution: {integrity: sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg==}
-
-  tslib@2.8.1:
-    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
-
-  type-check@0.4.0:
-    resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
-    engines: {node: '>= 0.8.0'}
-
-  type-is@2.1.0:
-    resolution: {integrity: sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==}
-    engines: {node: '>= 18'}
-
-  typed-array-buffer@1.0.3:
-    resolution: {integrity: sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==}
-    engines: {node: '>= 0.4'}
-
-  typed-array-byte-length@1.0.3:
-    resolution: {integrity: sha512-BaXgOuIxz8n8pIq3e7Atg/7s+DpiYrxn4vdot3w9KbnBhcRQq6o3xemQdIfynqSeXeDrF32x+WvfzmOjPiY9lg==}
-    engines: {node: '>= 0.4'}
-
-  typed-array-byte-offset@1.0.4:
-    resolution: {integrity: sha512-bTlAFB/FBYMcuX81gbL4OcpH5PmlFHqlCCpAl8AlEzMz5k53oNDvN8p1PNOWLEmI2x4orp3raOFB51tv9X+MFQ==}
-    engines: {node: '>= 0.4'}
-
-  typed-array-length@1.0.8:
-    resolution: {integrity: sha512-phPGCwqr2+Qo0fwniCE8e4pKnGu/yFb5nD5Y8bf0EEeiI5GklnACYA9GFy/DrAeRrKHXvHn+1SUsOWgJp6RO+g==}
-    engines: {node: '>= 0.4'}
-
-  typescript-eslint@8.59.1:
-    resolution: {integrity: sha512-xqDcFVBmlrltH64lklOVp1wYxgJr6LVdg3NamBgH2OOQDLFdTKfIZXF5PfghrnXQKXZGTQs8tr1vL7fJvq8CTQ==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
-      typescript: '>=4.8.4 <6.1.0'
-
-  typescript@6.0.3:
-    resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
-    engines: {node: '>=14.17'}
-    hasBin: true
-
-  unbox-primitive@1.1.0:
-    resolution: {integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==}
-    engines: {node: '>= 0.4'}
-
-  undici-types@7.19.2:
-    resolution: {integrity: sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==}
-
-  undici@6.24.1:
-    resolution: {integrity: sha512-sC+b0tB1whOCzbtlx20fx3WgCXwkW627p4EA9uM+/tNNPkSS+eSEld6pAs9nDv7WbY1UUljBMYPtu9BCOrCWKA==}
-    engines: {node: '>=18.17'}
-
-  unpipe@1.0.0:
-    resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
-    engines: {node: '>= 0.8'}
-
-  uri-js@4.4.1:
-    resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
-
-  util-deprecate@1.0.2:
-    resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
-
-  valibot@1.2.0:
-    resolution: {integrity: sha512-mm1rxUsmOxzrwnX5arGS+U4T25RdvpPjPN4yR0u9pUBov9+zGVtO84tif1eY4r6zWxVxu3KzIyknJy3rxfRZZg==}
-    peerDependencies:
-      typescript: '>=5'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-
-  vary@1.1.2:
-    resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
-    engines: {node: '>= 0.8'}
-
-  which-boxed-primitive@1.1.1:
-    resolution: {integrity: sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==}
-    engines: {node: '>= 0.4'}
-
-  which-builtin-type@1.2.1:
-    resolution: {integrity: sha512-6iBczoX+kDQ7a3+YJBnh3T+KZRxM/iYNPXicqk66/Qfm1b93iu+yOImkg0zHbj5LNOcNv1TEADiZ0xa34B4q6Q==}
-    engines: {node: '>= 0.4'}
-
-  which-collection@1.0.2:
-    resolution: {integrity: sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==}
-    engines: {node: '>= 0.4'}
-
-  which-typed-array@1.1.22:
-    resolution: {integrity: sha512-fvO4ExWMFsqyhG3AiPAObMuY1lxaqgYcxbc49CNdWDDECOJNgQyvsOWVwbZc+qf3rzRtxojBK+CMEv0Ld5CYpw==}
-    engines: {node: '>= 0.4'}
-
-  which@2.0.2:
-    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
-    engines: {node: '>= 8'}
-    hasBin: true
-
-  word-wrap@1.2.5:
-    resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
-    engines: {node: '>=0.10.0'}
-
-  wrappy@1.0.2:
-    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
-
-  ws@8.21.0:
-    resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
-    engines: {node: '>=10.0.0'}
-    peerDependencies:
-      bufferutil: ^4.0.1
-      utf-8-validate: '>=5.0.2'
-    peerDependenciesMeta:
-      bufferutil:
-        optional: true
-      utf-8-validate:
-        optional: true
-
-  xml-naming@0.1.0:
-    resolution: {integrity: sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==}
-    engines: {node: '>=16.0.0'}
-
-  xtend@4.0.2:
-    resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
-    engines: {node: '>=0.4'}
-
-  yocto-queue@0.1.0:
-    resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
-    engines: {node: '>=10'}
-
-  zeptomatch@2.1.0:
-    resolution: {integrity: sha512-KiGErG2J0G82LSpniV0CtIzjlJ10E04j02VOudJsPyPwNZgGnRKQy7I1R7GMyg/QswnE4l7ohSGrQbQbjXPPDA==}
-
-  zod@4.3.6:
-    resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
-
-  zod@4.4.1:
-    resolution: {integrity: sha512-a6ENMBBGZBsnlSebQ/eKCguSBeGKSf4O7BPnqVPmYGtpBYI7VSqoVqw+QcB7kPRjbqPwhYTpFbVj/RqNz/CT0Q==}
+    '@aws-crypto/crc32@5.2.0':
+        resolution:
+            {
+                integrity: sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==,
+            }
+        engines: { node: '>=16.0.0' }
+
+    '@aws-crypto/crc32c@5.2.0':
+        resolution:
+            {
+                integrity: sha512-+iWb8qaHLYKrNvGRbiYRHSdKRWhto5XlZUEBwDjYNf+ly5SVYG6zEoYIdxvf5R3zyeP16w4PLBn3rH1xc74Rag==,
+            }
+
+    '@aws-crypto/sha1-browser@5.2.0':
+        resolution:
+            {
+                integrity: sha512-OH6lveCFfcDjX4dbAvCFSYUjJZjDr/3XJ3xHtjn3Oj5b9RjojQo8npoLeA/bNwkOkrSQ0wgrHzXk4tDRxGKJeg==,
+            }
+
+    '@aws-crypto/sha256-browser@5.2.0':
+        resolution:
+            {
+                integrity: sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==,
+            }
+
+    '@aws-crypto/sha256-js@5.2.0':
+        resolution:
+            {
+                integrity: sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==,
+            }
+        engines: { node: '>=16.0.0' }
+
+    '@aws-crypto/supports-web-crypto@5.2.0':
+        resolution:
+            {
+                integrity: sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==,
+            }
+
+    '@aws-crypto/util@5.2.0':
+        resolution:
+            {
+                integrity: sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==,
+            }
+
+    '@aws-sdk/checksums@3.1000.2':
+        resolution:
+            {
+                integrity: sha512-PIha+kauTbp6IRmOpYktPTrlfrrSqDVixvhO/EUOFOf62DPX81CaJoHJreuA1m9HYpSKyXf99BKjU1dvJPeUfw==,
+            }
+        engines: { node: '>=20.0.0' }
+
+    '@aws-sdk/client-s3@3.1039.0':
+        resolution:
+            {
+                integrity: sha512-PVH9v0pHYBQnBADSR/m88NgcuJcYqPXfpmkcME66vRF75Y4swwbEVVFbTBFuvxu0YcZiLFXu3lw0FDK00vEa3A==,
+            }
+        engines: { node: '>=20.0.0' }
+
+    '@aws-sdk/core@3.974.18':
+        resolution:
+            {
+                integrity: sha512-JDYCPI0j7zGrzXTDFsLB346cxss7J/AxH7+O0MzWlqppJBEyB9Qe6TQXRL6iwLUo/xZkNv9KFmBL2hqElmwW0g==,
+            }
+        engines: { node: '>=20.0.0' }
+
+    '@aws-sdk/credential-provider-env@3.972.44':
+        resolution:
+            {
+                integrity: sha512-3hKJVrZ7bqXzDAXCQp+OaQ1ASN+vWstaNuEH418wQVl//cRZhqhfR9Bjk1qIWmgUGe8/D3gdO73PgidRj378EQ==,
+            }
+        engines: { node: '>=20.0.0' }
+
+    '@aws-sdk/credential-provider-http@3.972.46':
+        resolution:
+            {
+                integrity: sha512-VhwC9pGAZHhiQ2xSViyOPDFqvr9aRxGCAXZtADsUhU3R65nad7y//CwynE6mQnWNR+suRlqE79W36IVayL+m1g==,
+            }
+        engines: { node: '>=20.0.0' }
+
+    '@aws-sdk/credential-provider-ini@3.972.50':
+        resolution:
+            {
+                integrity: sha512-09Xi6ovxiK42+De/qBGF71sT5F2bWgYM+1fFyDwSOpy1xpsQ5R/naIu7MVDpH6Dic36QNc8dAv4KADtMGK2JYg==,
+            }
+        engines: { node: '>=20.0.0' }
+
+    '@aws-sdk/credential-provider-login@3.972.49':
+        resolution:
+            {
+                integrity: sha512-EfJF/1Fh9mI4pZyoheU2RY9xUhTcugIZNkD63+orXMkYj/QXacJNbKVDUK90Yv5hE+aX+rt9J/EZ9Qr3vKOa7g==,
+            }
+        engines: { node: '>=20.0.0' }
+
+    '@aws-sdk/credential-provider-node@3.972.52':
+        resolution:
+            {
+                integrity: sha512-7QX+PbyiWBEOVipJq8Nke/TqXT6lAPLE7fvTaopa39/IVWuLfS+Fzdy71sZJONf/mLGgmtj6aU17+REw3+aRrw==,
+            }
+        engines: { node: '>=20.0.0' }
+
+    '@aws-sdk/credential-provider-process@3.972.44':
+        resolution:
+            {
+                integrity: sha512-V+UUhZpRP7QDRhi+qgBDisM9tUBnYmMje8Bk77A6MZsfeGeGdMsQXmaHP1CDYFcept0o/Rz5g2Y0TMeVlG9dzg==,
+            }
+        engines: { node: '>=20.0.0' }
+
+    '@aws-sdk/credential-provider-sso@3.972.49':
+        resolution:
+            {
+                integrity: sha512-9QqOYGuh5tZ76OzaT68kwI78AH+5lS/uZGGvkfxb3fc8FzRrIz2jOufNTliEBEeSAwmgK2rWLNsK+IB3zbtNPA==,
+            }
+        engines: { node: '>=20.0.0' }
+
+    '@aws-sdk/credential-provider-web-identity@3.972.49':
+        resolution:
+            {
+                integrity: sha512-IYx1lN38MnnPXv+NBLpuATu0cZakbZ321TAfjW+aVkw7HIJF38YnEwdeEO55MSl3pl7hIX1IvvnD6EmnAzmAJw==,
+            }
+        engines: { node: '>=20.0.0' }
+
+    '@aws-sdk/lib-storage@3.1038.0':
+        resolution:
+            {
+                integrity: sha512-FEGuFSUL9gNfyWf4KcOgzhLiqQgSSvpML3YPnJbj8k2nSKdgyRznXxg8zd4W+NKoVehtNqXwFBvMXeHyOYlOrg==,
+            }
+        engines: { node: '>=20.0.0' }
+        peerDependencies:
+            '@aws-sdk/client-s3': ^3.1038.0
+
+    '@aws-sdk/middleware-bucket-endpoint@3.972.21':
+        resolution:
+            {
+                integrity: sha512-9hkf6r6GIovTMi3gl/9TZLokp4R27PrZ1t0yejQqDZ49bLGiVmRnbklU2uMjtuot9yBskIquvinEoYGpZ0wMKw==,
+            }
+        engines: { node: '>=20.0.0' }
+
+    '@aws-sdk/middleware-expect-continue@3.972.17':
+        resolution:
+            {
+                integrity: sha512-MzrvtvWEedwi4sg0DXT9SOiP8dFTfopnPBaOpQQcchMasCpZ/3v1EWzEi2RIAb8UiQKPQWzNvUARlGmlWuyZzQ==,
+            }
+        engines: { node: '>=20.0.0' }
+
+    '@aws-sdk/middleware-flexible-checksums@3.974.27':
+        resolution:
+            {
+                integrity: sha512-bZqezPLdllFC4VAeV/f+EIc/hz56ab3TD/+4zNCgOgmG5ZHAE5dMHrX1gtTwdcQXbPr3KR7x3zTC3zuCTE6+ng==,
+            }
+        engines: { node: '>=20.0.0' }
+
+    '@aws-sdk/middleware-host-header@3.972.19':
+        resolution:
+            {
+                integrity: sha512-08DkRJIr+RlzPhctrCv2zKLGW4RiF7IfgkhF6zvVRCtZkZ3yeojHG1wX/g4k5ujYdQxtEz4ifR48ZlC1eIwSmg==,
+            }
+        engines: { node: '>=20.0.0' }
+
+    '@aws-sdk/middleware-location-constraint@3.972.14':
+        resolution:
+            {
+                integrity: sha512-FcHrGhxZCFbWvkZ6VXSbjzAthO79NSvnjzHTvH6ai1ncyXJgZiqepgAwCUq1MxakIAHwjid+WJvkMUmQtyGtuA==,
+            }
+        engines: { node: '>=20.0.0' }
+
+    '@aws-sdk/middleware-logger@3.972.18':
+        resolution:
+            {
+                integrity: sha512-BRt6kXBrm5PSvTNr9aApq9qavKIVhInDRiNC9K7lGi7OT2yJW2ELnawElZWxImktLsKYDdiF94SM0lxoffJKUw==,
+            }
+        engines: { node: '>=20.0.0' }
+
+    '@aws-sdk/middleware-recursion-detection@3.972.20':
+        resolution:
+            {
+                integrity: sha512-hHEA/yuAcFk51MvQveT42OTv6w5EZ/hX/nWjy1p3a8sX5QQJQY6c/Wq5Wkh5V9xxveFg1Zjchp/op43Npx945w==,
+            }
+        engines: { node: '>=20.0.0' }
+
+    '@aws-sdk/middleware-sdk-s3@3.972.48':
+        resolution:
+            {
+                integrity: sha512-MRTqx8wD/T3REt6LTT3/yN8rrp6+xIHrbUekkDYJTYWVch70mwtdJBovR4qKJz1jIPlbN+9R/Sn6R04BfsglzA==,
+            }
+        engines: { node: '>=20.0.0' }
+
+    '@aws-sdk/middleware-ssec@3.972.14':
+        resolution:
+            {
+                integrity: sha512-T29abTnUuKa0Wt3DjXcx5vK/0OkNruLhiP9rbo668nxGXpyeulpxT3gpN22j/51MPFi8dAsgtz4Bpya1NT4EhQ==,
+            }
+        engines: { node: '>=20.0.0' }
+
+    '@aws-sdk/middleware-user-agent@3.972.48':
+        resolution:
+            {
+                integrity: sha512-DGvRUTu8IVQ+/918JHLb5xebJLK+8y4r+Spe4xj8OkyYieOpG/UxTCa8UpuzV5hxX3LCgK0MtklGN0qsYhXqIQ==,
+            }
+        engines: { node: '>=20.0.0' }
+
+    '@aws-sdk/nested-clients@3.997.17':
+        resolution:
+            {
+                integrity: sha512-lDRgraoTfKRawUyc176Ow93mrNrOho/x+EoK4C+lKU+vKkHWhNhzvSMVAx0WEJUJoeQxxDN5ZdKMfiGEyNejig==,
+            }
+        engines: { node: '>=20.0.0' }
+
+    '@aws-sdk/region-config-resolver@3.972.22':
+        resolution:
+            {
+                integrity: sha512-4dB88prnKR5YkD/o5gQLnHVii44xo3tjn2COy5UWcZvOl7TJK90kiHH6QR2kaC4hFH3KkXZKpPR0gEbUhXp3TA==,
+            }
+        engines: { node: '>=20.0.0' }
+
+    '@aws-sdk/signature-v4-multi-region@3.996.32':
+        resolution:
+            {
+                integrity: sha512-llvApLcsWtmRFhG2wT3WIp1CmDeRaIYutqty1ZZXoMzK7TiJ6MOLOimk9eXUS8PwgG4ew4pa4QAbt0lfhn++1w==,
+            }
+        engines: { node: '>=20.0.0' }
+
+    '@aws-sdk/token-providers@3.1063.0':
+        resolution:
+            {
+                integrity: sha512-nYDaWWdzjKiDP5xj8k4oUgcYd4WPgzfAOgdU5vJsaqH/07Dfvm7ffisHCFJ+NEl7kUC9JEIUxh0kznvenbo3NQ==,
+            }
+        engines: { node: '>=20.0.0' }
+
+    '@aws-sdk/types@3.973.11':
+        resolution:
+            {
+                integrity: sha512-YjS0qFuECClRh4qhEyW8XagW0fwEPBeZ1cfsW/gU73Kh/ExFILxbzxOfPCmzF/2DwEvhvsHYt0b0qnvStwKYrg==,
+            }
+        engines: { node: '>=20.0.0' }
+
+    '@aws-sdk/util-endpoints@3.996.17':
+        resolution:
+            {
+                integrity: sha512-2bp/vOZcxPXnsRtAGj6famUxlJ7lzGlCHgeCLufDeZUtHWneqeA70lxRNuhx6JNWOfzrJwweb099Xf4WGzP1bw==,
+            }
+        engines: { node: '>=20.0.0' }
+
+    '@aws-sdk/util-locate-window@3.965.6':
+        resolution:
+            {
+                integrity: sha512-ZfHjfwSzeXj+Lg9AK5ZNmeDkXev6V+w2tn1t4kgDdRtUaRCthepTQiFwbD06EF9oNGH4LaLg+Mb6U16Ypv5bSw==,
+            }
+        engines: { node: '>=20.0.0' }
+
+    '@aws-sdk/util-user-agent-browser@3.972.19':
+        resolution:
+            {
+                integrity: sha512-7Eu2HD1IHHktBorfwGUL6xrzcPPZ4lnu6TkNTcrpKaPPpeQ/hNuoO1UNw8NTKp68LwLuxfC5BZ7esoVBGBRuSg==,
+            }
+
+    '@aws-sdk/util-user-agent-node@3.973.34':
+        resolution:
+            {
+                integrity: sha512-smIFIUsRPSiRIBdUpXu+Y9VvtnIJQBQLU5KS0D4tOIjLKuq/3W7v7jpKdfETw1mxfQqynsvBE1+L1JsZDR4vnw==,
+            }
+        engines: { node: '>=20.0.0' }
+
+    '@aws-sdk/xml-builder@3.972.28':
+        resolution:
+            {
+                integrity: sha512-lI/l3c/vPvsxmspzV63NfS3x9q4CkMmdhJy4QiM+NThAufVkDvi/PZZQ6xETnICL0UD7jI808pY83gllf86RFg==,
+            }
+        engines: { node: '>=20.0.0' }
+
+    '@aws/lambda-invoke-store@0.2.4':
+        resolution:
+            {
+                integrity: sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==,
+            }
+        engines: { node: '>=18.0.0' }
+
+    '@discordjs/builders@1.14.1':
+        resolution:
+            {
+                integrity: sha512-gSKkhXLqs96TCzk66VZuHHl8z2bQMJFGwrXC0f33ngK+FLNau4hU1PYny3DNJfNdSH+gVMzE85/d5FQ2BpcNwQ==,
+            }
+        engines: { node: '>=16.11.0' }
+
+    '@discordjs/collection@1.5.3':
+        resolution:
+            {
+                integrity: sha512-SVb428OMd3WO1paV3rm6tSjM4wC+Kecaa1EUGX7vc6/fddvw/6lg90z4QtCqm21zvVe92vMMDt9+DkIvjXImQQ==,
+            }
+        engines: { node: '>=16.11.0' }
+
+    '@discordjs/collection@2.1.1':
+        resolution:
+            {
+                integrity: sha512-LiSusze9Tc7qF03sLCujF5iZp7K+vRNEDBZ86FT9aQAv3vxMLihUvKvpsCWiQ2DJq1tVckopKm1rxomgNUc9hg==,
+            }
+        engines: { node: '>=18' }
+
+    '@discordjs/formatters@0.6.2':
+        resolution:
+            {
+                integrity: sha512-y4UPwWhH6vChKRkGdMB4odasUbHOUwy7KL+OVwF86PvT6QVOwElx+TiI1/6kcmcEe+g5YRXJFiXSXUdabqZOvQ==,
+            }
+        engines: { node: '>=16.11.0' }
+
+    '@discordjs/rest@2.6.1':
+        resolution:
+            {
+                integrity: sha512-wwQdgjeaoYFiaG+atbqx6aJDpqW7JHAo0HrQkBTbYzM3/PJ3GweQIpgElNcGZ26DCUOXMyawYd0YF7vtr+fZXg==,
+            }
+        engines: { node: '>=18' }
+
+    '@discordjs/util@1.2.0':
+        resolution:
+            {
+                integrity: sha512-3LKP7F2+atl9vJFhaBjn4nOaSWahZ/yWjOvA4e5pnXkt2qyXRCHLxoBQy81GFtLGCq7K9lPm9R517M1U+/90Qg==,
+            }
+        engines: { node: '>=18' }
+
+    '@discordjs/ws@1.2.3':
+        resolution:
+            {
+                integrity: sha512-wPlQDxEmlDg5IxhJPuxXr3Vy9AjYq5xCvFWGJyD7w7Np8ZGu+Mc+97LCoEc/+AYCo2IDpKioiH0/c/mj5ZR9Uw==,
+            }
+        engines: { node: '>=16.11.0' }
+
+    '@electric-sql/pglite-socket@0.1.1':
+        resolution:
+            {
+                integrity: sha512-p2hoXw3Z3LQHwTeikdZNsFBOvXGqKY2hk51BBw+8NKND8eoH+8LFOtW9Z8CQKmTJ2qqGYu82ipqiyFZOTTXNfw==,
+            }
+        hasBin: true
+        peerDependencies:
+            '@electric-sql/pglite': 0.4.1
+
+    '@electric-sql/pglite-tools@0.3.1':
+        resolution:
+            {
+                integrity: sha512-C+T3oivmy9bpQvSxVqXA1UDY8cB9Eb9vZHL9zxWwEUfDixbXv4G3r2LjoTdR33LD8aomR3O9ZXEO3XEwr/cUCA==,
+            }
+        peerDependencies:
+            '@electric-sql/pglite': 0.4.1
+
+    '@electric-sql/pglite@0.4.1':
+        resolution:
+            {
+                integrity: sha512-mZ9NzzUSYPOCnxHH1oAHPRzoMFJHY472raDKwXl/+6oPbpdJ7g8LsCN4FSaIIfkiCKHhb3iF/Zqo3NYxaIhU7Q==,
+            }
+
+    '@eliyya/flagged-bitfield@1.1.1':
+        resolution:
+            {
+                integrity: sha512-E7oOtJGwGiCn2y5Zc87eLFXFV8B21/PrWlroD2KYPDu3d3qR4tKCTFyhYXKJqr9D2q4FbYpC4OtBdvkvvtCO/Q==,
+            }
+
+    '@epic-web/invariant@1.0.0':
+        resolution:
+            {
+                integrity: sha512-lrTPqgvfFQtR/eY/qkIzp98OGdNJu0m5ji3q/nJI8v3SXkRKEnWiOxMmbvcSoAIzv/cGiuvRy57k4suKQSAdwA==,
+            }
+
+    '@eslint-community/eslint-utils@4.9.1':
+        resolution:
+            {
+                integrity: sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==,
+            }
+        engines: { node: ^12.22.0 || ^14.17.0 || >=16.0.0 }
+        peerDependencies:
+            eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
+
+    '@eslint-community/regexpp@4.12.2':
+        resolution:
+            {
+                integrity: sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==,
+            }
+        engines: { node: ^12.0.0 || ^14.0.0 || >=16.0.0 }
+
+    '@eslint/config-array@0.23.5':
+        resolution:
+            {
+                integrity: sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA==,
+            }
+        engines: { node: ^20.19.0 || ^22.13.0 || >=24 }
+
+    '@eslint/config-helpers@0.5.5':
+        resolution:
+            {
+                integrity: sha512-eIJYKTCECbP/nsKaaruF6LW967mtbQbsw4JTtSVkUQc9MneSkbrgPJAbKl9nWr0ZeowV8BfsarBmPpBzGelA2w==,
+            }
+        engines: { node: ^20.19.0 || ^22.13.0 || >=24 }
+
+    '@eslint/core@1.2.1':
+        resolution:
+            {
+                integrity: sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==,
+            }
+        engines: { node: ^20.19.0 || ^22.13.0 || >=24 }
+
+    '@eslint/js@10.0.1':
+        resolution:
+            {
+                integrity: sha512-zeR9k5pd4gxjZ0abRoIaxdc7I3nDktoXZk2qOv9gCNWx3mVwEn32VRhyLaRsDiJjTs0xq/T8mfPtyuXu7GWBcA==,
+            }
+        engines: { node: ^20.19.0 || ^22.13.0 || >=24 }
+        peerDependencies:
+            eslint: ^10.0.0
+        peerDependenciesMeta:
+            eslint:
+                optional: true
+
+    '@eslint/json@1.2.0':
+        resolution:
+            {
+                integrity: sha512-CEFEyNgvzu8zn5QwVYDg3FaG+ZKUeUsNYitFpMYJAqoAlnw68EQgNbUfheSmexZr4n0wZPrAkPLuvsLaXO6wRw==,
+            }
+        engines: { node: ^20.19.0 || ^22.13.0 || >=24 }
+
+    '@eslint/object-schema@3.0.5':
+        resolution:
+            {
+                integrity: sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw==,
+            }
+        engines: { node: ^20.19.0 || ^22.13.0 || >=24 }
+
+    '@eslint/plugin-kit@0.6.1':
+        resolution:
+            {
+                integrity: sha512-iH1B076HoAshH1mLpHMgwdGeTs0CYwL0SPMkGuSebZrwBp16v415e9NZXg2jtrqPVQjf6IANe2Vtlr5KswtcZQ==,
+            }
+        engines: { node: ^20.19.0 || ^22.13.0 || >=24 }
+
+    '@eslint/plugin-kit@0.7.2':
+        resolution:
+            {
+                integrity: sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A==,
+            }
+        engines: { node: ^20.19.0 || ^22.13.0 || >=24 }
+
+    '@hono/node-server@1.19.11':
+        resolution:
+            {
+                integrity: sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==,
+            }
+        engines: { node: '>=18.14.1' }
+        peerDependencies:
+            hono: ^4
+
+    '@humanfs/core@0.19.2':
+        resolution:
+            {
+                integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==,
+            }
+        engines: { node: '>=18.18.0' }
+
+    '@humanfs/node@0.16.8':
+        resolution:
+            {
+                integrity: sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==,
+            }
+        engines: { node: '>=18.18.0' }
+
+    '@humanfs/types@0.15.0':
+        resolution:
+            {
+                integrity: sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==,
+            }
+        engines: { node: '>=18.18.0' }
+
+    '@humanwhocodes/module-importer@1.0.1':
+        resolution:
+            {
+                integrity: sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==,
+            }
+        engines: { node: '>=12.22' }
+
+    '@humanwhocodes/momoa@3.3.10':
+        resolution:
+            {
+                integrity: sha512-KWiFQpSAqEIyrTXko3hFNLeQvSK8zXlJQzhhxsyVn58WFRYXST99b3Nqnu+ttOtjds2Pl2grUHGpe2NzhPynuQ==,
+            }
+        engines: { node: '>=18' }
+
+    '@humanwhocodes/retry@0.4.3':
+        resolution:
+            {
+                integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==,
+            }
+        engines: { node: '>=18.18' }
+
+    '@js-temporal/polyfill@0.5.1':
+        resolution:
+            {
+                integrity: sha512-hloP58zRVCRSpgDxmqCWJNlizAlUgJFqG2ypq79DCvyv9tHjRYMDOcPFjzfl/A1/YxDvRCZz8wvZvmapQnKwFQ==,
+            }
+        engines: { node: '>=12' }
+
+    '@kurkle/color@0.3.4':
+        resolution:
+            {
+                integrity: sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==,
+            }
+
+    '@nodable/entities@2.1.1':
+        resolution:
+            {
+                integrity: sha512-Pig3HxDIoMgjdEH8OCf/dkcTmLFjJRjWuq8jSnklu284/TKOPibSRERmOykiwmyXTtv61mP+44f3GMx0tLAyjg==,
+            }
+
+    '@phc/format@1.0.0':
+        resolution:
+            {
+                integrity: sha512-m7X9U6BG2+J+R1lSOdCiITLLrxm+cWlNI3HUFA92oLO77ObGNzaKdh8pMLqdZcshtkKuV84olNNXDfMc4FezBQ==,
+            }
+        engines: { node: '>=10' }
+
+    '@pinojs/redact@0.4.0':
+        resolution:
+            {
+                integrity: sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==,
+            }
+
+    '@prisma/adapter-pg@7.8.0':
+        resolution:
+            {
+                integrity: sha512-ygb3UkerK3v8MDpXVgCISdRNDozpxh6+JVJgiIGbSr5KBgz10LLf5ejUskPGoXlsIjxsOu6nuy1JVQr2EKGSlg==,
+            }
+
+    '@prisma/client-runtime-utils@7.8.0':
+        resolution:
+            {
+                integrity: sha512-5NQZztQ0oY/ADFkmd9gPuweH5A1/CCY8YQPorLLO0Mu6a87mY5gsnDkzmFmIHs9NFaLnZojzgddFVN4RpKYrdw==,
+            }
+
+    '@prisma/client@7.8.0':
+        resolution:
+            {
+                integrity: sha512-HFp3Dawv/3sU3JtlPha90IB+48lS7zHiH4LKZPjmcE8YH5P9DOXGPvo8dqOtO7MqLDd1p2hOWMcFlRT1DMblHw==,
+            }
+        engines: { node: ^20.19 || ^22.12 || >=24.0 }
+        peerDependencies:
+            prisma: '*'
+            typescript: '>=5.4.0'
+        peerDependenciesMeta:
+            prisma:
+                optional: true
+            typescript:
+                optional: true
+
+    '@prisma/config@7.8.0':
+        resolution:
+            {
+                integrity: sha512-HFESzd9rx2ZQxlK+TL7tu1HPvCqrHiL6LCxYykI2c34mvaUuIVVl3lYuicJD/MNnzgPnyeBEMlK4WTomJCV5jw==,
+            }
+
+    '@prisma/debug@7.2.0':
+        resolution:
+            {
+                integrity: sha512-YSGTiSlBAVJPzX4ONZmMotL+ozJwQjRmZweQNIq/ER0tQJKJynNkRB3kyvt37eOfsbMCXk3gnLF6J9OJ4QWftw==,
+            }
+
+    '@prisma/debug@7.8.0':
+        resolution:
+            {
+                integrity: sha512-p+QZReysDUqXC+mk17q9a+Y/qzh4c2KYliDK30buYUyfrGeTGSyfmc0AIrJRhZJrLHhRiJa9Au/J72h3C+szvA==,
+            }
+
+    '@prisma/dev@0.24.3':
+        resolution:
+            {
+                integrity: sha512-ffHlQuKXZiaDt9Go0OnCTdJZrHxK0k7omJKNV86/VjpsXu5EIHZLK0T7JSWgvNlJwh56kW9JFu9v0qJciFzepg==,
+            }
+
+    '@prisma/driver-adapter-utils@7.8.0':
+        resolution:
+            {
+                integrity: sha512-/Q13o0ZT0rjc1Xk0Q9KhZYwuq2EW/vSbWUBKfgEKkaCuB/Sg6bqnjmTZqC5cD4d6y1vfFAEwBRzfzoSMIVJ55A==,
+            }
+
+    '@prisma/engines-version@7.8.0-6.3c6e192761c0362d496ed980de936e2f3cebcd3a':
+        resolution:
+            {
+                integrity: sha512-fJPQxCkLgA5EayWaW8eArgCvjJ+N+Kz3VyeNKMEeYiQC4alNkxRKFVAGxv/ZUzuJISKqdw+zGeDbS6mn6RCPOA==,
+            }
+
+    '@prisma/engines@7.8.0':
+        resolution:
+            {
+                integrity: sha512-jx3rCnNNrt5uzbkKlegtQ2GZHxSlihMCzutgT/BP6UIDF1r9tDI39hV/0T/cHZgzJ3ELbuQPXlVZy+Y1n0pcgw==,
+            }
+
+    '@prisma/fetch-engine@7.8.0':
+        resolution:
+            {
+                integrity: sha512-gwB0Euiz/DDRyxFRpLXYlK3RfaZUj1c5dAYMuhZYfApg7arknJlcb9bIsOHDppJmbqYaVA+yBIiFMDBfprsNPQ==,
+            }
+
+    '@prisma/get-platform@7.2.0':
+        resolution:
+            {
+                integrity: sha512-k1V0l0Td1732EHpAfi2eySTezyllok9dXb6UQanajkJQzPUGi3vO2z7jdkz67SypFTdmbnyGYxvEvYZdZsMAVA==,
+            }
+
+    '@prisma/get-platform@7.8.0':
+        resolution:
+            {
+                integrity: sha512-WlxgRGnolL8VH2EmkH1R/DkKNr/mVdS3G2h42IZFFZ3eUrH9OT6t73kIOSlkkrv50wG123Iq8d96ufv5LlZktw==,
+            }
+
+    '@prisma/query-plan-executor@7.2.0':
+        resolution:
+            {
+                integrity: sha512-EOZmNzcV8uJ0mae3DhTsiHgoNCuu1J9mULQpGCh62zN3PxPTd+qI9tJvk5jOst8WHKQNwJWR3b39t0XvfBB0WQ==,
+            }
+
+    '@prisma/streams-local@0.1.2':
+        resolution:
+            {
+                integrity: sha512-l49yTxKKF2odFxaAXTmwmkBKL3+bVQ1tFOooGifu4xkdb9NMNLxHj27XAhTylWZod8I+ISGM5erU1xcl/oBCtg==,
+            }
+        engines: { bun: '>=1.3.6', node: '>=22.0.0' }
+
+    '@prisma/studio-core@0.27.3':
+        resolution:
+            {
+                integrity: sha512-AADjNFPdsrglxHQVTmHFqv6DuKQZ5WY4p5/gVFY017twvNrSwpLJ9lqUbYYxEu2W7nbvVxTZA8deJ8LseNALsw==,
+            }
+        engines: { node: ^20.19 || ^22.12 || >=24.0, pnpm: '8' }
+        peerDependencies:
+            '@types/react': ^18.0.0 || ^19.0.0
+            react: ^18.0.0 || ^19.0.0
+            react-dom: ^18.0.0 || ^19.0.0
+
+    '@radix-ui/primitive@1.1.3':
+        resolution:
+            {
+                integrity: sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==,
+            }
+
+    '@radix-ui/react-compose-refs@1.1.2':
+        resolution:
+            {
+                integrity: sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==,
+            }
+        peerDependencies:
+            '@types/react': '*'
+            react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+        peerDependenciesMeta:
+            '@types/react':
+                optional: true
+
+    '@radix-ui/react-primitive@2.1.3':
+        resolution:
+            {
+                integrity: sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==,
+            }
+        peerDependencies:
+            '@types/react': '*'
+            '@types/react-dom': '*'
+            react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+            react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+        peerDependenciesMeta:
+            '@types/react':
+                optional: true
+            '@types/react-dom':
+                optional: true
+
+    '@radix-ui/react-slot@1.2.3':
+        resolution:
+            {
+                integrity: sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==,
+            }
+        peerDependencies:
+            '@types/react': '*'
+            react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+        peerDependenciesMeta:
+            '@types/react':
+                optional: true
+
+    '@radix-ui/react-toggle@1.1.10':
+        resolution:
+            {
+                integrity: sha512-lS1odchhFTeZv3xwHH31YPObmJn8gOg7Lq12inrr0+BH/l3Tsq32VfjqH1oh80ARM3mlkfMic15n0kg4sD1poQ==,
+            }
+        peerDependencies:
+            '@types/react': '*'
+            '@types/react-dom': '*'
+            react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+            react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+        peerDependenciesMeta:
+            '@types/react':
+                optional: true
+            '@types/react-dom':
+                optional: true
+
+    '@radix-ui/react-use-controllable-state@1.2.2':
+        resolution:
+            {
+                integrity: sha512-BjasUjixPFdS+NKkypcyyN5Pmg83Olst0+c6vGov0diwTEo6mgdqVR6hxcEgFuh4QrAs7Rc+9KuGJ9TVCj0Zzg==,
+            }
+        peerDependencies:
+            '@types/react': '*'
+            react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+        peerDependenciesMeta:
+            '@types/react':
+                optional: true
+
+    '@radix-ui/react-use-effect-event@0.0.2':
+        resolution:
+            {
+                integrity: sha512-Qp8WbZOBe+blgpuUT+lw2xheLP8q0oatc9UpmiemEICxGvFLYmHm9QowVZGHtJlGbS6A6yJ3iViad/2cVjnOiA==,
+            }
+        peerDependencies:
+            '@types/react': '*'
+            react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+        peerDependenciesMeta:
+            '@types/react':
+                optional: true
+
+    '@radix-ui/react-use-layout-effect@1.1.1':
+        resolution:
+            {
+                integrity: sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==,
+            }
+        peerDependencies:
+            '@types/react': '*'
+            react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+        peerDependenciesMeta:
+            '@types/react':
+                optional: true
+
+    '@rollup/rollup-linux-x64-gnu@4.61.1':
+        resolution:
+            {
+                integrity: sha512-bVWIOIk6pV01p4CdUbPP7CJ/434z+OooYjDuFcR+44N35YvKUC66G8MGnvcWx5mWKW3g61J+t74l3Kj15Kwn2Q==,
+            }
+        cpu: [x64]
+        os: [linux]
+        libc: [glibc]
+
+    '@rtsao/scc@1.1.0':
+        resolution:
+            {
+                integrity: sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==,
+            }
+
+    '@sapphire/async-queue@1.5.5':
+        resolution:
+            {
+                integrity: sha512-cvGzxbba6sav2zZkH8GPf2oGk9yYoD5qrNWdu9fRehifgnFZJMV+nuy2nON2roRO4yQQ+v7MK/Pktl/HgfsUXg==,
+            }
+        engines: { node: '>=v14.0.0', npm: '>=7.0.0' }
+
+    '@sapphire/shapeshift@4.0.0':
+        resolution:
+            {
+                integrity: sha512-d9dUmWVA7MMiKobL3VpLF8P2aeanRTu6ypG2OIaEv/ZHH/SUQ2iHOVyi5wAPjQ+HmnMuL0whK9ez8I/raWbtIg==,
+            }
+        engines: { node: '>=v16' }
+
+    '@sapphire/snowflake@3.5.3':
+        resolution:
+            {
+                integrity: sha512-jjmJywLAFoWeBi1W7994zZyiNWPIiqRRNAmSERxyg93xRGzNYvGjlZ0gR6x0F4gPRi2+0O6S71kOZYyr3cxaIQ==,
+            }
+        engines: { node: '>=v14.0.0', npm: '>=7.0.0' }
+
+    '@sapphire/snowflake@3.5.5':
+        resolution:
+            {
+                integrity: sha512-xzvBr1Q1c4lCe7i6sRnrofxeO1QTP/LKQ6A6qy0iB4x5yfiSfARMEQEghojzTNALDTcv8En04qYNIco9/K9eZQ==,
+            }
+        engines: { node: '>=v14.0.0', npm: '>=7.0.0' }
+
+    '@smithy/config-resolver@4.5.6':
+        resolution:
+            {
+                integrity: sha512-AXbvUX9aNY2qCLOMCikpl1Df5w2CNFEqbEb6XafG81FJbAbB8avIT7BOx1KDqiO86J/38qKQ3YuakfAfY3iBkQ==,
+            }
+        engines: { node: '>=18.0.0' }
+
+    '@smithy/core@3.24.6':
+        resolution:
+            {
+                integrity: sha512-wBXDRup6UU97VKyaiRo8AssnfStPtG0oAAfpq/bC0a1YYau8pM86YB4kM6ccoVi1mS8l/UHbn9oDM+7uozr/ug==,
+            }
+        engines: { node: '>=18.0.0' }
+
+    '@smithy/credential-provider-imds@4.3.8':
+        resolution:
+            {
+                integrity: sha512-5cAM+KZC02sTqDt6NaLXyu50M/GNMd1eTzDVR8Lb0BBsVtu7RWHo47VPPEEv1vt3Yub6uzr+M5FHC+GtoT0USg==,
+            }
+        engines: { node: '>=18.0.0' }
+
+    '@smithy/eventstream-serde-browser@4.3.6':
+        resolution:
+            {
+                integrity: sha512-BQao/dBhLCJqo953N1hadkcF3M/9G+i6qIgnMupfdpBQomwyhfV7Xfc5jjpCkm8HxfzaWAGrM/2nNnzronFqVQ==,
+            }
+        engines: { node: '>=18.0.0' }
+
+    '@smithy/eventstream-serde-config-resolver@4.4.6':
+        resolution:
+            {
+                integrity: sha512-OUoNRXJGZMM4ivoU7QIzOvCLbavD1YnadNEairrtYhTi+gmGhyn3c2wToL9CxEs4Cw2Ab/KeQM39T1K+/e9YdQ==,
+            }
+        engines: { node: '>=18.0.0' }
+
+    '@smithy/eventstream-serde-node@4.3.6':
+        resolution:
+            {
+                integrity: sha512-M6FeKRMi3oecpTy4EL5n1hLPWydw+xInFYQIzjbGYGBnFtW7IlJjnXrKr/Ev1GpMtmw44QCmrl8+ACEFPmRsIg==,
+            }
+        engines: { node: '>=18.0.0' }
+
+    '@smithy/fetch-http-handler@5.4.6':
+        resolution:
+            {
+                integrity: sha512-FEwEYJ1jlBKdhe9TPzfghEi1bP55ZeEImlDkEa62bBBYzUcnB6RUCyuiS2mqKt6ZVjUbBgcNhzfIctH+Hevx9g==,
+            }
+        engines: { node: '>=18.0.0' }
+
+    '@smithy/hash-blob-browser@4.3.6':
+        resolution:
+            {
+                integrity: sha512-/8D8rOFs2VEwvHwsx68sb6nE7XfVr2wbJTbC1YuKBHPhHeMnOt7IHxr7CoT5wBWujdV4fjVoLPn1BXXP4Ijlow==,
+            }
+        engines: { node: '>=18.0.0' }
+
+    '@smithy/hash-node@4.3.6':
+        resolution:
+            {
+                integrity: sha512-lIZyQ7gDxURrnfkjalM0lKmDnfZYuPzNBYlkza3czPTQNVYsg4e0o90Zx/RpxhamKKOGsQGCsopp0ULsJqltNQ==,
+            }
+        engines: { node: '>=18.0.0' }
+
+    '@smithy/hash-stream-node@4.3.6':
+        resolution:
+            {
+                integrity: sha512-Ziap41FoxpKqmlO9IE68NeFwPKhUJD4PVNcCQ2tl6IUCPSj0KykIuAPnJNWIQbWXvApwCauhRNlAFdt9KRvDpw==,
+            }
+        engines: { node: '>=18.0.0' }
+
+    '@smithy/invalid-dependency@4.3.6':
+        resolution:
+            {
+                integrity: sha512-jUH1Eth7Sgn4KPBX5OKYDRpNjzul7AzsIhxKXT1rHXPTSfY00/7Kb9RtNil5SDAlPPsxaUiesR/rql2wjackmw==,
+            }
+        engines: { node: '>=18.0.0' }
+
+    '@smithy/is-array-buffer@2.2.0':
+        resolution:
+            {
+                integrity: sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==,
+            }
+        engines: { node: '>=14.0.0' }
+
+    '@smithy/md5-js@4.3.6':
+        resolution:
+            {
+                integrity: sha512-LYcuBrO9oiajdRFHyFx3FJAWNKrP89s0grI6mcfpwTAeX2ZJ/9Xyi7Imghh9LT6CIcAy6/k6/MpoUiPNjXr1/w==,
+            }
+        engines: { node: '>=18.0.0' }
+
+    '@smithy/middleware-content-length@4.3.6':
+        resolution:
+            {
+                integrity: sha512-nfpYCrzSFAgfIXmIHFTjOGNeTV3DVF5E5rfi3ZuNfsOjKSpePBOJF3rjyXlWYND0anvxVoqioIwClWCNdKt4Og==,
+            }
+        engines: { node: '>=18.0.0' }
+
+    '@smithy/middleware-endpoint@4.5.6':
+        resolution:
+            {
+                integrity: sha512-zdG5bJZOiM2PRgL2lwcgui6uwZ+s5y6Qsk/rk05Q69sZJT6oi1x+v8Kn++V/q9VY94EgOtEe5kivpu+eGau0wQ==,
+            }
+        engines: { node: '>=18.0.0' }
+
+    '@smithy/middleware-retry@4.6.6':
+        resolution:
+            {
+                integrity: sha512-MWppaYUlc+W4cU2JZnYuMFeOxCWbKO4A57BWti6aCb7hRBK3+CL6llADGpX084hjImsqr3EvCGewArOj7G81eA==,
+            }
+        engines: { node: '>=18.0.0' }
+
+    '@smithy/middleware-serde@4.3.6':
+        resolution:
+            {
+                integrity: sha512-I3fPVYKKEog3a3qdqt1nttP1NBuQOAlNoQxEp6j5pMogSx0HHfid63difhcDgslV6p1XsTXG6D6ieTe13ycJtQ==,
+            }
+        engines: { node: '>=18.0.0' }
+
+    '@smithy/middleware-stack@4.3.6':
+        resolution:
+            {
+                integrity: sha512-QhNiWfg47Kl4SJHmuQvnlzCtlD1eX1J7d/vuuttIE17Ra2YUKp9Srv5lCwa3OvoYaSNWMKYn0PjGIsfCLMJsEA==,
+            }
+        engines: { node: '>=18.0.0' }
+
+    '@smithy/node-config-provider@4.4.6':
+        resolution:
+            {
+                integrity: sha512-M+gG6eQ0y073mSmNB+erRXJvwpsqsN72ol2w6vcd8FEKeG7pqYK0JvzfVqONkPj2ElBB2pg+cU13I850b//Wag==,
+            }
+        engines: { node: '>=18.0.0' }
+
+    '@smithy/node-http-handler@4.7.7':
+        resolution:
+            {
+                integrity: sha512-ZAFvHXrEk6K180EVhmZVg8GU5pUH5BSFqRs27JW3j1qEFx9YyYwWFx17x/MHcjALYimGAji7qEOlF1++be+G5A==,
+            }
+        engines: { node: '>=18.0.0' }
+
+    '@smithy/protocol-http@5.4.6':
+        resolution:
+            {
+                integrity: sha512-H6S7NyaaL+7qO8kIL7VQ7KyrGnKXdllGzJqvtp3hvDen25UOydKV51qGDVK0UciW125jV3CoLJQy/ihc0OEC6A==,
+            }
+        engines: { node: '>=18.0.0' }
+
+    '@smithy/signature-v4@5.4.6':
+        resolution:
+            {
+                integrity: sha512-Ojg4B6oIDlIr1R86xCDJt1zJWnYa0VINmqdjfe9qxWjdRivHalZ3iSlQgVqYbW0MdpFOC5XfHEWsnbmdnpIILQ==,
+            }
+        engines: { node: '>=18.0.0' }
+
+    '@smithy/smithy-client@4.13.6':
+        resolution:
+            {
+                integrity: sha512-tAf35/JW/DvMlACcazcoIOKOV0JBqyOvxjPTEME9W+m9wLcE0G1rwADc7Ntu38rY5C9OH8jZjpo4tbtjmIjEBQ==,
+            }
+        engines: { node: '>=18.0.0' }
+
+    '@smithy/types@4.14.3':
+        resolution:
+            {
+                integrity: sha512-YupL0ZWmFtJexUN2cHzkvvF/b9pKrtAIfT1o7/oY/Ppu8IYeZ+lDPM5vZdQJaSeA132dJCqojjGC9NhXeF71VQ==,
+            }
+        engines: { node: '>=18.0.0' }
+
+    '@smithy/url-parser@4.3.6':
+        resolution:
+            {
+                integrity: sha512-9MRJzwUrlswwHogOR7raDcykuzojZn74qGdQdbEQLVaixlvJuMiIT0g/CejKcmAIgrUVs8brBrnGtmYmBc0iuA==,
+            }
+        engines: { node: '>=18.0.0' }
+
+    '@smithy/util-base64@4.4.6':
+        resolution:
+            {
+                integrity: sha512-V6ApAGvCQnb7Wy1Sy60AQc+7UOEaNQxvAXBLdMi5Zzm66cmX0srvfAxDmg7BGuJ+9H9ez0PPWS/AeFgWxwGavA==,
+            }
+        engines: { node: '>=18.0.0' }
+
+    '@smithy/util-body-length-browser@4.3.6':
+        resolution:
+            {
+                integrity: sha512-+3vGcNHuvzuFLVWL9/wJgucOuQWufhuGhb3oxVDj9SWFGtwkOmtC2nFUwVC2IJoPe45uhs6TAb8bgE4IXDSPzA==,
+            }
+        engines: { node: '>=18.0.0' }
+
+    '@smithy/util-body-length-node@4.3.6':
+        resolution:
+            {
+                integrity: sha512-T15zTQJ/xKYdS0/3CFckhz1QBbhxmhk/xjL6FKvHKgkJPN4E985If2FI9CcV2kh2v0sfiWMfXVEOKFbqgw4m4w==,
+            }
+        engines: { node: '>=18.0.0' }
+
+    '@smithy/util-buffer-from@2.2.0':
+        resolution:
+            {
+                integrity: sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==,
+            }
+        engines: { node: '>=14.0.0' }
+
+    '@smithy/util-defaults-mode-browser@4.4.6':
+        resolution:
+            {
+                integrity: sha512-dRCZKu05AL7KQWrVuRJPotfjCRnvGkCjV56XNP067CRfyTtvgi/Ygu44qrBKb814Hsa52bWwDJ+Vt3pd04BjPA==,
+            }
+        engines: { node: '>=18.0.0' }
+
+    '@smithy/util-defaults-mode-node@4.3.6':
+        resolution:
+            {
+                integrity: sha512-tTR8tayMoa0WeRhtMH7j3WpHUtggBXjh7rBdf7j6POYI69R85gpWBW6B32kaJRnlQU8+0gOGAzJj50S7SU1Egw==,
+            }
+        engines: { node: '>=18.0.0' }
+
+    '@smithy/util-endpoints@3.5.6':
+        resolution:
+            {
+                integrity: sha512-kaB41eVUYC7ajVWUsZRqagxwRaa3VupjQ/Z2Z2v/Vffh/gJ/fFOS25s6mTyR2Lw1FrnBbRWo1iShR9BhekpPeQ==,
+            }
+        engines: { node: '>=18.0.0' }
+
+    '@smithy/util-middleware@4.3.6':
+        resolution:
+            {
+                integrity: sha512-TrAgOcL63TRi7G92arTzq0n+VDrmZifwP1I1T9y2xU3lJpybsHdm33S2d3xaFfG0c8zJNIF9yYRqLSe6rbhH/A==,
+            }
+        engines: { node: '>=18.0.0' }
+
+    '@smithy/util-retry@4.4.6':
+        resolution:
+            {
+                integrity: sha512-E/kFnvWQL6rIPr0Ucjk8oDgJSkKx2bv0nJkJ/cB3ywys7xCqeL1AXP9liHjgYONdQ+MKw/xT06IQK3vgbtu2Ww==,
+            }
+        engines: { node: '>=18.0.0' }
+
+    '@smithy/util-stream@4.6.6':
+        resolution:
+            {
+                integrity: sha512-g+hQ45sPnaIDU4CnaG8EufmeWwziQlcpIvPG6hVY7v65RcUgasM63J/WNfSsXEcZ1zFu9rS/r/qqfDxkIrQtDw==,
+            }
+        engines: { node: '>=18.0.0' }
+
+    '@smithy/util-utf8@2.3.0':
+        resolution:
+            {
+                integrity: sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==,
+            }
+        engines: { node: '>=14.0.0' }
+
+    '@smithy/util-utf8@4.3.6':
+        resolution:
+            {
+                integrity: sha512-tAa4sePYB7mlJzdYbdBqdv37KwFKWixmM/r3ihcI0HFOVjf+a5oGvtcLXcGm4S1bY4DFsLAIOHgjubtp+oRufw==,
+            }
+        engines: { node: '>=18.0.0' }
+
+    '@smithy/util-waiter@4.4.6':
+        resolution:
+            {
+                integrity: sha512-oTt3OP9NcJkrySCSCCdSbP6XLSMNgOmt/ulaiYtb0Ng6tfEWtXQ1mwfyqmLd+GapmDUjbU2mgkf7QIq9H4ij/g==,
+            }
+        engines: { node: '>=18.0.0' }
+
+    '@standard-schema/spec@1.1.0':
+        resolution:
+            {
+                integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==,
+            }
+
+    '@triskcraft/api-types@1.2.1':
+        resolution:
+            {
+                integrity: sha512-WP0gPDxW60apUrdQ9y7FkZTzJgwI5nGPPSoR+eEa4Ec7EcfbgEOyZN+MUUd4u5kHWDKa4u/4th1YIMs5l48CZg==,
+            }
+        engines: { node: '>=24.14' }
+
+    '@types/body-parser@1.19.6':
+        resolution:
+            {
+                integrity: sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==,
+            }
+
+    '@types/busboy@1.5.4':
+        resolution:
+            {
+                integrity: sha512-kG7WrUuAKK0NoyxfQHsVE6j1m01s6kMma64E+OZenQABMQyTJop1DumUWcLwAQ2JzpefU7PDYoRDKl8uZosFjw==,
+            }
+
+    '@types/connect@3.4.38':
+        resolution:
+            {
+                integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==,
+            }
+
+    '@types/cookie-parser@1.4.10':
+        resolution:
+            {
+                integrity: sha512-B4xqkqfZ8Wek+rCOeRxsjMS9OgvzebEzzLYw7NHYuvzb7IdxOkI0ZHGgeEBX4PUM7QGVvNSK60T3OvWj3YfBRg==,
+            }
+        peerDependencies:
+            '@types/express': '*'
+
+    '@types/cors@2.8.19':
+        resolution:
+            {
+                integrity: sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==,
+            }
+
+    '@types/esrecurse@4.3.1':
+        resolution:
+            {
+                integrity: sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==,
+            }
+
+    '@types/estree@1.0.9':
+        resolution:
+            {
+                integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==,
+            }
+
+    '@types/express-serve-static-core@5.1.1':
+        resolution:
+            {
+                integrity: sha512-v4zIMr/cX7/d2BpAEX3KNKL/JrT1s43s96lLvvdTmza1oEvDudCqK9aF/djc/SWgy8Yh0h30TZx5VpzqFCxk5A==,
+            }
+
+    '@types/express@5.0.6':
+        resolution:
+            {
+                integrity: sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==,
+            }
+
+    '@types/http-errors@2.0.5':
+        resolution:
+            {
+                integrity: sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==,
+            }
+
+    '@types/json-schema@7.0.15':
+        resolution:
+            {
+                integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==,
+            }
+
+    '@types/json5@0.0.29':
+        resolution:
+            {
+                integrity: sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==,
+            }
+
+    '@types/luxon@3.7.1':
+        resolution:
+            {
+                integrity: sha512-H3iskjFIAn5SlJU7OuxUmTEpebK6TKB8rxZShDslBMZJ5u9S//KM1sbdAisiSrqwLQncVjnpi2OK2J51h+4lsg==,
+            }
+
+    '@types/multer@2.1.0':
+        resolution:
+            {
+                integrity: sha512-zYZb0+nJhOHtPpGDb3vqPjwpdeGlGC157VpkqNQL+UU2qwoacoQ7MpsAmUptI/0Oa127X32JzWDqQVEXp2RcIA==,
+            }
+
+    '@types/node@25.6.0':
+        resolution:
+            {
+                integrity: sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==,
+            }
+
+    '@types/pg@8.20.0':
+        resolution:
+            {
+                integrity: sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==,
+            }
+
+    '@types/qs@6.15.1':
+        resolution:
+            {
+                integrity: sha512-GZHUBZR9hckSUhrxmp1nG6NwdpM9fCunJwyThLW1X3AyHgd9IlHb6VANpQQqDr2o/qQp6McZ3y/IA2rVzKzSbw==,
+            }
+
+    '@types/range-parser@1.2.7':
+        resolution:
+            {
+                integrity: sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==,
+            }
+
+    '@types/react@19.2.17':
+        resolution:
+            {
+                integrity: sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==,
+            }
+
+    '@types/send@1.2.1':
+        resolution:
+            {
+                integrity: sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==,
+            }
+
+    '@types/serve-static@2.2.0':
+        resolution:
+            {
+                integrity: sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ==,
+            }
+
+    '@types/ws@8.18.1':
+        resolution:
+            {
+                integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==,
+            }
+
+    '@typescript-eslint/eslint-plugin@8.59.1':
+        resolution:
+            {
+                integrity: sha512-BOziFIfE+6osHO9FoJG4zjoHUcvI7fTNBSpdAwrNH0/TLvzjsk2oo8XSSOT2HhqUyhZPfHv4UOffoJ9oEEQ7Ag==,
+            }
+        engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
+        peerDependencies:
+            '@typescript-eslint/parser': ^8.59.1
+            eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+            typescript: '>=4.8.4 <6.1.0'
+
+    '@typescript-eslint/parser@8.59.1':
+        resolution:
+            {
+                integrity: sha512-HDQH9O/47Dxi1ceDhBXdaldtf/WV9yRYMjbjCuNk3qnaTD564qwv61Y7+gTxwxRKzSrgO5uhtw584igXVuuZkA==,
+            }
+        engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
+        peerDependencies:
+            eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+            typescript: '>=4.8.4 <6.1.0'
+
+    '@typescript-eslint/project-service@8.59.1':
+        resolution:
+            {
+                integrity: sha512-+MuHQlHiEr00Of/IQbE/MmEoi44znZHbR/Pz7Opq4HryUOlRi+/44dro9Ycy8Fyo+/024IWtw8m4JUMCGTYxDg==,
+            }
+        engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
+        peerDependencies:
+            typescript: '>=4.8.4 <6.1.0'
+
+    '@typescript-eslint/scope-manager@8.59.1':
+        resolution:
+            {
+                integrity: sha512-LwuHQI4pDOYVKvmH2dkaJo6YZCSgouVgnS/z7yBPKBMvgtBvyLqiLy9Z6b7+m/TRcX1NFYUqZetI5Y+aT4GEfg==,
+            }
+        engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
+
+    '@typescript-eslint/tsconfig-utils@8.59.1':
+        resolution:
+            {
+                integrity: sha512-/0nEyPbX7gRsk0Uwfe4ALwwgxuA66d/l2mhRDNlAvaj4U3juhUtJNq0DsY8M2AYwwb9rEq2hrC3IcIcEt++iJA==,
+            }
+        engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
+        peerDependencies:
+            typescript: '>=4.8.4 <6.1.0'
+
+    '@typescript-eslint/type-utils@8.59.1':
+        resolution:
+            {
+                integrity: sha512-klWPBR2ciQHS3f++ug/mVnWKPjBUo7icEL3FAO1lhAR1Z1i5NQYZ1EannMSRYcq5qCv5wNALlXr6fksRHyYl7w==,
+            }
+        engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
+        peerDependencies:
+            eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+            typescript: '>=4.8.4 <6.1.0'
+
+    '@typescript-eslint/types@8.59.1':
+        resolution:
+            {
+                integrity: sha512-ZDCjgccSdYPw5Bxh+my4Z0lJU96ZDN7jbBzvmEn0FZx3RtU1C7VWl6NbDx94bwY3V5YsgwRzJPOgeY2Q/nLG8A==,
+            }
+        engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
+
+    '@typescript-eslint/typescript-estree@8.59.1':
+        resolution:
+            {
+                integrity: sha512-OUd+vJS05sSkOip+BkZ/2NS8RMxrAAJemsC6vU3kmfLyeaJT0TftHkV9mcx2107MmsBVXXexhVu4F0TZXyMl4g==,
+            }
+        engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
+        peerDependencies:
+            typescript: '>=4.8.4 <6.1.0'
+
+    '@typescript-eslint/utils@8.59.1':
+        resolution:
+            {
+                integrity: sha512-3pIeoXhCeYH9FSCBI8P3iNwJlGuzPlYKkTlen2O9T1DSeeg8UG8jstq6BLk+Mda0qup7mgk4z4XL4OzRaxZ8LA==,
+            }
+        engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
+        peerDependencies:
+            eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+            typescript: '>=4.8.4 <6.1.0'
+
+    '@typescript-eslint/visitor-keys@8.59.1':
+        resolution:
+            {
+                integrity: sha512-LdDNl6C5iJExcM0Yh0PwAIBb9PrSiCsWamF/JyEZawm3kFDnRoaq3LGE4bpyRao/fWeGKKyw7icx0YxrLFC5Cg==,
+            }
+        engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
+
+    '@vladfrangu/async_event_emitter@2.4.7':
+        resolution:
+            {
+                integrity: sha512-Xfe6rpCTxSxfbswi/W/Pz7zp1WWSNn4A0eW4mLkQUewCrXXtMj31lCg+iQyTkh/CkusZSq9eDflu7tjEDXUY6g==,
+            }
+        engines: { node: '>=v14.0.0', npm: '>=7.0.0' }
+
+    accepts@2.0.0:
+        resolution:
+            {
+                integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==,
+            }
+        engines: { node: '>= 0.6' }
+
+    acorn-jsx@5.3.2:
+        resolution:
+            {
+                integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==,
+            }
+        peerDependencies:
+            acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
+
+    acorn@8.16.0:
+        resolution:
+            {
+                integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==,
+            }
+        engines: { node: '>=0.4.0' }
+        hasBin: true
+
+    ajv@6.15.0:
+        resolution:
+            {
+                integrity: sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==,
+            }
+
+    ajv@8.20.0:
+        resolution:
+            {
+                integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==,
+            }
+
+    argon2@0.44.0:
+        resolution:
+            {
+                integrity: sha512-zHPGN3S55sihSQo0dBbK0A5qpi2R31z7HZDZnry3ifOyj8bZZnpZND2gpmhnRGO1V/d555RwBqIK5W4Mrmv3ig==,
+            }
+        engines: { node: '>=16.17.0' }
+
+    array-buffer-byte-length@1.0.2:
+        resolution:
+            {
+                integrity: sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==,
+            }
+        engines: { node: '>= 0.4' }
+
+    array-includes@3.1.9:
+        resolution:
+            {
+                integrity: sha512-FmeCCAenzH0KH381SPT5FZmiA/TmpndpcaShhfgEN9eCVjnFBqq3l1xrI42y8+PPLI6hypzou4GXw00WHmPBLQ==,
+            }
+        engines: { node: '>= 0.4' }
+
+    array.prototype.findlastindex@1.2.6:
+        resolution:
+            {
+                integrity: sha512-F/TKATkzseUExPlfvmwQKGITM3DGTK+vkAsCZoDc5daVygbJBnjEUCbgkAvVFsgfXfX4YIqZ/27G3k3tdXrTxQ==,
+            }
+        engines: { node: '>= 0.4' }
+
+    array.prototype.flat@1.3.3:
+        resolution:
+            {
+                integrity: sha512-rwG/ja1neyLqCuGZ5YYrznA62D4mZXg0i1cIskIUKSiqF3Cje9/wXAls9B9s1Wa2fomMsIv8czB8jZcPmxCXFg==,
+            }
+        engines: { node: '>= 0.4' }
+
+    array.prototype.flatmap@1.3.3:
+        resolution:
+            {
+                integrity: sha512-Y7Wt51eKJSyi80hFrJCePGGNo5ktJCslFuboqJsbf57CCPcm5zztluPlc4/aD8sWsKvlwatezpV4U1efk8kpjg==,
+            }
+        engines: { node: '>= 0.4' }
+
+    arraybuffer.prototype.slice@1.0.4:
+        resolution:
+            {
+                integrity: sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==,
+            }
+        engines: { node: '>= 0.4' }
+
+    async-function@1.0.0:
+        resolution:
+            {
+                integrity: sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==,
+            }
+        engines: { node: '>= 0.4' }
+
+    atomic-sleep@1.0.0:
+        resolution:
+            {
+                integrity: sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==,
+            }
+        engines: { node: '>=8.0.0' }
+
+    available-typed-arrays@1.0.7:
+        resolution:
+            {
+                integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==,
+            }
+        engines: { node: '>= 0.4' }
+
+    aws-ssl-profiles@1.1.2:
+        resolution:
+            {
+                integrity: sha512-NZKeq9AfyQvEeNlN0zSYAaWrmBffJh3IELMZfRpJVWgrpEbtEpnjvzqBPf+mxoI287JohRDoa+/nsfqqiZmF6g==,
+            }
+        engines: { node: '>= 6.0.0' }
+
+    balanced-match@1.0.2:
+        resolution:
+            {
+                integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==,
+            }
+
+    balanced-match@4.0.4:
+        resolution:
+            {
+                integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==,
+            }
+        engines: { node: 18 || 20 || >=22 }
+
+    base64-js@1.5.1:
+        resolution:
+            {
+                integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==,
+            }
+
+    better-result@2.9.2:
+        resolution:
+            {
+                integrity: sha512-WIFoBPCdnTOdk9inkE1ZRvCZ4P0CpSkAiLlchC65N7n9DcjZ3NhqkBOlafzpOVnO8ixyi37kicmSJ3ENhPZl7Q==,
+            }
+
+    body-parser@2.2.2:
+        resolution:
+            {
+                integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==,
+            }
+        engines: { node: '>=18' }
+
+    bowser@2.14.1:
+        resolution:
+            {
+                integrity: sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==,
+            }
+
+    brace-expansion@1.1.15:
+        resolution:
+            {
+                integrity: sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==,
+            }
+
+    brace-expansion@5.0.6:
+        resolution:
+            {
+                integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==,
+            }
+        engines: { node: 18 || 20 || >=22 }
+
+    buffer@5.6.0:
+        resolution:
+            {
+                integrity: sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==,
+            }
+
+    busboy@1.6.0:
+        resolution:
+            {
+                integrity: sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==,
+            }
+        engines: { node: '>=10.16.0' }
+
+    bytes@3.1.2:
+        resolution:
+            {
+                integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==,
+            }
+        engines: { node: '>= 0.8' }
+
+    c12@3.3.4:
+        resolution:
+            {
+                integrity: sha512-cM0ApFQSBXuourJejzwv/AuPRvAxordTyParRVcHjjtXirtkzM0uK2L9TTn9s0cXZbG7E55jCivRQzoxYmRAlA==,
+            }
+        peerDependencies:
+            magicast: '*'
+        peerDependenciesMeta:
+            magicast:
+                optional: true
+
+    call-bind-apply-helpers@1.0.2:
+        resolution:
+            {
+                integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==,
+            }
+        engines: { node: '>= 0.4' }
+
+    call-bind@1.0.9:
+        resolution:
+            {
+                integrity: sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==,
+            }
+        engines: { node: '>= 0.4' }
+
+    call-bound@1.0.4:
+        resolution:
+            {
+                integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==,
+            }
+        engines: { node: '>= 0.4' }
+
+    chart.js@4.5.1:
+        resolution:
+            {
+                integrity: sha512-GIjfiT9dbmHRiYi6Nl2yFCq7kkwdkp1W/lp2J99rX0yo9tgJGn3lKQATztIjb5tVtevcBtIdICNWqlq5+E8/Pw==,
+            }
+        engines: { pnpm: '>=8' }
+
+    chokidar@5.0.0:
+        resolution:
+            {
+                integrity: sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==,
+            }
+        engines: { node: '>= 20.19.0' }
+
+    colorette@2.0.20:
+        resolution:
+            {
+                integrity: sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==,
+            }
+
+    concat-map@0.0.1:
+        resolution:
+            {
+                integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==,
+            }
+
+    confbox@0.2.4:
+        resolution:
+            {
+                integrity: sha512-ysOGlgTFbN2/Y6Cg3Iye8YKulHw+R2fNXHrgSmXISQdMnomY6eNDprVdW9R5xBguEqI954+S6709UyiO7B+6OQ==,
+            }
+
+    content-disposition@1.1.0:
+        resolution:
+            {
+                integrity: sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==,
+            }
+        engines: { node: '>=18' }
+
+    content-type@1.0.5:
+        resolution:
+            {
+                integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==,
+            }
+        engines: { node: '>= 0.6' }
+
+    content-type@2.0.0:
+        resolution:
+            {
+                integrity: sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==,
+            }
+        engines: { node: '>=18' }
+
+    cookie-parser@1.4.7:
+        resolution:
+            {
+                integrity: sha512-nGUvgXnotP3BsjiLX2ypbQnWoGUPIIfHQNZkkC668ntrzGWEZVW70HDEB1qnNGMicPje6EttlIgzo51YSwNQGw==,
+            }
+        engines: { node: '>= 0.8.0' }
+
+    cookie-signature@1.0.6:
+        resolution:
+            {
+                integrity: sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==,
+            }
+
+    cookie-signature@1.2.2:
+        resolution:
+            {
+                integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==,
+            }
+        engines: { node: '>=6.6.0' }
+
+    cookie@0.7.2:
+        resolution:
+            {
+                integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==,
+            }
+        engines: { node: '>= 0.6' }
+
+    cors@2.8.6:
+        resolution:
+            {
+                integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==,
+            }
+        engines: { node: '>= 0.10' }
+
+    cross-env@10.1.0:
+        resolution:
+            {
+                integrity: sha512-GsYosgnACZTADcmEyJctkJIoqAhHjttw7RsFrVoJNXbsWWqaq6Ym+7kZjq6mS45O0jij6vtiReppKQEtqWy6Dw==,
+            }
+        engines: { node: '>=20' }
+        hasBin: true
+
+    cross-spawn@7.0.6:
+        resolution:
+            {
+                integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==,
+            }
+        engines: { node: '>= 8' }
+
+    csstype@3.2.3:
+        resolution:
+            {
+                integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==,
+            }
+
+    data-view-buffer@1.0.2:
+        resolution:
+            {
+                integrity: sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==,
+            }
+        engines: { node: '>= 0.4' }
+
+    data-view-byte-length@1.0.2:
+        resolution:
+            {
+                integrity: sha512-tuhGbE6CfTM9+5ANGf+oQb72Ky/0+s3xKUpHvShfiz2RxMFgFPjsXuRLBVMtvMs15awe45SRb83D6wH4ew6wlQ==,
+            }
+        engines: { node: '>= 0.4' }
+
+    data-view-byte-offset@1.0.1:
+        resolution:
+            {
+                integrity: sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==,
+            }
+        engines: { node: '>= 0.4' }
+
+    dateformat@4.6.3:
+        resolution:
+            {
+                integrity: sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==,
+            }
+
+    debug@3.2.7:
+        resolution:
+            {
+                integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==,
+            }
+        peerDependencies:
+            supports-color: '*'
+        peerDependenciesMeta:
+            supports-color:
+                optional: true
+
+    debug@4.4.3:
+        resolution:
+            {
+                integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==,
+            }
+        engines: { node: '>=6.0' }
+        peerDependencies:
+            supports-color: '*'
+        peerDependenciesMeta:
+            supports-color:
+                optional: true
+
+    deep-is@0.1.4:
+        resolution:
+            {
+                integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==,
+            }
+
+    deepmerge-ts@7.1.5:
+        resolution:
+            {
+                integrity: sha512-HOJkrhaYsweh+W+e74Yn7YStZOilkoPb6fycpwNLKzSPtruFs48nYis0zy5yJz1+ktUhHxoRDJ27RQAWLIJVJw==,
+            }
+        engines: { node: '>=16.0.0' }
+
+    define-data-property@1.1.4:
+        resolution:
+            {
+                integrity: sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==,
+            }
+        engines: { node: '>= 0.4' }
+
+    define-properties@1.2.1:
+        resolution:
+            {
+                integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==,
+            }
+        engines: { node: '>= 0.4' }
+
+    defu@6.1.7:
+        resolution:
+            {
+                integrity: sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==,
+            }
+
+    denque@2.1.0:
+        resolution:
+            {
+                integrity: sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==,
+            }
+        engines: { node: '>=0.10' }
+
+    depd@2.0.0:
+        resolution:
+            {
+                integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==,
+            }
+        engines: { node: '>= 0.8' }
+
+    destr@2.0.5:
+        resolution:
+            {
+                integrity: sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA==,
+            }
+
+    discord-api-types@0.38.48:
+        resolution:
+            {
+                integrity: sha512-WFUE/2o0lBlLeCQonQ+Pu2RqHAqbytBJ2RlXR91gzk05InSS6k9ShzzLYoymrA4c2oRgRKGE7/VqQJNNdGWSxQ==,
+            }
+
+    discord.js@14.26.3:
+        resolution:
+            {
+                integrity: sha512-XEKtYn28YFsiJ5l4fLRyikdbo6RD5oFyqfVHQlvXz2104JhH/E8slN28dbky05w3DCrJcNVWvhVvcJCTSl/KIg==,
+            }
+        engines: { node: '>=18' }
+
+    doctrine@2.1.0:
+        resolution:
+            {
+                integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==,
+            }
+        engines: { node: '>=0.10.0' }
+
+    dotenv@17.4.2:
+        resolution:
+            {
+                integrity: sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==,
+            }
+        engines: { node: '>=12' }
+
+    dunder-proto@1.0.1:
+        resolution:
+            {
+                integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==,
+            }
+        engines: { node: '>= 0.4' }
+
+    ee-first@1.1.1:
+        resolution:
+            {
+                integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==,
+            }
+
+    effect@3.20.0:
+        resolution:
+            {
+                integrity: sha512-qMLfDJscrNG8p/aw+IkT9W7fgj50Z4wG5bLBy0Txsxz8iUHjDIkOgO3SV0WZfnQbNG2VJYb0b+rDLMrhM4+Krw==,
+            }
+
+    empathic@2.0.0:
+        resolution:
+            {
+                integrity: sha512-i6UzDscO/XfAcNYD75CfICkmfLedpyPDdozrLMmQc5ORaQcdMoc21OnlEylMIqI7U8eniKrPMxxtj8k0vhmJhA==,
+            }
+        engines: { node: '>=14' }
+
+    encodeurl@2.0.0:
+        resolution:
+            {
+                integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==,
+            }
+        engines: { node: '>= 0.8' }
+
+    end-of-stream@1.4.5:
+        resolution:
+            {
+                integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==,
+            }
+
+    env-paths@3.0.0:
+        resolution:
+            {
+                integrity: sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A==,
+            }
+        engines: { node: ^12.20.0 || ^14.13.1 || >=16.0.0 }
+
+    es-abstract@1.24.2:
+        resolution:
+            {
+                integrity: sha512-2FpH9Q5i2RRwyEP1AylXe6nYLR5OhaJTZwmlcP0dL/+JCbgg7yyEo/sEK6HeGZRf3dFpWwThaRHVApXSkW3xeg==,
+            }
+        engines: { node: '>= 0.4' }
+
+    es-define-property@1.0.1:
+        resolution:
+            {
+                integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==,
+            }
+        engines: { node: '>= 0.4' }
+
+    es-errors@1.3.0:
+        resolution:
+            {
+                integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==,
+            }
+        engines: { node: '>= 0.4' }
+
+    es-object-atoms@1.1.2:
+        resolution:
+            {
+                integrity: sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==,
+            }
+        engines: { node: '>= 0.4' }
+
+    es-set-tostringtag@2.1.0:
+        resolution:
+            {
+                integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==,
+            }
+        engines: { node: '>= 0.4' }
+
+    es-shim-unscopables@1.1.0:
+        resolution:
+            {
+                integrity: sha512-d9T8ucsEhh8Bi1woXCf+TIKDIROLG5WCkxg8geBCbvk22kzwC5G2OnXVMO6FUsvQlgUUXQ2itephWDLqDzbeCw==,
+            }
+        engines: { node: '>= 0.4' }
+
+    es-to-primitive@1.3.0:
+        resolution:
+            {
+                integrity: sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==,
+            }
+        engines: { node: '>= 0.4' }
+
+    escape-html@1.0.3:
+        resolution:
+            {
+                integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==,
+            }
+
+    escape-string-regexp@4.0.0:
+        resolution:
+            {
+                integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==,
+            }
+        engines: { node: '>=10' }
+
+    eslint-config-prettier@10.1.8:
+        resolution:
+            {
+                integrity: sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==,
+            }
+        hasBin: true
+        peerDependencies:
+            eslint: '>=7.0.0'
+
+    eslint-import-resolver-node@0.3.10:
+        resolution:
+            {
+                integrity: sha512-tRrKqFyCaKict5hOd244sL6EQFNycnMQnBe+j8uqGNXYzsImGbGUU4ibtoaBmv5FLwJwcFJNeg1GeVjQfbMrDQ==,
+            }
+
+    eslint-module-utils@2.13.0:
+        resolution:
+            {
+                integrity: sha512-bLohSkT6469rRs8czj0tLTD8vaeIS/whvPRJVjDr7IuoTT1k5DYDERlNycjDj/HkOlvQdYurmfZ/g3fG5bgeLQ==,
+            }
+        engines: { node: '>=4' }
+        peerDependencies:
+            '@typescript-eslint/parser': '*'
+            eslint: '*'
+            eslint-import-resolver-node: '*'
+            eslint-import-resolver-typescript: '*'
+            eslint-import-resolver-webpack: '*'
+        peerDependenciesMeta:
+            '@typescript-eslint/parser':
+                optional: true
+            eslint:
+                optional: true
+            eslint-import-resolver-node:
+                optional: true
+            eslint-import-resolver-typescript:
+                optional: true
+            eslint-import-resolver-webpack:
+                optional: true
+
+    eslint-plugin-import@2.32.0:
+        resolution:
+            {
+                integrity: sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==,
+            }
+        engines: { node: '>=4' }
+        peerDependencies:
+            '@typescript-eslint/parser': '*'
+            eslint: 10.2.1
+        peerDependenciesMeta:
+            '@typescript-eslint/parser':
+                optional: true
+
+    eslint-scope@9.1.2:
+        resolution:
+            {
+                integrity: sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==,
+            }
+        engines: { node: ^20.19.0 || ^22.13.0 || >=24 }
+
+    eslint-visitor-keys@3.4.3:
+        resolution:
+            {
+                integrity: sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==,
+            }
+        engines: { node: ^12.22.0 || ^14.17.0 || >=16.0.0 }
+
+    eslint-visitor-keys@5.0.1:
+        resolution:
+            {
+                integrity: sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==,
+            }
+        engines: { node: ^20.19.0 || ^22.13.0 || >=24 }
+
+    eslint@10.2.1:
+        resolution:
+            {
+                integrity: sha512-wiyGaKsDgqXvF40P8mDwiUp/KQjE1FdrIEJsM8PZ3XCiniTMXS3OHWWUe5FI5agoCnr8x4xPrTDZuxsBlNHl+Q==,
+            }
+        engines: { node: ^20.19.0 || ^22.13.0 || >=24 }
+        hasBin: true
+        peerDependencies:
+            jiti: '*'
+        peerDependenciesMeta:
+            jiti:
+                optional: true
+
+    espree@11.2.0:
+        resolution:
+            {
+                integrity: sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==,
+            }
+        engines: { node: ^20.19.0 || ^22.13.0 || >=24 }
+
+    esquery@1.7.0:
+        resolution:
+            {
+                integrity: sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==,
+            }
+        engines: { node: '>=0.10' }
+
+    esrecurse@4.3.0:
+        resolution:
+            {
+                integrity: sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==,
+            }
+        engines: { node: '>=4.0' }
+
+    estraverse@5.3.0:
+        resolution:
+            {
+                integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==,
+            }
+        engines: { node: '>=4.0' }
+
+    esutils@2.0.3:
+        resolution:
+            {
+                integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==,
+            }
+        engines: { node: '>=0.10.0' }
+
+    etag@1.8.1:
+        resolution:
+            {
+                integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==,
+            }
+        engines: { node: '>= 0.6' }
+
+    events@3.3.0:
+        resolution:
+            {
+                integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==,
+            }
+        engines: { node: '>=0.8.x' }
+
+    express@5.2.1:
+        resolution:
+            {
+                integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==,
+            }
+        engines: { node: '>= 18' }
+
+    exsolve@1.0.8:
+        resolution:
+            {
+                integrity: sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==,
+            }
+
+    fast-check@3.23.2:
+        resolution:
+            {
+                integrity: sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A==,
+            }
+        engines: { node: '>=8.0.0' }
+
+    fast-copy@4.0.3:
+        resolution:
+            {
+                integrity: sha512-58apWr0GUiDFM8+3afrO6eYwJBn9ZAhDOzG3L+/9llab/haCARS2UIfffmOurYLwbgDRs8n0rfr6qAAPEAuAQw==,
+            }
+
+    fast-deep-equal@3.1.3:
+        resolution:
+            {
+                integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==,
+            }
+
+    fast-json-stable-stringify@2.1.0:
+        resolution:
+            {
+                integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==,
+            }
+
+    fast-levenshtein@2.0.6:
+        resolution:
+            {
+                integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==,
+            }
+
+    fast-safe-stringify@2.1.1:
+        resolution:
+            {
+                integrity: sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==,
+            }
+
+    fast-uri@3.1.2:
+        resolution:
+            {
+                integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==,
+            }
+
+    fast-xml-builder@1.2.0:
+        resolution:
+            {
+                integrity: sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==,
+            }
+
+    fast-xml-parser@5.7.3:
+        resolution:
+            {
+                integrity: sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg==,
+            }
+        hasBin: true
+
+    fdir@6.5.0:
+        resolution:
+            {
+                integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==,
+            }
+        engines: { node: '>=12.0.0' }
+        peerDependencies:
+            picomatch: ^3 || ^4
+        peerDependenciesMeta:
+            picomatch:
+                optional: true
+
+    file-entry-cache@8.0.0:
+        resolution:
+            {
+                integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==,
+            }
+        engines: { node: '>=16.0.0' }
+
+    finalhandler@2.1.1:
+        resolution:
+            {
+                integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==,
+            }
+        engines: { node: '>= 18.0.0' }
+
+    find-up@5.0.0:
+        resolution:
+            {
+                integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==,
+            }
+        engines: { node: '>=10' }
+
+    flat-cache@4.0.1:
+        resolution:
+            {
+                integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==,
+            }
+        engines: { node: '>=16' }
+
+    flatted@3.4.2:
+        resolution:
+            {
+                integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==,
+            }
+
+    for-each@0.3.5:
+        resolution:
+            {
+                integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==,
+            }
+        engines: { node: '>= 0.4' }
+
+    foreground-child@3.3.1:
+        resolution:
+            {
+                integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==,
+            }
+        engines: { node: '>=14' }
+
+    forwarded@0.2.0:
+        resolution:
+            {
+                integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==,
+            }
+        engines: { node: '>= 0.6' }
+
+    fresh@2.0.0:
+        resolution:
+            {
+                integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==,
+            }
+        engines: { node: '>= 0.8' }
+
+    function-bind@1.1.2:
+        resolution:
+            {
+                integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==,
+            }
+
+    function.prototype.name@1.1.8:
+        resolution:
+            {
+                integrity: sha512-e5iwyodOHhbMr/yNrc7fDYG4qlbIvI5gajyzPnb5TCwyhjApznQh1BMFou9b30SevY43gCJKXycoCBjMbsuW0Q==,
+            }
+        engines: { node: '>= 0.4' }
+
+    functions-have-names@1.2.3:
+        resolution:
+            {
+                integrity: sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==,
+            }
+
+    generate-function@2.3.1:
+        resolution:
+            {
+                integrity: sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==,
+            }
+
+    generator-function@2.0.1:
+        resolution:
+            {
+                integrity: sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==,
+            }
+        engines: { node: '>= 0.4' }
+
+    get-intrinsic@1.3.0:
+        resolution:
+            {
+                integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==,
+            }
+        engines: { node: '>= 0.4' }
+
+    get-port-please@3.2.0:
+        resolution:
+            {
+                integrity: sha512-I9QVvBw5U/hw3RmWpYKRumUeaDgxTPd401x364rLmWBJcOQ753eov1eTgzDqRG9bqFIfDc7gfzcQEWrUri3o1A==,
+            }
+
+    get-proto@1.0.1:
+        resolution:
+            {
+                integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==,
+            }
+        engines: { node: '>= 0.4' }
+
+    get-symbol-description@1.1.0:
+        resolution:
+            {
+                integrity: sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg==,
+            }
+        engines: { node: '>= 0.4' }
+
+    giget@3.2.0:
+        resolution:
+            {
+                integrity: sha512-GvHTWcykIR/fP8cj8dMpuMMkvaeJfPvYnhq0oW+chSeIr+ldX21ifU2Ms6KBoyKZQZmVaUAAhQ2EZ68KJF8a7A==,
+            }
+        hasBin: true
+
+    glob-parent@6.0.2:
+        resolution:
+            {
+                integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==,
+            }
+        engines: { node: '>=10.13.0' }
+
+    globals@17.5.0:
+        resolution:
+            {
+                integrity: sha512-qoV+HK2yFl/366t2/Cb3+xxPUo5BuMynomoDmiaZBIdbs+0pYbjfZU+twLhGKp4uCZ/+NbtpVepH5bGCxRyy2g==,
+            }
+        engines: { node: '>=18' }
+
+    globalthis@1.0.4:
+        resolution:
+            {
+                integrity: sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==,
+            }
+        engines: { node: '>= 0.4' }
+
+    gopd@1.2.0:
+        resolution:
+            {
+                integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==,
+            }
+        engines: { node: '>= 0.4' }
+
+    graceful-fs@4.2.11:
+        resolution:
+            {
+                integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==,
+            }
+
+    grammex@3.1.12:
+        resolution:
+            {
+                integrity: sha512-6ufJOsSA7LcQehIJNCO7HIBykfM7DXQual0Ny780/DEcJIpBlHRvcqEBWGPYd7hrXL2GJ3oJI1MIhaXjWmLQOQ==,
+            }
+
+    graphmatch@1.1.1:
+        resolution:
+            {
+                integrity: sha512-5ykVn/EXM1hF0XCaWh05VbYvEiOL2lY1kBxZtaYsyvjp7cmWOU1XsAdfQBwClraEofXDT197lFbXOEVMHpvQOg==,
+            }
+
+    has-bigints@1.1.0:
+        resolution:
+            {
+                integrity: sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==,
+            }
+        engines: { node: '>= 0.4' }
+
+    has-property-descriptors@1.0.2:
+        resolution:
+            {
+                integrity: sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==,
+            }
+
+    has-proto@1.2.0:
+        resolution:
+            {
+                integrity: sha512-KIL7eQPfHQRC8+XluaIw7BHUwwqL19bQn4hzNgdr+1wXoU0KKj6rufu47lhY7KbJR2C6T6+PfyN0Ea7wkSS+qQ==,
+            }
+        engines: { node: '>= 0.4' }
+
+    has-symbols@1.1.0:
+        resolution:
+            {
+                integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==,
+            }
+        engines: { node: '>= 0.4' }
+
+    has-tostringtag@1.0.2:
+        resolution:
+            {
+                integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==,
+            }
+        engines: { node: '>= 0.4' }
+
+    hasown@2.0.4:
+        resolution:
+            {
+                integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==,
+            }
+        engines: { node: '>= 0.4' }
+
+    help-me@5.0.0:
+        resolution:
+            {
+                integrity: sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg==,
+            }
+
+    hono@4.12.23:
+        resolution:
+            {
+                integrity: sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA==,
+            }
+        engines: { node: '>=16.9.0' }
+
+    http-errors@2.0.1:
+        resolution:
+            {
+                integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==,
+            }
+        engines: { node: '>= 0.8' }
+
+    http-status-codes@2.3.0:
+        resolution:
+            {
+                integrity: sha512-RJ8XvFvpPM/Dmc5SV+dC4y5PCeOhT3x1Hq0NU3rjGeg5a/CqlhZ7uudknPwZFz4aeAXDcbAyaeP7GAo9lvngtA==,
+            }
+
+    iconv-lite@0.7.2:
+        resolution:
+            {
+                integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==,
+            }
+        engines: { node: '>=0.10.0' }
+
+    ieee754@1.2.1:
+        resolution:
+            {
+                integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==,
+            }
+
+    ignore@5.3.2:
+        resolution:
+            {
+                integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==,
+            }
+        engines: { node: '>= 4' }
+
+    ignore@7.0.5:
+        resolution:
+            {
+                integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==,
+            }
+        engines: { node: '>= 4' }
+
+    imurmurhash@0.1.4:
+        resolution:
+            {
+                integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==,
+            }
+        engines: { node: '>=0.8.19' }
+
+    inherits@2.0.4:
+        resolution:
+            {
+                integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==,
+            }
+
+    internal-slot@1.1.0:
+        resolution:
+            {
+                integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==,
+            }
+        engines: { node: '>= 0.4' }
+
+    ipaddr.js@1.9.1:
+        resolution:
+            {
+                integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==,
+            }
+        engines: { node: '>= 0.10' }
+
+    is-array-buffer@3.0.5:
+        resolution:
+            {
+                integrity: sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==,
+            }
+        engines: { node: '>= 0.4' }
+
+    is-async-function@2.1.1:
+        resolution:
+            {
+                integrity: sha512-9dgM/cZBnNvjzaMYHVoxxfPj2QXt22Ev7SuuPrs+xav0ukGB0S6d4ydZdEiM48kLx5kDV+QBPrpVnFyefL8kkQ==,
+            }
+        engines: { node: '>= 0.4' }
+
+    is-bigint@1.1.0:
+        resolution:
+            {
+                integrity: sha512-n4ZT37wG78iz03xPRKJrHTdZbe3IicyucEtdRsV5yglwc3GyUfbAfpSeD0FJ41NbUNSt5wbhqfp1fS+BgnvDFQ==,
+            }
+        engines: { node: '>= 0.4' }
+
+    is-boolean-object@1.2.2:
+        resolution:
+            {
+                integrity: sha512-wa56o2/ElJMYqjCjGkXri7it5FbebW5usLw/nPmCMs5DeZ7eziSYZhSmPRn0txqeW4LnAmQQU7FgqLpsEFKM4A==,
+            }
+        engines: { node: '>= 0.4' }
+
+    is-callable@1.2.7:
+        resolution:
+            {
+                integrity: sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==,
+            }
+        engines: { node: '>= 0.4' }
+
+    is-core-module@2.16.2:
+        resolution:
+            {
+                integrity: sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==,
+            }
+        engines: { node: '>= 0.4' }
+
+    is-data-view@1.0.2:
+        resolution:
+            {
+                integrity: sha512-RKtWF8pGmS87i2D6gqQu/l7EYRlVdfzemCJN/P3UOs//x1QE7mfhvzHIApBTRf7axvT6DMGwSwBXYCT0nfB9xw==,
+            }
+        engines: { node: '>= 0.4' }
+
+    is-date-object@1.1.0:
+        resolution:
+            {
+                integrity: sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==,
+            }
+        engines: { node: '>= 0.4' }
+
+    is-extglob@2.1.1:
+        resolution:
+            {
+                integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==,
+            }
+        engines: { node: '>=0.10.0' }
+
+    is-finalizationregistry@1.1.1:
+        resolution:
+            {
+                integrity: sha512-1pC6N8qWJbWoPtEjgcL2xyhQOP491EQjeUo3qTKcmV8YSDDJrOepfG8pcC7h/QgnQHYSv0mJ3Z/ZWxmatVrysg==,
+            }
+        engines: { node: '>= 0.4' }
+
+    is-generator-function@1.1.2:
+        resolution:
+            {
+                integrity: sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==,
+            }
+        engines: { node: '>= 0.4' }
+
+    is-glob@4.0.3:
+        resolution:
+            {
+                integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==,
+            }
+        engines: { node: '>=0.10.0' }
+
+    is-map@2.0.3:
+        resolution:
+            {
+                integrity: sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==,
+            }
+        engines: { node: '>= 0.4' }
+
+    is-negative-zero@2.0.3:
+        resolution:
+            {
+                integrity: sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==,
+            }
+        engines: { node: '>= 0.4' }
+
+    is-number-object@1.1.1:
+        resolution:
+            {
+                integrity: sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==,
+            }
+        engines: { node: '>= 0.4' }
+
+    is-promise@4.0.0:
+        resolution:
+            {
+                integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==,
+            }
+
+    is-property@1.0.2:
+        resolution:
+            {
+                integrity: sha512-Ks/IoX00TtClbGQr4TWXemAnktAQvYB7HzcCxDGqEZU6oCmb2INHuOoKxbtR+HFkmYWBKv/dOZtGRiAjDhj92g==,
+            }
+
+    is-regex@1.2.1:
+        resolution:
+            {
+                integrity: sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==,
+            }
+        engines: { node: '>= 0.4' }
+
+    is-set@2.0.3:
+        resolution:
+            {
+                integrity: sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg==,
+            }
+        engines: { node: '>= 0.4' }
+
+    is-shared-array-buffer@1.0.4:
+        resolution:
+            {
+                integrity: sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A==,
+            }
+        engines: { node: '>= 0.4' }
+
+    is-string@1.1.1:
+        resolution:
+            {
+                integrity: sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA==,
+            }
+        engines: { node: '>= 0.4' }
+
+    is-symbol@1.1.1:
+        resolution:
+            {
+                integrity: sha512-9gGx6GTtCQM73BgmHQXfDmLtfjjTUDSyoxTCbp5WtoixAhfgsDirWIcVQ/IHpvI5Vgd5i/J5F7B9cN/WlVbC/w==,
+            }
+        engines: { node: '>= 0.4' }
+
+    is-typed-array@1.1.15:
+        resolution:
+            {
+                integrity: sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==,
+            }
+        engines: { node: '>= 0.4' }
+
+    is-weakmap@2.0.2:
+        resolution:
+            {
+                integrity: sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==,
+            }
+        engines: { node: '>= 0.4' }
+
+    is-weakref@1.1.1:
+        resolution:
+            {
+                integrity: sha512-6i9mGWSlqzNMEqpCp93KwRS1uUOodk2OJ6b+sq7ZPDSy2WuI5NFIxp/254TytR8ftefexkWn5xNiHUNpPOfSew==,
+            }
+        engines: { node: '>= 0.4' }
+
+    is-weakset@2.0.4:
+        resolution:
+            {
+                integrity: sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ==,
+            }
+        engines: { node: '>= 0.4' }
+
+    isarray@2.0.5:
+        resolution:
+            {
+                integrity: sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==,
+            }
+
+    isexe@2.0.0:
+        resolution:
+            {
+                integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==,
+            }
+
+    jiti@2.7.0:
+        resolution:
+            {
+                integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==,
+            }
+        hasBin: true
+
+    jose@6.2.3:
+        resolution:
+            {
+                integrity: sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==,
+            }
+
+    joycon@3.1.1:
+        resolution:
+            {
+                integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==,
+            }
+        engines: { node: '>=10' }
+
+    jsbi@4.3.2:
+        resolution:
+            {
+                integrity: sha512-9fqMSQbhJykSeii05nxKl4m6Eqn2P6rOlYiS+C5Dr/HPIU/7yZxu5qzbs40tgaFORiw2Amd0mirjxatXYMkIew==,
+            }
+
+    json-buffer@3.0.1:
+        resolution:
+            {
+                integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==,
+            }
+
+    json-schema-traverse@0.4.1:
+        resolution:
+            {
+                integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==,
+            }
+
+    json-schema-traverse@1.0.0:
+        resolution:
+            {
+                integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==,
+            }
+
+    json-stable-stringify-without-jsonify@1.0.1:
+        resolution:
+            {
+                integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==,
+            }
+
+    json5@1.0.2:
+        resolution:
+            {
+                integrity: sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==,
+            }
+        hasBin: true
+
+    keyv@4.5.4:
+        resolution:
+            {
+                integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==,
+            }
+
+    levn@0.4.1:
+        resolution:
+            {
+                integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==,
+            }
+        engines: { node: '>= 0.8.0' }
+
+    locate-path@6.0.0:
+        resolution:
+            {
+                integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==,
+            }
+        engines: { node: '>=10' }
+
+    lodash.snakecase@4.1.1:
+        resolution:
+            {
+                integrity: sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw==,
+            }
+
+    lodash@4.18.1:
+        resolution:
+            {
+                integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==,
+            }
+
+    long@5.3.2:
+        resolution:
+            {
+                integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==,
+            }
+
+    lru.min@1.1.4:
+        resolution:
+            {
+                integrity: sha512-DqC6n3QQ77zdFpCMASA1a3Jlb64Hv2N2DciFGkO/4L9+q/IpIAuRlKOvCXabtRW6cQf8usbmM6BE/TOPysCdIA==,
+            }
+        engines: { bun: '>=1.0.0', deno: '>=1.30.0', node: '>=8.0.0' }
+
+    luxon@3.7.2:
+        resolution:
+            {
+                integrity: sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==,
+            }
+        engines: { node: '>=12' }
+
+    magic-bytes.js@1.13.0:
+        resolution:
+            {
+                integrity: sha512-afO2mnxW7GDTXMm5/AoN1WuOcdoKhtgXjIvHmobqTD1grNplhGdv3PFOyjCVmrnOZBIT/gD/koDKpYG+0mvHcg==,
+            }
+
+    math-intrinsics@1.1.0:
+        resolution:
+            {
+                integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==,
+            }
+        engines: { node: '>= 0.4' }
+
+    media-typer@1.1.0:
+        resolution:
+            {
+                integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==,
+            }
+        engines: { node: '>= 0.8' }
+
+    merge-descriptors@2.0.0:
+        resolution:
+            {
+                integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==,
+            }
+        engines: { node: '>=18' }
+
+    mime-db@1.54.0:
+        resolution:
+            {
+                integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==,
+            }
+        engines: { node: '>= 0.6' }
+
+    mime-types@3.0.2:
+        resolution:
+            {
+                integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==,
+            }
+        engines: { node: '>=18' }
+
+    minimatch@10.2.5:
+        resolution:
+            {
+                integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==,
+            }
+        engines: { node: 18 || 20 || >=22 }
+
+    minimatch@3.1.5:
+        resolution:
+            {
+                integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==,
+            }
+
+    minimist@1.2.8:
+        resolution:
+            {
+                integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==,
+            }
+
+    ms@2.1.3:
+        resolution:
+            {
+                integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==,
+            }
+
+    mysql2@3.15.3:
+        resolution:
+            {
+                integrity: sha512-FBrGau0IXmuqg4haEZRBfHNWB5mUARw6hNwPDXXGg0XzVJ50mr/9hb267lvpVMnhZ1FON3qNd4Xfcez1rbFwSg==,
+            }
+        engines: { node: '>= 8.0' }
+
+    named-placeholders@1.1.6:
+        resolution:
+            {
+                integrity: sha512-Tz09sEL2EEuv5fFowm419c1+a/jSMiBjI9gHxVLrVdbUkkNUUfjsVYs9pVZu5oCon/kmRh9TfLEObFtkVxmY0w==,
+            }
+        engines: { node: '>=8.0.0' }
+
+    natural-compare@1.4.0:
+        resolution:
+            {
+                integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==,
+            }
+
+    negotiator@1.0.0:
+        resolution:
+            {
+                integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==,
+            }
+        engines: { node: '>= 0.6' }
+
+    neverthrow@8.2.0:
+        resolution:
+            {
+                integrity: sha512-kOCT/1MCPAxY5iUV3wytNFUMUolzuwd/VF/1KCx7kf6CutrOsTie+84zTGTpgQycjvfLdBBdvBvFLqFD2c0wkQ==,
+            }
+        engines: { node: '>=18' }
+
+    node-addon-api@8.8.0:
+        resolution:
+            {
+                integrity: sha512-c5Ko1fZJIJmzhFIkhRN76WTq+fC6tWnGy9CXA0fA+XygsWZmEwG8vmbkNqxMyoaa0Tin4djul49NzdVcJJcjeA==,
+            }
+        engines: { node: ^18 || ^20 || >= 21 }
+
+    node-exports-info@1.6.0:
+        resolution:
+            {
+                integrity: sha512-pyFS63ptit/P5WqUkt+UUfe+4oevH+bFeIiPPdfb0pFeYEu/1ELnJu5l+5EcTKYL5M7zaAa7S8ddywgXypqKCw==,
+            }
+        engines: { node: '>= 0.4' }
+
+    node-gyp-build@4.8.4:
+        resolution:
+            {
+                integrity: sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==,
+            }
+        hasBin: true
+
+    object-assign@4.1.1:
+        resolution:
+            {
+                integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==,
+            }
+        engines: { node: '>=0.10.0' }
+
+    object-inspect@1.13.4:
+        resolution:
+            {
+                integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==,
+            }
+        engines: { node: '>= 0.4' }
+
+    object-keys@1.1.1:
+        resolution:
+            {
+                integrity: sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==,
+            }
+        engines: { node: '>= 0.4' }
+
+    object.assign@4.1.7:
+        resolution:
+            {
+                integrity: sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==,
+            }
+        engines: { node: '>= 0.4' }
+
+    object.entries@1.1.9:
+        resolution:
+            {
+                integrity: sha512-8u/hfXFRBD1O0hPUjioLhoWFHRmt6tKA4/vZPyckBr18l1KE9uHrFaFaUi8MDRTpi4uak2goyPTSNJLXX2k2Hw==,
+            }
+        engines: { node: '>= 0.4' }
+
+    object.fromentries@2.0.8:
+        resolution:
+            {
+                integrity: sha512-k6E21FzySsSK5a21KRADBd/NGneRegFO5pLHfdQLpRDETUNJueLXs3WCzyQ3tFRDYgbq3KHGXfTbi2bs8WQ6rQ==,
+            }
+        engines: { node: '>= 0.4' }
+
+    object.groupby@1.0.3:
+        resolution:
+            {
+                integrity: sha512-+Lhy3TQTuzXI5hevh8sBGqbmurHbbIjAi0Z4S63nthVLmLxfbj4T54a4CfZrXIrt9iP4mVAPYMo/v99taj3wjQ==,
+            }
+        engines: { node: '>= 0.4' }
+
+    object.values@1.2.1:
+        resolution:
+            {
+                integrity: sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA==,
+            }
+        engines: { node: '>= 0.4' }
+
+    ohash@2.0.11:
+        resolution:
+            {
+                integrity: sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==,
+            }
+
+    on-exit-leak-free@2.1.2:
+        resolution:
+            {
+                integrity: sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==,
+            }
+        engines: { node: '>=14.0.0' }
+
+    on-finished@2.4.1:
+        resolution:
+            {
+                integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==,
+            }
+        engines: { node: '>= 0.8' }
+
+    once@1.4.0:
+        resolution:
+            {
+                integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==,
+            }
+
+    optionator@0.9.4:
+        resolution:
+            {
+                integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==,
+            }
+        engines: { node: '>= 0.8.0' }
+
+    own-keys@1.0.1:
+        resolution:
+            {
+                integrity: sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==,
+            }
+        engines: { node: '>= 0.4' }
+
+    p-limit@3.1.0:
+        resolution:
+            {
+                integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==,
+            }
+        engines: { node: '>=10' }
+
+    p-locate@5.0.0:
+        resolution:
+            {
+                integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==,
+            }
+        engines: { node: '>=10' }
+
+    parseurl@1.3.3:
+        resolution:
+            {
+                integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==,
+            }
+        engines: { node: '>= 0.8' }
+
+    path-exists@4.0.0:
+        resolution:
+            {
+                integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==,
+            }
+        engines: { node: '>=8' }
+
+    path-expression-matcher@1.5.0:
+        resolution:
+            {
+                integrity: sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==,
+            }
+        engines: { node: '>=14.0.0' }
+
+    path-key@3.1.1:
+        resolution:
+            {
+                integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==,
+            }
+        engines: { node: '>=8' }
+
+    path-parse@1.0.7:
+        resolution:
+            {
+                integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==,
+            }
+
+    path-to-regexp@8.4.2:
+        resolution:
+            {
+                integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==,
+            }
+
+    pathe@2.0.3:
+        resolution:
+            {
+                integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==,
+            }
+
+    perfect-debounce@2.1.0:
+        resolution:
+            {
+                integrity: sha512-LjgdTytVFXeUgtHZr9WYViYSM/g8MkcTPYDlPa3cDqMirHjKiSZPYd6DoL7pK8AJQr+uWkQvCjHNdiMqsrJs+g==,
+            }
+
+    pg-cloudflare@1.4.0:
+        resolution:
+            {
+                integrity: sha512-Vo7z/6rrQYxpNRylp4Tlob2elzbh+N/MOQbxFVWCxS7oEx6jF53GTJFxK2WWpKuBRkmiin4Mt+xofFDjx09R0A==,
+            }
+
+    pg-connection-string@2.13.0:
+        resolution:
+            {
+                integrity: sha512-EMnU9E2fSULdsbErBbMaXJvFeD9B4+nPcM3f+4lsiCR0BHLPrLVjv3DbyM2hgQQviKJaTWIRRTjKjWlHg3p2ig==,
+            }
+
+    pg-int8@1.0.1:
+        resolution:
+            {
+                integrity: sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==,
+            }
+        engines: { node: '>=4.0.0' }
+
+    pg-pool@3.14.0:
+        resolution:
+            {
+                integrity: sha512-gKtPkFdQPU3DksooVLi9LsjZxrsBUZIpa+7aVx+LV5pNh0KzP4Zleud2po+ConrxbuXGBJ6Hfer6hdgpIBpBaw==,
+            }
+        peerDependencies:
+            pg: '>=8.0'
+
+    pg-protocol@1.14.0:
+        resolution:
+            {
+                integrity: sha512-n5taZ1kO3s9ngDTVxsEznOqCyToTgz0FLuPq0B33COy5pPpuWJpY3/2oRBVETuOgzdqRXfWpM9HIhp2LBBT1BA==,
+            }
+
+    pg-types@2.2.0:
+        resolution:
+            {
+                integrity: sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==,
+            }
+        engines: { node: '>=4' }
+
+    pg@8.20.0:
+        resolution:
+            {
+                integrity: sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==,
+            }
+        engines: { node: '>= 16.0.0' }
+        peerDependencies:
+            pg-native: '>=3.0.1'
+        peerDependenciesMeta:
+            pg-native:
+                optional: true
+
+    pgpass@1.0.5:
+        resolution:
+            {
+                integrity: sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==,
+            }
+
+    picomatch@4.0.4:
+        resolution:
+            {
+                integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==,
+            }
+        engines: { node: '>=12' }
+
+    pino-abstract-transport@3.0.0:
+        resolution:
+            {
+                integrity: sha512-wlfUczU+n7Hy/Ha5j9a/gZNy7We5+cXp8YL+X+PG8S0KXxw7n/JXA3c46Y0zQznIJ83URJiwy7Lh56WLokNuxg==,
+            }
+
+    pino-pretty@13.1.3:
+        resolution:
+            {
+                integrity: sha512-ttXRkkOz6WWC95KeY9+xxWL6AtImwbyMHrL1mSwqwW9u+vLp/WIElvHvCSDg0xO/Dzrggz1zv3rN5ovTRVowKg==,
+            }
+        hasBin: true
+
+    pino-std-serializers@7.1.0:
+        resolution:
+            {
+                integrity: sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==,
+            }
+
+    pino@10.3.1:
+        resolution:
+            {
+                integrity: sha512-r34yH/GlQpKZbU1BvFFqOjhISRo1MNx1tWYsYvmj6KIRHSPMT2+yHOEb1SG6NMvRoHRF0a07kCOox/9yakl1vg==,
+            }
+        hasBin: true
+
+    pkg-types@2.3.1:
+        resolution:
+            {
+                integrity: sha512-y+ichcgc2LrADuhLNAx8DFjVfgz91pRxfZdI3UDhxHvcVEZsenLO+7XaU5vOp0u/7V/wZ+plyuQxtrDlZJ+yeg==,
+            }
+
+    possible-typed-array-names@1.1.0:
+        resolution:
+            {
+                integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==,
+            }
+        engines: { node: '>= 0.4' }
+
+    postgres-array@2.0.0:
+        resolution:
+            {
+                integrity: sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==,
+            }
+        engines: { node: '>=4' }
+
+    postgres-array@3.0.4:
+        resolution:
+            {
+                integrity: sha512-nAUSGfSDGOaOAEGwqsRY27GPOea7CNipJPOA7lPbdEpx5Kg3qzdP0AaWC5MlhTWV9s4hFX39nomVZ+C4tnGOJQ==,
+            }
+        engines: { node: '>=12' }
+
+    postgres-bytea@1.0.1:
+        resolution:
+            {
+                integrity: sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==,
+            }
+        engines: { node: '>=0.10.0' }
+
+    postgres-date@1.0.7:
+        resolution:
+            {
+                integrity: sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==,
+            }
+        engines: { node: '>=0.10.0' }
+
+    postgres-interval@1.2.0:
+        resolution:
+            {
+                integrity: sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==,
+            }
+        engines: { node: '>=0.10.0' }
+
+    postgres@3.4.7:
+        resolution:
+            {
+                integrity: sha512-Jtc2612XINuBjIl/QTWsV5UvE8UHuNblcO3vVADSrKsrc6RqGX6lOW1cEo3CM2v0XG4Nat8nI+YM7/f26VxXLw==,
+            }
+        engines: { node: '>=12' }
+
+    prelude-ls@1.2.1:
+        resolution:
+            {
+                integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==,
+            }
+        engines: { node: '>= 0.8.0' }
+
+    prettier@3.8.3:
+        resolution:
+            {
+                integrity: sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==,
+            }
+        engines: { node: '>=14' }
+        hasBin: true
+
+    prisma@7.8.0:
+        resolution:
+            {
+                integrity: sha512-yfN4yrw7HV9kEJhoy1+jgah0jafEIQsf7uWouSsM8MvJtlubsk+kM7AIBWZ8+GJl74Yj3c+nbYqBkMOxtsZ3Lw==,
+            }
+        engines: { node: ^20.19 || ^22.12 || >=24.0 }
+        hasBin: true
+        peerDependencies:
+            better-sqlite3: '>=9.0.0'
+            typescript: '>=5.4.0'
+        peerDependenciesMeta:
+            better-sqlite3:
+                optional: true
+            typescript:
+                optional: true
+
+    process-warning@5.0.0:
+        resolution:
+            {
+                integrity: sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==,
+            }
+
+    proper-lockfile@4.1.2:
+        resolution:
+            {
+                integrity: sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==,
+            }
+
+    proxy-addr@2.0.7:
+        resolution:
+            {
+                integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==,
+            }
+        engines: { node: '>= 0.10' }
+
+    pump@3.0.4:
+        resolution:
+            {
+                integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==,
+            }
+
+    punycode@2.3.1:
+        resolution:
+            {
+                integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==,
+            }
+        engines: { node: '>=6' }
+
+    pure-rand@6.1.0:
+        resolution:
+            {
+                integrity: sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==,
+            }
+
+    qs@6.15.2:
+        resolution:
+            {
+                integrity: sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==,
+            }
+        engines: { node: '>=0.6' }
+
+    quick-format-unescaped@4.0.4:
+        resolution:
+            {
+                integrity: sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==,
+            }
+
+    range-parser@1.2.1:
+        resolution:
+            {
+                integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==,
+            }
+        engines: { node: '>= 0.6' }
+
+    raw-body@3.0.2:
+        resolution:
+            {
+                integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==,
+            }
+        engines: { node: '>= 0.10' }
+
+    rc9@3.0.1:
+        resolution:
+            {
+                integrity: sha512-gMDyleLWVE+i6Sgtc0QbbY6pEKqYs97NGi6isHQPqYlLemPoO8dxQ3uGi0f4NiP98c+jMW6cG1Kx9dDwfvqARQ==,
+            }
+
+    react-dom@19.2.7:
+        resolution:
+            {
+                integrity: sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==,
+            }
+        peerDependencies:
+            react: ^19.2.7
+
+    react@19.2.7:
+        resolution:
+            {
+                integrity: sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==,
+            }
+        engines: { node: '>=0.10.0' }
+
+    readable-stream@3.6.2:
+        resolution:
+            {
+                integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==,
+            }
+        engines: { node: '>= 6' }
+
+    readdirp@5.0.0:
+        resolution:
+            {
+                integrity: sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==,
+            }
+        engines: { node: '>= 20.19.0' }
+
+    real-require@0.2.0:
+        resolution:
+            {
+                integrity: sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==,
+            }
+        engines: { node: '>= 12.13.0' }
+
+    real-require@1.0.0:
+        resolution:
+            {
+                integrity: sha512-P4nbQYQfePJxRSmY+v/KINxVucm4NF3p3s7pJveMTtom52FR4YGltUQLB8idDXwDDWW+eYrWDFbuzUnjoWHF7g==,
+            }
+
+    reflect.getprototypeof@1.0.10:
+        resolution:
+            {
+                integrity: sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==,
+            }
+        engines: { node: '>= 0.4' }
+
+    regexp.prototype.flags@1.5.4:
+        resolution:
+            {
+                integrity: sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==,
+            }
+        engines: { node: '>= 0.4' }
+
+    remeda@2.33.4:
+        resolution:
+            {
+                integrity: sha512-ygHswjlc/opg2VrtiYvUOPLjxjtdKvjGz1/plDhkG66hjNjFr1xmfrs2ClNFo/E6TyUFiwYNh53bKV26oBoMGQ==,
+            }
+
+    require-from-string@2.0.2:
+        resolution:
+            {
+                integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==,
+            }
+        engines: { node: '>=0.10.0' }
+
+    resolve@2.0.0-next.7:
+        resolution:
+            {
+                integrity: sha512-tqt+NBWwyaMgw3zDsnygx4CByWjQEJHOPMdslYhppaQSJUtL/D4JO9CcBBlhPoI8lz9oJIDXkwXfhF4aWqP8xQ==,
+            }
+        engines: { node: '>= 0.4' }
+        hasBin: true
+
+    retry@0.12.0:
+        resolution:
+            {
+                integrity: sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==,
+            }
+        engines: { node: '>= 4' }
+
+    router@2.2.0:
+        resolution:
+            {
+                integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==,
+            }
+        engines: { node: '>= 18' }
+
+    safe-array-concat@1.1.4:
+        resolution:
+            {
+                integrity: sha512-wtZlHyOje6OZTGqAoaDKxFkgRtkF9CnHAVnCHKfuj200wAgL+bSJhdsCD2l0Qx/2ekEXjPWcyKkfGb5CPboslg==,
+            }
+        engines: { node: '>=0.4' }
+
+    safe-buffer@5.2.1:
+        resolution:
+            {
+                integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==,
+            }
+
+    safe-push-apply@1.0.0:
+        resolution:
+            {
+                integrity: sha512-iKE9w/Z7xCzUMIZqdBsp6pEQvwuEebH4vdpjcDWnyzaI6yl6O9FHvVpmGelvEHNsoY6wGblkxR6Zty/h00WiSA==,
+            }
+        engines: { node: '>= 0.4' }
+
+    safe-regex-test@1.1.0:
+        resolution:
+            {
+                integrity: sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==,
+            }
+        engines: { node: '>= 0.4' }
+
+    safe-stable-stringify@2.5.0:
+        resolution:
+            {
+                integrity: sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==,
+            }
+        engines: { node: '>=10' }
+
+    safer-buffer@2.1.2:
+        resolution:
+            {
+                integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==,
+            }
+
+    scheduler@0.27.0:
+        resolution:
+            {
+                integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==,
+            }
+
+    secure-json-parse@4.1.0:
+        resolution:
+            {
+                integrity: sha512-l4KnYfEyqYJxDwlNVyRfO2E4NTHfMKAWdUuA8J0yve2Dz/E/PdBepY03RvyJpssIpRFwJoCD55wA+mEDs6ByWA==,
+            }
+
+    semver@6.3.1:
+        resolution:
+            {
+                integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==,
+            }
+        hasBin: true
+
+    semver@7.8.2:
+        resolution:
+            {
+                integrity: sha512-c8jsqUZm3omBOI66G90z1Dyw5z622G8oLG+omfsHBJf3CWQTlOcwOjvOG6wtiNfW6anKm/eA39LMwMtMez2TiQ==,
+            }
+        engines: { node: '>=10' }
+        hasBin: true
+
+    send@1.2.1:
+        resolution:
+            {
+                integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==,
+            }
+        engines: { node: '>= 18' }
+
+    seq-queue@0.0.5:
+        resolution:
+            {
+                integrity: sha512-hr3Wtp/GZIc/6DAGPDcV4/9WoZhjrkXsi5B/07QgX8tsdc6ilr7BFM6PM6rbdAX1kFSDYeZGLipIZZKyQP0O5Q==,
+            }
+
+    serve-static@2.2.1:
+        resolution:
+            {
+                integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==,
+            }
+        engines: { node: '>= 18' }
+
+    set-function-length@1.2.2:
+        resolution:
+            {
+                integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==,
+            }
+        engines: { node: '>= 0.4' }
+
+    set-function-name@2.0.2:
+        resolution:
+            {
+                integrity: sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==,
+            }
+        engines: { node: '>= 0.4' }
+
+    set-proto@1.0.0:
+        resolution:
+            {
+                integrity: sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw==,
+            }
+        engines: { node: '>= 0.4' }
+
+    setprototypeof@1.2.0:
+        resolution:
+            {
+                integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==,
+            }
+
+    shebang-command@2.0.0:
+        resolution:
+            {
+                integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==,
+            }
+        engines: { node: '>=8' }
+
+    shebang-regex@3.0.0:
+        resolution:
+            {
+                integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==,
+            }
+        engines: { node: '>=8' }
+
+    side-channel-list@1.0.1:
+        resolution:
+            {
+                integrity: sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==,
+            }
+        engines: { node: '>= 0.4' }
+
+    side-channel-map@1.0.1:
+        resolution:
+            {
+                integrity: sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==,
+            }
+        engines: { node: '>= 0.4' }
+
+    side-channel-weakmap@1.0.2:
+        resolution:
+            {
+                integrity: sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==,
+            }
+        engines: { node: '>= 0.4' }
+
+    side-channel@1.1.0:
+        resolution:
+            {
+                integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==,
+            }
+        engines: { node: '>= 0.4' }
+
+    signal-exit@3.0.7:
+        resolution:
+            {
+                integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==,
+            }
+
+    signal-exit@4.1.0:
+        resolution:
+            {
+                integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==,
+            }
+        engines: { node: '>=14' }
+
+    sonic-boom@4.2.1:
+        resolution:
+            {
+                integrity: sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==,
+            }
+
+    split2@4.2.0:
+        resolution:
+            {
+                integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==,
+            }
+        engines: { node: '>= 10.x' }
+
+    sqlstring@2.3.3:
+        resolution:
+            {
+                integrity: sha512-qC9iz2FlN7DQl3+wjwn3802RTyjCx7sDvfQEXchwa6CWOx07/WVfh91gBmQ9fahw8snwGEWU3xGzOt4tFyHLxg==,
+            }
+        engines: { node: '>= 0.6' }
+
+    statuses@2.0.2:
+        resolution:
+            {
+                integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==,
+            }
+        engines: { node: '>= 0.8' }
+
+    std-env@3.10.0:
+        resolution:
+            {
+                integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==,
+            }
+
+    stop-iteration-iterator@1.1.0:
+        resolution:
+            {
+                integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==,
+            }
+        engines: { node: '>= 0.4' }
+
+    stream-browserify@3.0.0:
+        resolution:
+            {
+                integrity: sha512-H73RAHsVBapbim0tU2JwwOiXUj+fikfiaoYAKHF3VJfA0pe2BCzkhAHBlLG6REzE+2WNZcxOXjK7lkso+9euLA==,
+            }
+
+    streamsearch@1.1.0:
+        resolution:
+            {
+                integrity: sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==,
+            }
+        engines: { node: '>=10.0.0' }
+
+    string.prototype.trim@1.2.11:
+        resolution:
+            {
+                integrity: sha512-PwvK7BU+CMTJGYQCTZb5RWXIML92lftJLhQz1tBzgKiqGxJaMlBAa48POXaNAC2s4y8jr3EFqrkF9+44neS46w==,
+            }
+        engines: { node: '>= 0.4' }
+
+    string.prototype.trimend@1.0.10:
+        resolution:
+            {
+                integrity: sha512-2+3aDAOmPTmuFwjDnmJG2ctEkQKVki7vOSqaxkv42Mowj1V6PnvuwFCRrR5lChUux1TBskPjfkeTOhqczDMxTw==,
+            }
+        engines: { node: '>= 0.4' }
+
+    string.prototype.trimstart@1.0.8:
+        resolution:
+            {
+                integrity: sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==,
+            }
+        engines: { node: '>= 0.4' }
+
+    string_decoder@1.3.0:
+        resolution:
+            {
+                integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==,
+            }
+
+    strip-bom@3.0.0:
+        resolution:
+            {
+                integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==,
+            }
+        engines: { node: '>=4' }
+
+    strip-json-comments@5.0.3:
+        resolution:
+            {
+                integrity: sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw==,
+            }
+        engines: { node: '>=14.16' }
+
+    strnum@2.3.0:
+        resolution:
+            {
+                integrity: sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==,
+            }
+
+    supports-preserve-symlinks-flag@1.0.0:
+        resolution:
+            {
+                integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==,
+            }
+        engines: { node: '>= 0.4' }
+
+    thread-stream@4.2.0:
+        resolution:
+            {
+                integrity: sha512-e2zZ96wSChazBsbENf/Pcm/4swHt2cEKQ92rhUjkL9GCKiTDJIaTBenjE/m9DXi0QBmTMDkFDdOomUy20A1tDQ==,
+            }
+        engines: { node: '>=20' }
+
+    tinyglobby@0.2.17:
+        resolution:
+            {
+                integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==,
+            }
+        engines: { node: '>=12.0.0' }
+
+    toidentifier@1.0.1:
+        resolution:
+            {
+                integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==,
+            }
+        engines: { node: '>=0.6' }
+
+    ts-api-utils@2.5.0:
+        resolution:
+            {
+                integrity: sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==,
+            }
+        engines: { node: '>=18.12' }
+        peerDependencies:
+            typescript: '>=4.8.4'
+
+    ts-mixer@6.0.4:
+        resolution:
+            {
+                integrity: sha512-ufKpbmrugz5Aou4wcr5Wc1UUFWOLhq+Fm6qa6P0w0K5Qw2yhaUoiWszhCVuNQyNwrlGiscHOmqYoAox1PtvgjA==,
+            }
+
+    tsconfig-paths@3.15.0:
+        resolution:
+            {
+                integrity: sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg==,
+            }
+
+    tslib@2.8.1:
+        resolution:
+            {
+                integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==,
+            }
+
+    type-check@0.4.0:
+        resolution:
+            {
+                integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==,
+            }
+        engines: { node: '>= 0.8.0' }
+
+    type-is@2.1.0:
+        resolution:
+            {
+                integrity: sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==,
+            }
+        engines: { node: '>= 18' }
+
+    typed-array-buffer@1.0.3:
+        resolution:
+            {
+                integrity: sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==,
+            }
+        engines: { node: '>= 0.4' }
+
+    typed-array-byte-length@1.0.3:
+        resolution:
+            {
+                integrity: sha512-BaXgOuIxz8n8pIq3e7Atg/7s+DpiYrxn4vdot3w9KbnBhcRQq6o3xemQdIfynqSeXeDrF32x+WvfzmOjPiY9lg==,
+            }
+        engines: { node: '>= 0.4' }
+
+    typed-array-byte-offset@1.0.4:
+        resolution:
+            {
+                integrity: sha512-bTlAFB/FBYMcuX81gbL4OcpH5PmlFHqlCCpAl8AlEzMz5k53oNDvN8p1PNOWLEmI2x4orp3raOFB51tv9X+MFQ==,
+            }
+        engines: { node: '>= 0.4' }
+
+    typed-array-length@1.0.8:
+        resolution:
+            {
+                integrity: sha512-phPGCwqr2+Qo0fwniCE8e4pKnGu/yFb5nD5Y8bf0EEeiI5GklnACYA9GFy/DrAeRrKHXvHn+1SUsOWgJp6RO+g==,
+            }
+        engines: { node: '>= 0.4' }
+
+    typescript-eslint@8.59.1:
+        resolution:
+            {
+                integrity: sha512-xqDcFVBmlrltH64lklOVp1wYxgJr6LVdg3NamBgH2OOQDLFdTKfIZXF5PfghrnXQKXZGTQs8tr1vL7fJvq8CTQ==,
+            }
+        engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
+        peerDependencies:
+            eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+            typescript: '>=4.8.4 <6.1.0'
+
+    typescript@6.0.3:
+        resolution:
+            {
+                integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==,
+            }
+        engines: { node: '>=14.17' }
+        hasBin: true
+
+    unbox-primitive@1.1.0:
+        resolution:
+            {
+                integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==,
+            }
+        engines: { node: '>= 0.4' }
+
+    undici-types@7.19.2:
+        resolution:
+            {
+                integrity: sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==,
+            }
+
+    undici@6.24.1:
+        resolution:
+            {
+                integrity: sha512-sC+b0tB1whOCzbtlx20fx3WgCXwkW627p4EA9uM+/tNNPkSS+eSEld6pAs9nDv7WbY1UUljBMYPtu9BCOrCWKA==,
+            }
+        engines: { node: '>=18.17' }
+
+    unpipe@1.0.0:
+        resolution:
+            {
+                integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==,
+            }
+        engines: { node: '>= 0.8' }
+
+    uri-js@4.4.1:
+        resolution:
+            {
+                integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==,
+            }
+
+    util-deprecate@1.0.2:
+        resolution:
+            {
+                integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==,
+            }
+
+    valibot@1.2.0:
+        resolution:
+            {
+                integrity: sha512-mm1rxUsmOxzrwnX5arGS+U4T25RdvpPjPN4yR0u9pUBov9+zGVtO84tif1eY4r6zWxVxu3KzIyknJy3rxfRZZg==,
+            }
+        peerDependencies:
+            typescript: '>=5'
+        peerDependenciesMeta:
+            typescript:
+                optional: true
+
+    vary@1.1.2:
+        resolution:
+            {
+                integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==,
+            }
+        engines: { node: '>= 0.8' }
+
+    which-boxed-primitive@1.1.1:
+        resolution:
+            {
+                integrity: sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==,
+            }
+        engines: { node: '>= 0.4' }
+
+    which-builtin-type@1.2.1:
+        resolution:
+            {
+                integrity: sha512-6iBczoX+kDQ7a3+YJBnh3T+KZRxM/iYNPXicqk66/Qfm1b93iu+yOImkg0zHbj5LNOcNv1TEADiZ0xa34B4q6Q==,
+            }
+        engines: { node: '>= 0.4' }
+
+    which-collection@1.0.2:
+        resolution:
+            {
+                integrity: sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==,
+            }
+        engines: { node: '>= 0.4' }
+
+    which-typed-array@1.1.22:
+        resolution:
+            {
+                integrity: sha512-fvO4ExWMFsqyhG3AiPAObMuY1lxaqgYcxbc49CNdWDDECOJNgQyvsOWVwbZc+qf3rzRtxojBK+CMEv0Ld5CYpw==,
+            }
+        engines: { node: '>= 0.4' }
+
+    which@2.0.2:
+        resolution:
+            {
+                integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==,
+            }
+        engines: { node: '>= 8' }
+        hasBin: true
+
+    word-wrap@1.2.5:
+        resolution:
+            {
+                integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==,
+            }
+        engines: { node: '>=0.10.0' }
+
+    wrappy@1.0.2:
+        resolution:
+            {
+                integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==,
+            }
+
+    ws@8.21.0:
+        resolution:
+            {
+                integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==,
+            }
+        engines: { node: '>=10.0.0' }
+        peerDependencies:
+            bufferutil: ^4.0.1
+            utf-8-validate: '>=5.0.2'
+        peerDependenciesMeta:
+            bufferutil:
+                optional: true
+            utf-8-validate:
+                optional: true
+
+    xml-naming@0.1.0:
+        resolution:
+            {
+                integrity: sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==,
+            }
+        engines: { node: '>=16.0.0' }
+
+    xtend@4.0.2:
+        resolution:
+            {
+                integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==,
+            }
+        engines: { node: '>=0.4' }
+
+    yocto-queue@0.1.0:
+        resolution:
+            {
+                integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==,
+            }
+        engines: { node: '>=10' }
+
+    zeptomatch@2.1.0:
+        resolution:
+            {
+                integrity: sha512-KiGErG2J0G82LSpniV0CtIzjlJ10E04j02VOudJsPyPwNZgGnRKQy7I1R7GMyg/QswnE4l7ohSGrQbQbjXPPDA==,
+            }
+
+    zod@4.3.6:
+        resolution:
+            {
+                integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==,
+            }
+
+    zod@4.4.1:
+        resolution:
+            {
+                integrity: sha512-a6ENMBBGZBsnlSebQ/eKCguSBeGKSf4O7BPnqVPmYGtpBYI7VSqoVqw+QcB7kPRjbqPwhYTpFbVj/RqNz/CT0Q==,
+            }
 
 snapshots:
-
-  '@aws-crypto/crc32@5.2.0':
-    dependencies:
-      '@aws-crypto/util': 5.2.0
-      '@aws-sdk/types': 3.973.11
-      tslib: 2.8.1
-
-  '@aws-crypto/crc32c@5.2.0':
-    dependencies:
-      '@aws-crypto/util': 5.2.0
-      '@aws-sdk/types': 3.973.11
-      tslib: 2.8.1
-
-  '@aws-crypto/sha1-browser@5.2.0':
-    dependencies:
-      '@aws-crypto/supports-web-crypto': 5.2.0
-      '@aws-crypto/util': 5.2.0
-      '@aws-sdk/types': 3.973.11
-      '@aws-sdk/util-locate-window': 3.965.6
-      '@smithy/util-utf8': 2.3.0
-      tslib: 2.8.1
-
-  '@aws-crypto/sha256-browser@5.2.0':
-    dependencies:
-      '@aws-crypto/sha256-js': 5.2.0
-      '@aws-crypto/supports-web-crypto': 5.2.0
-      '@aws-crypto/util': 5.2.0
-      '@aws-sdk/types': 3.973.11
-      '@aws-sdk/util-locate-window': 3.965.6
-      '@smithy/util-utf8': 2.3.0
-      tslib: 2.8.1
-
-  '@aws-crypto/sha256-js@5.2.0':
-    dependencies:
-      '@aws-crypto/util': 5.2.0
-      '@aws-sdk/types': 3.973.11
-      tslib: 2.8.1
-
-  '@aws-crypto/supports-web-crypto@5.2.0':
-    dependencies:
-      tslib: 2.8.1
-
-  '@aws-crypto/util@5.2.0':
-    dependencies:
-      '@aws-sdk/types': 3.973.11
-      '@smithy/util-utf8': 2.3.0
-      tslib: 2.8.1
-
-  '@aws-sdk/checksums@3.1000.2':
-    dependencies:
-      '@aws-crypto/crc32': 5.2.0
-      '@aws-crypto/crc32c': 5.2.0
-      '@aws-crypto/util': 5.2.0
-      '@aws-sdk/core': 3.974.18
-      '@aws-sdk/types': 3.973.11
-      '@smithy/core': 3.24.6
-      '@smithy/types': 4.14.3
-      tslib: 2.8.1
-
-  '@aws-sdk/client-s3@3.1039.0':
-    dependencies:
-      '@aws-crypto/sha1-browser': 5.2.0
-      '@aws-crypto/sha256-browser': 5.2.0
-      '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/core': 3.974.18
-      '@aws-sdk/credential-provider-node': 3.972.52
-      '@aws-sdk/middleware-bucket-endpoint': 3.972.21
-      '@aws-sdk/middleware-expect-continue': 3.972.17
-      '@aws-sdk/middleware-flexible-checksums': 3.974.27
-      '@aws-sdk/middleware-host-header': 3.972.19
-      '@aws-sdk/middleware-location-constraint': 3.972.14
-      '@aws-sdk/middleware-logger': 3.972.18
-      '@aws-sdk/middleware-recursion-detection': 3.972.20
-      '@aws-sdk/middleware-sdk-s3': 3.972.48
-      '@aws-sdk/middleware-ssec': 3.972.14
-      '@aws-sdk/middleware-user-agent': 3.972.48
-      '@aws-sdk/region-config-resolver': 3.972.22
-      '@aws-sdk/signature-v4-multi-region': 3.996.32
-      '@aws-sdk/types': 3.973.11
-      '@aws-sdk/util-endpoints': 3.996.17
-      '@aws-sdk/util-user-agent-browser': 3.972.19
-      '@aws-sdk/util-user-agent-node': 3.973.34
-      '@smithy/config-resolver': 4.5.6
-      '@smithy/core': 3.24.6
-      '@smithy/eventstream-serde-browser': 4.3.6
-      '@smithy/eventstream-serde-config-resolver': 4.4.6
-      '@smithy/eventstream-serde-node': 4.3.6
-      '@smithy/fetch-http-handler': 5.4.6
-      '@smithy/hash-blob-browser': 4.3.6
-      '@smithy/hash-node': 4.3.6
-      '@smithy/hash-stream-node': 4.3.6
-      '@smithy/invalid-dependency': 4.3.6
-      '@smithy/md5-js': 4.3.6
-      '@smithy/middleware-content-length': 4.3.6
-      '@smithy/middleware-endpoint': 4.5.6
-      '@smithy/middleware-retry': 4.6.6
-      '@smithy/middleware-serde': 4.3.6
-      '@smithy/middleware-stack': 4.3.6
-      '@smithy/node-config-provider': 4.4.6
-      '@smithy/node-http-handler': 4.7.7
-      '@smithy/protocol-http': 5.4.6
-      '@smithy/smithy-client': 4.13.6
-      '@smithy/types': 4.14.3
-      '@smithy/url-parser': 4.3.6
-      '@smithy/util-base64': 4.4.6
-      '@smithy/util-body-length-browser': 4.3.6
-      '@smithy/util-body-length-node': 4.3.6
-      '@smithy/util-defaults-mode-browser': 4.4.6
-      '@smithy/util-defaults-mode-node': 4.3.6
-      '@smithy/util-endpoints': 3.5.6
-      '@smithy/util-middleware': 4.3.6
-      '@smithy/util-retry': 4.4.6
-      '@smithy/util-stream': 4.6.6
-      '@smithy/util-utf8': 4.3.6
-      '@smithy/util-waiter': 4.4.6
-      tslib: 2.8.1
-
-  '@aws-sdk/core@3.974.18':
-    dependencies:
-      '@aws-sdk/types': 3.973.11
-      '@aws-sdk/xml-builder': 3.972.28
-      '@aws/lambda-invoke-store': 0.2.4
-      '@smithy/core': 3.24.6
-      '@smithy/signature-v4': 5.4.6
-      '@smithy/types': 4.14.3
-      bowser: 2.14.1
-      tslib: 2.8.1
-
-  '@aws-sdk/credential-provider-env@3.972.44':
-    dependencies:
-      '@aws-sdk/core': 3.974.18
-      '@aws-sdk/types': 3.973.11
-      '@smithy/core': 3.24.6
-      '@smithy/types': 4.14.3
-      tslib: 2.8.1
-
-  '@aws-sdk/credential-provider-http@3.972.46':
-    dependencies:
-      '@aws-sdk/core': 3.974.18
-      '@aws-sdk/types': 3.973.11
-      '@smithy/core': 3.24.6
-      '@smithy/fetch-http-handler': 5.4.6
-      '@smithy/node-http-handler': 4.7.7
-      '@smithy/types': 4.14.3
-      tslib: 2.8.1
-
-  '@aws-sdk/credential-provider-ini@3.972.50':
-    dependencies:
-      '@aws-sdk/core': 3.974.18
-      '@aws-sdk/credential-provider-env': 3.972.44
-      '@aws-sdk/credential-provider-http': 3.972.46
-      '@aws-sdk/credential-provider-login': 3.972.49
-      '@aws-sdk/credential-provider-process': 3.972.44
-      '@aws-sdk/credential-provider-sso': 3.972.49
-      '@aws-sdk/credential-provider-web-identity': 3.972.49
-      '@aws-sdk/nested-clients': 3.997.17
-      '@aws-sdk/types': 3.973.11
-      '@smithy/core': 3.24.6
-      '@smithy/credential-provider-imds': 4.3.8
-      '@smithy/types': 4.14.3
-      tslib: 2.8.1
-
-  '@aws-sdk/credential-provider-login@3.972.49':
-    dependencies:
-      '@aws-sdk/core': 3.974.18
-      '@aws-sdk/nested-clients': 3.997.17
-      '@aws-sdk/types': 3.973.11
-      '@smithy/core': 3.24.6
-      '@smithy/types': 4.14.3
-      tslib: 2.8.1
-
-  '@aws-sdk/credential-provider-node@3.972.52':
-    dependencies:
-      '@aws-sdk/credential-provider-env': 3.972.44
-      '@aws-sdk/credential-provider-http': 3.972.46
-      '@aws-sdk/credential-provider-ini': 3.972.50
-      '@aws-sdk/credential-provider-process': 3.972.44
-      '@aws-sdk/credential-provider-sso': 3.972.49
-      '@aws-sdk/credential-provider-web-identity': 3.972.49
-      '@aws-sdk/types': 3.973.11
-      '@smithy/core': 3.24.6
-      '@smithy/credential-provider-imds': 4.3.8
-      '@smithy/types': 4.14.3
-      tslib: 2.8.1
-
-  '@aws-sdk/credential-provider-process@3.972.44':
-    dependencies:
-      '@aws-sdk/core': 3.974.18
-      '@aws-sdk/types': 3.973.11
-      '@smithy/core': 3.24.6
-      '@smithy/types': 4.14.3
-      tslib: 2.8.1
-
-  '@aws-sdk/credential-provider-sso@3.972.49':
-    dependencies:
-      '@aws-sdk/core': 3.974.18
-      '@aws-sdk/nested-clients': 3.997.17
-      '@aws-sdk/token-providers': 3.1063.0
-      '@aws-sdk/types': 3.973.11
-      '@smithy/core': 3.24.6
-      '@smithy/types': 4.14.3
-      tslib: 2.8.1
-
-  '@aws-sdk/credential-provider-web-identity@3.972.49':
-    dependencies:
-      '@aws-sdk/core': 3.974.18
-      '@aws-sdk/nested-clients': 3.997.17
-      '@aws-sdk/types': 3.973.11
-      '@smithy/core': 3.24.6
-      '@smithy/types': 4.14.3
-      tslib: 2.8.1
-
-  '@aws-sdk/lib-storage@3.1038.0(@aws-sdk/client-s3@3.1039.0)':
-    dependencies:
-      '@aws-sdk/client-s3': 3.1039.0
-      '@smithy/middleware-endpoint': 4.5.6
-      '@smithy/protocol-http': 5.4.6
-      '@smithy/smithy-client': 4.13.6
-      '@smithy/types': 4.14.3
-      buffer: 5.6.0
-      events: 3.3.0
-      stream-browserify: 3.0.0
-      tslib: 2.8.1
-
-  '@aws-sdk/middleware-bucket-endpoint@3.972.21':
-    dependencies:
-      '@aws-sdk/middleware-sdk-s3': 3.972.48
-      tslib: 2.8.1
-
-  '@aws-sdk/middleware-expect-continue@3.972.17':
-    dependencies:
-      '@aws-sdk/middleware-sdk-s3': 3.972.48
-      tslib: 2.8.1
-
-  '@aws-sdk/middleware-flexible-checksums@3.974.27':
-    dependencies:
-      '@aws-sdk/checksums': 3.1000.2
-      tslib: 2.8.1
-
-  '@aws-sdk/middleware-host-header@3.972.19':
-    dependencies:
-      '@aws-sdk/core': 3.974.18
-      tslib: 2.8.1
-
-  '@aws-sdk/middleware-location-constraint@3.972.14':
-    dependencies:
-      '@aws-sdk/middleware-sdk-s3': 3.972.48
-      tslib: 2.8.1
-
-  '@aws-sdk/middleware-logger@3.972.18':
-    dependencies:
-      '@aws-sdk/core': 3.974.18
-      tslib: 2.8.1
-
-  '@aws-sdk/middleware-recursion-detection@3.972.20':
-    dependencies:
-      '@aws-sdk/core': 3.974.18
-      tslib: 2.8.1
-
-  '@aws-sdk/middleware-sdk-s3@3.972.48':
-    dependencies:
-      '@aws-sdk/core': 3.974.18
-      '@aws-sdk/signature-v4-multi-region': 3.996.32
-      '@aws-sdk/types': 3.973.11
-      '@smithy/core': 3.24.6
-      '@smithy/types': 4.14.3
-      tslib: 2.8.1
-
-  '@aws-sdk/middleware-ssec@3.972.14':
-    dependencies:
-      '@aws-sdk/middleware-sdk-s3': 3.972.48
-      tslib: 2.8.1
-
-  '@aws-sdk/middleware-user-agent@3.972.48':
-    dependencies:
-      '@aws-sdk/core': 3.974.18
-      tslib: 2.8.1
-
-  '@aws-sdk/nested-clients@3.997.17':
-    dependencies:
-      '@aws-crypto/sha256-browser': 5.2.0
-      '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/core': 3.974.18
-      '@aws-sdk/signature-v4-multi-region': 3.996.32
-      '@aws-sdk/types': 3.973.11
-      '@smithy/core': 3.24.6
-      '@smithy/fetch-http-handler': 5.4.6
-      '@smithy/node-http-handler': 4.7.7
-      '@smithy/types': 4.14.3
-      tslib: 2.8.1
-
-  '@aws-sdk/region-config-resolver@3.972.22':
-    dependencies:
-      '@aws-sdk/core': 3.974.18
-      tslib: 2.8.1
-
-  '@aws-sdk/signature-v4-multi-region@3.996.32':
-    dependencies:
-      '@aws-sdk/types': 3.973.11
-      '@smithy/signature-v4': 5.4.6
-      '@smithy/types': 4.14.3
-      tslib: 2.8.1
-
-  '@aws-sdk/token-providers@3.1063.0':
-    dependencies:
-      '@aws-sdk/core': 3.974.18
-      '@aws-sdk/nested-clients': 3.997.17
-      '@aws-sdk/types': 3.973.11
-      '@smithy/core': 3.24.6
-      '@smithy/types': 4.14.3
-      tslib: 2.8.1
-
-  '@aws-sdk/types@3.973.11':
-    dependencies:
-      '@smithy/types': 4.14.3
-      tslib: 2.8.1
-
-  '@aws-sdk/util-endpoints@3.996.17':
-    dependencies:
-      '@aws-sdk/core': 3.974.18
-      '@smithy/core': 3.24.6
-      tslib: 2.8.1
-
-  '@aws-sdk/util-locate-window@3.965.6':
-    dependencies:
-      tslib: 2.8.1
-
-  '@aws-sdk/util-user-agent-browser@3.972.19':
-    dependencies:
-      '@aws-sdk/core': 3.974.18
-      tslib: 2.8.1
-
-  '@aws-sdk/util-user-agent-node@3.973.34':
-    dependencies:
-      '@aws-sdk/core': 3.974.18
-      tslib: 2.8.1
-
-  '@aws-sdk/xml-builder@3.972.28':
-    dependencies:
-      '@smithy/types': 4.14.3
-      fast-xml-parser: 5.7.3
-      tslib: 2.8.1
-
-  '@aws/lambda-invoke-store@0.2.4': {}
-
-  '@discordjs/builders@1.14.1':
-    dependencies:
-      '@discordjs/formatters': 0.6.2
-      '@discordjs/util': 1.2.0
-      '@sapphire/shapeshift': 4.0.0
-      discord-api-types: 0.38.48
-      fast-deep-equal: 3.1.3
-      ts-mixer: 6.0.4
-      tslib: 2.8.1
-
-  '@discordjs/collection@1.5.3': {}
-
-  '@discordjs/collection@2.1.1': {}
-
-  '@discordjs/formatters@0.6.2':
-    dependencies:
-      discord-api-types: 0.38.48
-
-  '@discordjs/rest@2.6.1':
-    dependencies:
-      '@discordjs/collection': 2.1.1
-      '@discordjs/util': 1.2.0
-      '@sapphire/async-queue': 1.5.5
-      '@sapphire/snowflake': 3.5.5
-      '@vladfrangu/async_event_emitter': 2.4.7
-      discord-api-types: 0.38.48
-      magic-bytes.js: 1.13.0
-      tslib: 2.8.1
-      undici: 6.24.1
-
-  '@discordjs/util@1.2.0':
-    dependencies:
-      discord-api-types: 0.38.48
-
-  '@discordjs/ws@1.2.3':
-    dependencies:
-      '@discordjs/collection': 2.1.1
-      '@discordjs/rest': 2.6.1
-      '@discordjs/util': 1.2.0
-      '@sapphire/async-queue': 1.5.5
-      '@types/ws': 8.18.1
-      '@vladfrangu/async_event_emitter': 2.4.7
-      discord-api-types: 0.38.48
-      tslib: 2.8.1
-      ws: 8.21.0
-    transitivePeerDependencies:
-      - bufferutil
-      - utf-8-validate
-
-  '@electric-sql/pglite-socket@0.1.1(@electric-sql/pglite@0.4.1)':
-    dependencies:
-      '@electric-sql/pglite': 0.4.1
-
-  '@electric-sql/pglite-tools@0.3.1(@electric-sql/pglite@0.4.1)':
-    dependencies:
-      '@electric-sql/pglite': 0.4.1
-
-  '@electric-sql/pglite@0.4.1': {}
-
-  '@eliyya/flagged-bitfield@1.1.1': {}
-
-  '@epic-web/invariant@1.0.0': {}
-
-  '@eslint-community/eslint-utils@4.9.1(eslint@10.2.1(jiti@2.7.0))':
-    dependencies:
-      eslint: 10.2.1(jiti@2.7.0)
-      eslint-visitor-keys: 3.4.3
-
-  '@eslint-community/regexpp@4.12.2': {}
-
-  '@eslint/config-array@0.23.5':
-    dependencies:
-      '@eslint/object-schema': 3.0.5
-      debug: 4.4.3
-      minimatch: 10.2.5
-    transitivePeerDependencies:
-      - supports-color
-
-  '@eslint/config-helpers@0.5.5':
-    dependencies:
-      '@eslint/core': 1.2.1
-
-  '@eslint/core@1.2.1':
-    dependencies:
-      '@types/json-schema': 7.0.15
-
-  '@eslint/js@10.0.1(eslint@10.2.1(jiti@2.7.0))':
-    optionalDependencies:
-      eslint: 10.2.1(jiti@2.7.0)
-
-  '@eslint/json@1.2.0':
-    dependencies:
-      '@eslint/core': 1.2.1
-      '@eslint/plugin-kit': 0.6.1
-      '@humanwhocodes/momoa': 3.3.10
-      natural-compare: 1.4.0
-
-  '@eslint/object-schema@3.0.5': {}
-
-  '@eslint/plugin-kit@0.6.1':
-    dependencies:
-      '@eslint/core': 1.2.1
-      levn: 0.4.1
-
-  '@eslint/plugin-kit@0.7.2':
-    dependencies:
-      '@eslint/core': 1.2.1
-      levn: 0.4.1
-
-  '@hono/node-server@1.19.11(hono@4.12.23)':
-    dependencies:
-      hono: 4.12.23
-
-  '@humanfs/core@0.19.2':
-    dependencies:
-      '@humanfs/types': 0.15.0
-
-  '@humanfs/node@0.16.8':
-    dependencies:
-      '@humanfs/core': 0.19.2
-      '@humanfs/types': 0.15.0
-      '@humanwhocodes/retry': 0.4.3
-
-  '@humanfs/types@0.15.0': {}
-
-  '@humanwhocodes/module-importer@1.0.1': {}
-
-  '@humanwhocodes/momoa@3.3.10': {}
-
-  '@humanwhocodes/retry@0.4.3': {}
-
-  '@js-temporal/polyfill@0.5.1':
-    dependencies:
-      jsbi: 4.3.2
-
-  '@kurkle/color@0.3.4': {}
-
-  '@nodable/entities@2.1.1': {}
-
-  '@phc/format@1.0.0': {}
-
-  '@pinojs/redact@0.4.0': {}
-
-  '@prisma/adapter-pg@7.8.0':
-    dependencies:
-      '@prisma/driver-adapter-utils': 7.8.0
-      '@types/pg': 8.20.0
-      pg: 8.20.0
-      postgres-array: 3.0.4
-    transitivePeerDependencies:
-      - pg-native
-
-  '@prisma/client-runtime-utils@7.8.0': {}
-
-  '@prisma/client@7.8.0(prisma@7.8.0(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3))(typescript@6.0.3)':
-    dependencies:
-      '@prisma/client-runtime-utils': 7.8.0
-    optionalDependencies:
-      prisma: 7.8.0(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)
-      typescript: 6.0.3
-
-  '@prisma/config@7.8.0':
-    dependencies:
-      c12: 3.3.4
-      deepmerge-ts: 7.1.5
-      effect: 3.20.0
-      empathic: 2.0.0
-    transitivePeerDependencies:
-      - magicast
-
-  '@prisma/debug@7.2.0': {}
-
-  '@prisma/debug@7.8.0': {}
-
-  '@prisma/dev@0.24.3(typescript@6.0.3)':
-    dependencies:
-      '@electric-sql/pglite': 0.4.1
-      '@electric-sql/pglite-socket': 0.1.1(@electric-sql/pglite@0.4.1)
-      '@electric-sql/pglite-tools': 0.3.1(@electric-sql/pglite@0.4.1)
-      '@hono/node-server': 1.19.11(hono@4.12.23)
-      '@prisma/get-platform': 7.2.0
-      '@prisma/query-plan-executor': 7.2.0
-      '@prisma/streams-local': 0.1.2
-      foreground-child: 3.3.1
-      get-port-please: 3.2.0
-      hono: 4.12.23
-      http-status-codes: 2.3.0
-      pathe: 2.0.3
-      proper-lockfile: 4.1.2
-      remeda: 2.33.4
-      std-env: 3.10.0
-      valibot: 1.2.0(typescript@6.0.3)
-      zeptomatch: 2.1.0
-    transitivePeerDependencies:
-      - typescript
-
-  '@prisma/driver-adapter-utils@7.8.0':
-    dependencies:
-      '@prisma/debug': 7.8.0
-
-  '@prisma/engines-version@7.8.0-6.3c6e192761c0362d496ed980de936e2f3cebcd3a': {}
-
-  '@prisma/engines@7.8.0':
-    dependencies:
-      '@prisma/debug': 7.8.0
-      '@prisma/engines-version': 7.8.0-6.3c6e192761c0362d496ed980de936e2f3cebcd3a
-      '@prisma/fetch-engine': 7.8.0
-      '@prisma/get-platform': 7.8.0
-
-  '@prisma/fetch-engine@7.8.0':
-    dependencies:
-      '@prisma/debug': 7.8.0
-      '@prisma/engines-version': 7.8.0-6.3c6e192761c0362d496ed980de936e2f3cebcd3a
-      '@prisma/get-platform': 7.8.0
-
-  '@prisma/get-platform@7.2.0':
-    dependencies:
-      '@prisma/debug': 7.2.0
-
-  '@prisma/get-platform@7.8.0':
-    dependencies:
-      '@prisma/debug': 7.8.0
-
-  '@prisma/query-plan-executor@7.2.0': {}
-
-  '@prisma/streams-local@0.1.2':
-    dependencies:
-      ajv: 8.20.0
-      better-result: 2.9.2
-      env-paths: 3.0.0
-      proper-lockfile: 4.1.2
-
-  '@prisma/studio-core@0.27.3(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
-    dependencies:
-      '@radix-ui/react-toggle': 1.1.10(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@types/react': 19.2.17
-      chart.js: 4.5.1
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
-    transitivePeerDependencies:
-      - '@types/react-dom'
-
-  '@radix-ui/primitive@1.1.3': {}
-
-  '@radix-ui/react-compose-refs@1.1.2(@types/react@19.2.17)(react@19.2.7)':
-    dependencies:
-      react: 19.2.7
-    optionalDependencies:
-      '@types/react': 19.2.17
-
-  '@radix-ui/react-primitive@2.1.3(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
-    dependencies:
-      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.17)(react@19.2.7)
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
-    optionalDependencies:
-      '@types/react': 19.2.17
-
-  '@radix-ui/react-slot@1.2.3(@types/react@19.2.17)(react@19.2.7)':
-    dependencies:
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.17)(react@19.2.7)
-      react: 19.2.7
-    optionalDependencies:
-      '@types/react': 19.2.17
-
-  '@radix-ui/react-toggle@1.1.10(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
-    dependencies:
-      '@radix-ui/primitive': 1.1.3
-      '@radix-ui/react-primitive': 2.1.3(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.17)(react@19.2.7)
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
-    optionalDependencies:
-      '@types/react': 19.2.17
-
-  '@radix-ui/react-use-controllable-state@1.2.2(@types/react@19.2.17)(react@19.2.7)':
-    dependencies:
-      '@radix-ui/react-use-effect-event': 0.0.2(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.17)(react@19.2.7)
-      react: 19.2.7
-    optionalDependencies:
-      '@types/react': 19.2.17
-
-  '@radix-ui/react-use-effect-event@0.0.2(@types/react@19.2.17)(react@19.2.7)':
-    dependencies:
-      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.17)(react@19.2.7)
-      react: 19.2.7
-    optionalDependencies:
-      '@types/react': 19.2.17
-
-  '@radix-ui/react-use-layout-effect@1.1.1(@types/react@19.2.17)(react@19.2.7)':
-    dependencies:
-      react: 19.2.7
-    optionalDependencies:
-      '@types/react': 19.2.17
-
-  '@rollup/rollup-linux-x64-gnu@4.61.1':
-    optional: true
-
-  '@rtsao/scc@1.1.0': {}
-
-  '@sapphire/async-queue@1.5.5': {}
-
-  '@sapphire/shapeshift@4.0.0':
-    dependencies:
-      fast-deep-equal: 3.1.3
-      lodash: 4.18.1
-
-  '@sapphire/snowflake@3.5.3': {}
-
-  '@sapphire/snowflake@3.5.5': {}
-
-  '@smithy/config-resolver@4.5.6':
-    dependencies:
-      '@smithy/core': 3.24.6
-      tslib: 2.8.1
-
-  '@smithy/core@3.24.6':
-    dependencies:
-      '@aws-crypto/crc32': 5.2.0
-      '@smithy/types': 4.14.3
-      tslib: 2.8.1
-
-  '@smithy/credential-provider-imds@4.3.8':
-    dependencies:
-      '@smithy/core': 3.24.6
-      '@smithy/types': 4.14.3
-      tslib: 2.8.1
-
-  '@smithy/eventstream-serde-browser@4.3.6':
-    dependencies:
-      '@smithy/core': 3.24.6
-      tslib: 2.8.1
-
-  '@smithy/eventstream-serde-config-resolver@4.4.6':
-    dependencies:
-      '@smithy/core': 3.24.6
-      tslib: 2.8.1
-
-  '@smithy/eventstream-serde-node@4.3.6':
-    dependencies:
-      '@smithy/core': 3.24.6
-      tslib: 2.8.1
-
-  '@smithy/fetch-http-handler@5.4.6':
-    dependencies:
-      '@smithy/core': 3.24.6
-      '@smithy/types': 4.14.3
-      tslib: 2.8.1
-
-  '@smithy/hash-blob-browser@4.3.6':
-    dependencies:
-      '@smithy/core': 3.24.6
-      tslib: 2.8.1
-
-  '@smithy/hash-node@4.3.6':
-    dependencies:
-      '@smithy/core': 3.24.6
-      tslib: 2.8.1
-
-  '@smithy/hash-stream-node@4.3.6':
-    dependencies:
-      '@smithy/core': 3.24.6
-      tslib: 2.8.1
-
-  '@smithy/invalid-dependency@4.3.6':
-    dependencies:
-      '@smithy/core': 3.24.6
-      tslib: 2.8.1
-
-  '@smithy/is-array-buffer@2.2.0':
-    dependencies:
-      tslib: 2.8.1
-
-  '@smithy/md5-js@4.3.6':
-    dependencies:
-      '@smithy/core': 3.24.6
-      tslib: 2.8.1
-
-  '@smithy/middleware-content-length@4.3.6':
-    dependencies:
-      '@smithy/core': 3.24.6
-      tslib: 2.8.1
-
-  '@smithy/middleware-endpoint@4.5.6':
-    dependencies:
-      '@smithy/core': 3.24.6
-      tslib: 2.8.1
-
-  '@smithy/middleware-retry@4.6.6':
-    dependencies:
-      '@smithy/core': 3.24.6
-      tslib: 2.8.1
-
-  '@smithy/middleware-serde@4.3.6':
-    dependencies:
-      '@smithy/core': 3.24.6
-      tslib: 2.8.1
-
-  '@smithy/middleware-stack@4.3.6':
-    dependencies:
-      '@smithy/core': 3.24.6
-      tslib: 2.8.1
-
-  '@smithy/node-config-provider@4.4.6':
-    dependencies:
-      '@smithy/core': 3.24.6
-      tslib: 2.8.1
-
-  '@smithy/node-http-handler@4.7.7':
-    dependencies:
-      '@smithy/core': 3.24.6
-      '@smithy/types': 4.14.3
-      tslib: 2.8.1
-
-  '@smithy/protocol-http@5.4.6':
-    dependencies:
-      '@smithy/core': 3.24.6
-      tslib: 2.8.1
-
-  '@smithy/signature-v4@5.4.6':
-    dependencies:
-      '@smithy/core': 3.24.6
-      '@smithy/types': 4.14.3
-      tslib: 2.8.1
-
-  '@smithy/smithy-client@4.13.6':
-    dependencies:
-      '@smithy/core': 3.24.6
-      '@smithy/types': 4.14.3
-      tslib: 2.8.1
-
-  '@smithy/types@4.14.3':
-    dependencies:
-      tslib: 2.8.1
-
-  '@smithy/url-parser@4.3.6':
-    dependencies:
-      '@smithy/core': 3.24.6
-      tslib: 2.8.1
-
-  '@smithy/util-base64@4.4.6':
-    dependencies:
-      '@smithy/core': 3.24.6
-      tslib: 2.8.1
-
-  '@smithy/util-body-length-browser@4.3.6':
-    dependencies:
-      '@smithy/core': 3.24.6
-      tslib: 2.8.1
-
-  '@smithy/util-body-length-node@4.3.6':
-    dependencies:
-      '@smithy/core': 3.24.6
-      tslib: 2.8.1
-
-  '@smithy/util-buffer-from@2.2.0':
-    dependencies:
-      '@smithy/is-array-buffer': 2.2.0
-      tslib: 2.8.1
-
-  '@smithy/util-defaults-mode-browser@4.4.6':
-    dependencies:
-      '@smithy/core': 3.24.6
-      tslib: 2.8.1
-
-  '@smithy/util-defaults-mode-node@4.3.6':
-    dependencies:
-      '@smithy/core': 3.24.6
-      tslib: 2.8.1
-
-  '@smithy/util-endpoints@3.5.6':
-    dependencies:
-      '@smithy/core': 3.24.6
-      tslib: 2.8.1
-
-  '@smithy/util-middleware@4.3.6':
-    dependencies:
-      '@smithy/core': 3.24.6
-      tslib: 2.8.1
-
-  '@smithy/util-retry@4.4.6':
-    dependencies:
-      '@smithy/core': 3.24.6
-      tslib: 2.8.1
-
-  '@smithy/util-stream@4.6.6':
-    dependencies:
-      '@smithy/core': 3.24.6
-      tslib: 2.8.1
-
-  '@smithy/util-utf8@2.3.0':
-    dependencies:
-      '@smithy/util-buffer-from': 2.2.0
-      tslib: 2.8.1
-
-  '@smithy/util-utf8@4.3.6':
-    dependencies:
-      '@smithy/core': 3.24.6
-      tslib: 2.8.1
-
-  '@smithy/util-waiter@4.4.6':
-    dependencies:
-      '@smithy/core': 3.24.6
-      tslib: 2.8.1
-
-  '@standard-schema/spec@1.1.0': {}
-
-  '@triskcraft/api-types@1.2.1':
-    dependencies:
-      zod: 4.4.1
-
-  '@types/body-parser@1.19.6':
-    dependencies:
-      '@types/connect': 3.4.38
-      '@types/node': 25.6.0
-
-  '@types/busboy@1.5.4':
-    dependencies:
-      '@types/node': 25.6.0
-
-  '@types/connect@3.4.38':
-    dependencies:
-      '@types/node': 25.6.0
-
-  '@types/cookie-parser@1.4.10(@types/express@5.0.6)':
-    dependencies:
-      '@types/express': 5.0.6
-
-  '@types/cors@2.8.19':
-    dependencies:
-      '@types/node': 25.6.0
-
-  '@types/esrecurse@4.3.1': {}
-
-  '@types/estree@1.0.9': {}
-
-  '@types/express-serve-static-core@5.1.1':
-    dependencies:
-      '@types/node': 25.6.0
-      '@types/qs': 6.15.1
-      '@types/range-parser': 1.2.7
-      '@types/send': 1.2.1
-
-  '@types/express@5.0.6':
-    dependencies:
-      '@types/body-parser': 1.19.6
-      '@types/express-serve-static-core': 5.1.1
-      '@types/serve-static': 2.2.0
-
-  '@types/http-errors@2.0.5': {}
-
-  '@types/json-schema@7.0.15': {}
-
-  '@types/json5@0.0.29': {}
-
-  '@types/luxon@3.7.1': {}
-
-  '@types/multer@2.1.0':
-    dependencies:
-      '@types/express': 5.0.6
-
-  '@types/node@25.6.0':
-    dependencies:
-      undici-types: 7.19.2
-
-  '@types/pg@8.20.0':
-    dependencies:
-      '@types/node': 25.6.0
-      pg-protocol: 1.14.0
-      pg-types: 2.2.0
-
-  '@types/qs@6.15.1': {}
-
-  '@types/range-parser@1.2.7': {}
-
-  '@types/react@19.2.17':
-    dependencies:
-      csstype: 3.2.3
-
-  '@types/send@1.2.1':
-    dependencies:
-      '@types/node': 25.6.0
-
-  '@types/serve-static@2.2.0':
-    dependencies:
-      '@types/http-errors': 2.0.5
-      '@types/node': 25.6.0
-
-  '@types/ws@8.18.1':
-    dependencies:
-      '@types/node': 25.6.0
-
-  '@typescript-eslint/eslint-plugin@8.59.1(@typescript-eslint/parser@8.59.1(eslint@10.2.1(jiti@2.7.0))(typescript@6.0.3))(eslint@10.2.1(jiti@2.7.0))(typescript@6.0.3)':
-    dependencies:
-      '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.59.1(eslint@10.2.1(jiti@2.7.0))(typescript@6.0.3)
-      '@typescript-eslint/scope-manager': 8.59.1
-      '@typescript-eslint/type-utils': 8.59.1(eslint@10.2.1(jiti@2.7.0))(typescript@6.0.3)
-      '@typescript-eslint/utils': 8.59.1(eslint@10.2.1(jiti@2.7.0))(typescript@6.0.3)
-      '@typescript-eslint/visitor-keys': 8.59.1
-      eslint: 10.2.1(jiti@2.7.0)
-      ignore: 7.0.5
-      natural-compare: 1.4.0
-      ts-api-utils: 2.5.0(typescript@6.0.3)
-      typescript: 6.0.3
-    transitivePeerDependencies:
-      - supports-color
-
-  '@typescript-eslint/parser@8.59.1(eslint@10.2.1(jiti@2.7.0))(typescript@6.0.3)':
-    dependencies:
-      '@typescript-eslint/scope-manager': 8.59.1
-      '@typescript-eslint/types': 8.59.1
-      '@typescript-eslint/typescript-estree': 8.59.1(typescript@6.0.3)
-      '@typescript-eslint/visitor-keys': 8.59.1
-      debug: 4.4.3
-      eslint: 10.2.1(jiti@2.7.0)
-      typescript: 6.0.3
-    transitivePeerDependencies:
-      - supports-color
-
-  '@typescript-eslint/project-service@8.59.1(typescript@6.0.3)':
-    dependencies:
-      '@typescript-eslint/tsconfig-utils': 8.59.1(typescript@6.0.3)
-      '@typescript-eslint/types': 8.59.1
-      debug: 4.4.3
-      typescript: 6.0.3
-    transitivePeerDependencies:
-      - supports-color
-
-  '@typescript-eslint/scope-manager@8.59.1':
-    dependencies:
-      '@typescript-eslint/types': 8.59.1
-      '@typescript-eslint/visitor-keys': 8.59.1
-
-  '@typescript-eslint/tsconfig-utils@8.59.1(typescript@6.0.3)':
-    dependencies:
-      typescript: 6.0.3
-
-  '@typescript-eslint/type-utils@8.59.1(eslint@10.2.1(jiti@2.7.0))(typescript@6.0.3)':
-    dependencies:
-      '@typescript-eslint/types': 8.59.1
-      '@typescript-eslint/typescript-estree': 8.59.1(typescript@6.0.3)
-      '@typescript-eslint/utils': 8.59.1(eslint@10.2.1(jiti@2.7.0))(typescript@6.0.3)
-      debug: 4.4.3
-      eslint: 10.2.1(jiti@2.7.0)
-      ts-api-utils: 2.5.0(typescript@6.0.3)
-      typescript: 6.0.3
-    transitivePeerDependencies:
-      - supports-color
-
-  '@typescript-eslint/types@8.59.1': {}
-
-  '@typescript-eslint/typescript-estree@8.59.1(typescript@6.0.3)':
-    dependencies:
-      '@typescript-eslint/project-service': 8.59.1(typescript@6.0.3)
-      '@typescript-eslint/tsconfig-utils': 8.59.1(typescript@6.0.3)
-      '@typescript-eslint/types': 8.59.1
-      '@typescript-eslint/visitor-keys': 8.59.1
-      debug: 4.4.3
-      minimatch: 10.2.5
-      semver: 7.8.2
-      tinyglobby: 0.2.17
-      ts-api-utils: 2.5.0(typescript@6.0.3)
-      typescript: 6.0.3
-    transitivePeerDependencies:
-      - supports-color
-
-  '@typescript-eslint/utils@8.59.1(eslint@10.2.1(jiti@2.7.0))(typescript@6.0.3)':
-    dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@10.2.1(jiti@2.7.0))
-      '@typescript-eslint/scope-manager': 8.59.1
-      '@typescript-eslint/types': 8.59.1
-      '@typescript-eslint/typescript-estree': 8.59.1(typescript@6.0.3)
-      eslint: 10.2.1(jiti@2.7.0)
-      typescript: 6.0.3
-    transitivePeerDependencies:
-      - supports-color
-
-  '@typescript-eslint/visitor-keys@8.59.1':
-    dependencies:
-      '@typescript-eslint/types': 8.59.1
-      eslint-visitor-keys: 5.0.1
-
-  '@vladfrangu/async_event_emitter@2.4.7': {}
-
-  accepts@2.0.0:
-    dependencies:
-      mime-types: 3.0.2
-      negotiator: 1.0.0
-
-  acorn-jsx@5.3.2(acorn@8.16.0):
-    dependencies:
-      acorn: 8.16.0
-
-  acorn@8.16.0: {}
-
-  ajv@6.15.0:
-    dependencies:
-      fast-deep-equal: 3.1.3
-      fast-json-stable-stringify: 2.1.0
-      json-schema-traverse: 0.4.1
-      uri-js: 4.4.1
-
-  ajv@8.20.0:
-    dependencies:
-      fast-deep-equal: 3.1.3
-      fast-uri: 3.1.2
-      json-schema-traverse: 1.0.0
-      require-from-string: 2.0.2
-
-  argon2@0.44.0:
-    dependencies:
-      '@phc/format': 1.0.0
-      cross-env: 10.1.0
-      node-addon-api: 8.8.0
-      node-gyp-build: 4.8.4
-
-  array-buffer-byte-length@1.0.2:
-    dependencies:
-      call-bound: 1.0.4
-      is-array-buffer: 3.0.5
-
-  array-includes@3.1.9:
-    dependencies:
-      call-bind: 1.0.9
-      call-bound: 1.0.4
-      define-properties: 1.2.1
-      es-abstract: 1.24.2
-      es-object-atoms: 1.1.2
-      get-intrinsic: 1.3.0
-      is-string: 1.1.1
-      math-intrinsics: 1.1.0
-
-  array.prototype.findlastindex@1.2.6:
-    dependencies:
-      call-bind: 1.0.9
-      call-bound: 1.0.4
-      define-properties: 1.2.1
-      es-abstract: 1.24.2
-      es-errors: 1.3.0
-      es-object-atoms: 1.1.2
-      es-shim-unscopables: 1.1.0
-
-  array.prototype.flat@1.3.3:
-    dependencies:
-      call-bind: 1.0.9
-      define-properties: 1.2.1
-      es-abstract: 1.24.2
-      es-shim-unscopables: 1.1.0
-
-  array.prototype.flatmap@1.3.3:
-    dependencies:
-      call-bind: 1.0.9
-      define-properties: 1.2.1
-      es-abstract: 1.24.2
-      es-shim-unscopables: 1.1.0
-
-  arraybuffer.prototype.slice@1.0.4:
-    dependencies:
-      array-buffer-byte-length: 1.0.2
-      call-bind: 1.0.9
-      define-properties: 1.2.1
-      es-abstract: 1.24.2
-      es-errors: 1.3.0
-      get-intrinsic: 1.3.0
-      is-array-buffer: 3.0.5
-
-  async-function@1.0.0: {}
-
-  atomic-sleep@1.0.0: {}
-
-  available-typed-arrays@1.0.7:
-    dependencies:
-      possible-typed-array-names: 1.1.0
-
-  aws-ssl-profiles@1.1.2: {}
-
-  balanced-match@1.0.2: {}
-
-  balanced-match@4.0.4: {}
-
-  base64-js@1.5.1: {}
-
-  better-result@2.9.2: {}
-
-  body-parser@2.2.2:
-    dependencies:
-      bytes: 3.1.2
-      content-type: 1.0.5
-      debug: 4.4.3
-      http-errors: 2.0.1
-      iconv-lite: 0.7.2
-      on-finished: 2.4.1
-      qs: 6.15.2
-      raw-body: 3.0.2
-      type-is: 2.1.0
-    transitivePeerDependencies:
-      - supports-color
-
-  bowser@2.14.1: {}
-
-  brace-expansion@1.1.15:
-    dependencies:
-      balanced-match: 1.0.2
-      concat-map: 0.0.1
-
-  brace-expansion@5.0.6:
-    dependencies:
-      balanced-match: 4.0.4
-
-  buffer@5.6.0:
-    dependencies:
-      base64-js: 1.5.1
-      ieee754: 1.2.1
-
-  busboy@1.6.0:
-    dependencies:
-      streamsearch: 1.1.0
-
-  bytes@3.1.2: {}
-
-  c12@3.3.4:
-    dependencies:
-      chokidar: 5.0.0
-      confbox: 0.2.4
-      defu: 6.1.7
-      dotenv: 17.4.2
-      exsolve: 1.0.8
-      giget: 3.2.0
-      jiti: 2.7.0
-      ohash: 2.0.11
-      pathe: 2.0.3
-      perfect-debounce: 2.1.0
-      pkg-types: 2.3.1
-      rc9: 3.0.1
-
-  call-bind-apply-helpers@1.0.2:
-    dependencies:
-      es-errors: 1.3.0
-      function-bind: 1.1.2
-
-  call-bind@1.0.9:
-    dependencies:
-      call-bind-apply-helpers: 1.0.2
-      es-define-property: 1.0.1
-      get-intrinsic: 1.3.0
-      set-function-length: 1.2.2
-
-  call-bound@1.0.4:
-    dependencies:
-      call-bind-apply-helpers: 1.0.2
-      get-intrinsic: 1.3.0
-
-  chart.js@4.5.1:
-    dependencies:
-      '@kurkle/color': 0.3.4
-
-  chokidar@5.0.0:
-    dependencies:
-      readdirp: 5.0.0
-
-  colorette@2.0.20: {}
-
-  concat-map@0.0.1: {}
-
-  confbox@0.2.4: {}
-
-  content-disposition@1.1.0: {}
-
-  content-type@1.0.5: {}
-
-  content-type@2.0.0: {}
-
-  cookie-parser@1.4.7:
-    dependencies:
-      cookie: 0.7.2
-      cookie-signature: 1.0.6
-
-  cookie-signature@1.0.6: {}
-
-  cookie-signature@1.2.2: {}
-
-  cookie@0.7.2: {}
-
-  cors@2.8.6:
-    dependencies:
-      object-assign: 4.1.1
-      vary: 1.1.2
-
-  cross-env@10.1.0:
-    dependencies:
-      '@epic-web/invariant': 1.0.0
-      cross-spawn: 7.0.6
-
-  cross-spawn@7.0.6:
-    dependencies:
-      path-key: 3.1.1
-      shebang-command: 2.0.0
-      which: 2.0.2
-
-  csstype@3.2.3: {}
-
-  data-view-buffer@1.0.2:
-    dependencies:
-      call-bound: 1.0.4
-      es-errors: 1.3.0
-      is-data-view: 1.0.2
-
-  data-view-byte-length@1.0.2:
-    dependencies:
-      call-bound: 1.0.4
-      es-errors: 1.3.0
-      is-data-view: 1.0.2
-
-  data-view-byte-offset@1.0.1:
-    dependencies:
-      call-bound: 1.0.4
-      es-errors: 1.3.0
-      is-data-view: 1.0.2
-
-  dateformat@4.6.3: {}
-
-  debug@3.2.7:
-    dependencies:
-      ms: 2.1.3
-
-  debug@4.4.3:
-    dependencies:
-      ms: 2.1.3
-
-  deep-is@0.1.4: {}
-
-  deepmerge-ts@7.1.5: {}
-
-  define-data-property@1.1.4:
-    dependencies:
-      es-define-property: 1.0.1
-      es-errors: 1.3.0
-      gopd: 1.2.0
-
-  define-properties@1.2.1:
-    dependencies:
-      define-data-property: 1.1.4
-      has-property-descriptors: 1.0.2
-      object-keys: 1.1.1
-
-  defu@6.1.7: {}
-
-  denque@2.1.0: {}
-
-  depd@2.0.0: {}
-
-  destr@2.0.5: {}
-
-  discord-api-types@0.38.48: {}
-
-  discord.js@14.26.3:
-    dependencies:
-      '@discordjs/builders': 1.14.1
-      '@discordjs/collection': 1.5.3
-      '@discordjs/formatters': 0.6.2
-      '@discordjs/rest': 2.6.1
-      '@discordjs/util': 1.2.0
-      '@discordjs/ws': 1.2.3
-      '@sapphire/snowflake': 3.5.3
-      discord-api-types: 0.38.48
-      fast-deep-equal: 3.1.3
-      lodash.snakecase: 4.1.1
-      magic-bytes.js: 1.13.0
-      tslib: 2.8.1
-      undici: 6.24.1
-    transitivePeerDependencies:
-      - bufferutil
-      - utf-8-validate
-
-  doctrine@2.1.0:
-    dependencies:
-      esutils: 2.0.3
-
-  dotenv@17.4.2: {}
-
-  dunder-proto@1.0.1:
-    dependencies:
-      call-bind-apply-helpers: 1.0.2
-      es-errors: 1.3.0
-      gopd: 1.2.0
-
-  ee-first@1.1.1: {}
-
-  effect@3.20.0:
-    dependencies:
-      '@standard-schema/spec': 1.1.0
-      fast-check: 3.23.2
-
-  empathic@2.0.0: {}
-
-  encodeurl@2.0.0: {}
-
-  end-of-stream@1.4.5:
-    dependencies:
-      once: 1.4.0
-
-  env-paths@3.0.0: {}
-
-  es-abstract@1.24.2:
-    dependencies:
-      array-buffer-byte-length: 1.0.2
-      arraybuffer.prototype.slice: 1.0.4
-      available-typed-arrays: 1.0.7
-      call-bind: 1.0.9
-      call-bound: 1.0.4
-      data-view-buffer: 1.0.2
-      data-view-byte-length: 1.0.2
-      data-view-byte-offset: 1.0.1
-      es-define-property: 1.0.1
-      es-errors: 1.3.0
-      es-object-atoms: 1.1.2
-      es-set-tostringtag: 2.1.0
-      es-to-primitive: 1.3.0
-      function.prototype.name: 1.1.8
-      get-intrinsic: 1.3.0
-      get-proto: 1.0.1
-      get-symbol-description: 1.1.0
-      globalthis: 1.0.4
-      gopd: 1.2.0
-      has-property-descriptors: 1.0.2
-      has-proto: 1.2.0
-      has-symbols: 1.1.0
-      hasown: 2.0.4
-      internal-slot: 1.1.0
-      is-array-buffer: 3.0.5
-      is-callable: 1.2.7
-      is-data-view: 1.0.2
-      is-negative-zero: 2.0.3
-      is-regex: 1.2.1
-      is-set: 2.0.3
-      is-shared-array-buffer: 1.0.4
-      is-string: 1.1.1
-      is-typed-array: 1.1.15
-      is-weakref: 1.1.1
-      math-intrinsics: 1.1.0
-      object-inspect: 1.13.4
-      object-keys: 1.1.1
-      object.assign: 4.1.7
-      own-keys: 1.0.1
-      regexp.prototype.flags: 1.5.4
-      safe-array-concat: 1.1.4
-      safe-push-apply: 1.0.0
-      safe-regex-test: 1.1.0
-      set-proto: 1.0.0
-      stop-iteration-iterator: 1.1.0
-      string.prototype.trim: 1.2.11
-      string.prototype.trimend: 1.0.10
-      string.prototype.trimstart: 1.0.8
-      typed-array-buffer: 1.0.3
-      typed-array-byte-length: 1.0.3
-      typed-array-byte-offset: 1.0.4
-      typed-array-length: 1.0.8
-      unbox-primitive: 1.1.0
-      which-typed-array: 1.1.22
-
-  es-define-property@1.0.1: {}
-
-  es-errors@1.3.0: {}
-
-  es-object-atoms@1.1.2:
-    dependencies:
-      es-errors: 1.3.0
-
-  es-set-tostringtag@2.1.0:
-    dependencies:
-      es-errors: 1.3.0
-      get-intrinsic: 1.3.0
-      has-tostringtag: 1.0.2
-      hasown: 2.0.4
-
-  es-shim-unscopables@1.1.0:
-    dependencies:
-      hasown: 2.0.4
-
-  es-to-primitive@1.3.0:
-    dependencies:
-      is-callable: 1.2.7
-      is-date-object: 1.1.0
-      is-symbol: 1.1.1
-
-  escape-html@1.0.3: {}
-
-  escape-string-regexp@4.0.0: {}
-
-  eslint-config-prettier@10.1.8(eslint@10.2.1(jiti@2.7.0)):
-    dependencies:
-      eslint: 10.2.1(jiti@2.7.0)
-
-  eslint-import-resolver-node@0.3.10:
-    dependencies:
-      debug: 3.2.7
-      is-core-module: 2.16.2
-      resolve: 2.0.0-next.7
-    transitivePeerDependencies:
-      - supports-color
-
-  eslint-module-utils@2.13.0(@typescript-eslint/parser@8.59.1(eslint@10.2.1(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint@10.2.1(jiti@2.7.0)):
-    dependencies:
-      debug: 3.2.7
-    optionalDependencies:
-      '@typescript-eslint/parser': 8.59.1(eslint@10.2.1(jiti@2.7.0))(typescript@6.0.3)
-      eslint: 10.2.1(jiti@2.7.0)
-      eslint-import-resolver-node: 0.3.10
-    transitivePeerDependencies:
-      - supports-color
-
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.1(eslint@10.2.1(jiti@2.7.0))(typescript@6.0.3))(eslint@10.2.1(jiti@2.7.0)):
-    dependencies:
-      '@rtsao/scc': 1.1.0
-      array-includes: 3.1.9
-      array.prototype.findlastindex: 1.2.6
-      array.prototype.flat: 1.3.3
-      array.prototype.flatmap: 1.3.3
-      debug: 3.2.7
-      doctrine: 2.1.0
-      eslint: 10.2.1(jiti@2.7.0)
-      eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.13.0(@typescript-eslint/parser@8.59.1(eslint@10.2.1(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint@10.2.1(jiti@2.7.0))
-      hasown: 2.0.4
-      is-core-module: 2.16.2
-      is-glob: 4.0.3
-      minimatch: 3.1.5
-      object.fromentries: 2.0.8
-      object.groupby: 1.0.3
-      object.values: 1.2.1
-      semver: 6.3.1
-      string.prototype.trimend: 1.0.10
-      tsconfig-paths: 3.15.0
-    optionalDependencies:
-      '@typescript-eslint/parser': 8.59.1(eslint@10.2.1(jiti@2.7.0))(typescript@6.0.3)
-    transitivePeerDependencies:
-      - eslint-import-resolver-typescript
-      - eslint-import-resolver-webpack
-      - supports-color
-
-  eslint-scope@9.1.2:
-    dependencies:
-      '@types/esrecurse': 4.3.1
-      '@types/estree': 1.0.9
-      esrecurse: 4.3.0
-      estraverse: 5.3.0
-
-  eslint-visitor-keys@3.4.3: {}
-
-  eslint-visitor-keys@5.0.1: {}
-
-  eslint@10.2.1(jiti@2.7.0):
-    dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@10.2.1(jiti@2.7.0))
-      '@eslint-community/regexpp': 4.12.2
-      '@eslint/config-array': 0.23.5
-      '@eslint/config-helpers': 0.5.5
-      '@eslint/core': 1.2.1
-      '@eslint/plugin-kit': 0.7.2
-      '@humanfs/node': 0.16.8
-      '@humanwhocodes/module-importer': 1.0.1
-      '@humanwhocodes/retry': 0.4.3
-      '@types/estree': 1.0.9
-      ajv: 6.15.0
-      cross-spawn: 7.0.6
-      debug: 4.4.3
-      escape-string-regexp: 4.0.0
-      eslint-scope: 9.1.2
-      eslint-visitor-keys: 5.0.1
-      espree: 11.2.0
-      esquery: 1.7.0
-      esutils: 2.0.3
-      fast-deep-equal: 3.1.3
-      file-entry-cache: 8.0.0
-      find-up: 5.0.0
-      glob-parent: 6.0.2
-      ignore: 5.3.2
-      imurmurhash: 0.1.4
-      is-glob: 4.0.3
-      json-stable-stringify-without-jsonify: 1.0.1
-      minimatch: 10.2.5
-      natural-compare: 1.4.0
-      optionator: 0.9.4
-    optionalDependencies:
-      jiti: 2.7.0
-    transitivePeerDependencies:
-      - supports-color
-
-  espree@11.2.0:
-    dependencies:
-      acorn: 8.16.0
-      acorn-jsx: 5.3.2(acorn@8.16.0)
-      eslint-visitor-keys: 5.0.1
-
-  esquery@1.7.0:
-    dependencies:
-      estraverse: 5.3.0
-
-  esrecurse@4.3.0:
-    dependencies:
-      estraverse: 5.3.0
-
-  estraverse@5.3.0: {}
-
-  esutils@2.0.3: {}
-
-  etag@1.8.1: {}
-
-  events@3.3.0: {}
-
-  express@5.2.1:
-    dependencies:
-      accepts: 2.0.0
-      body-parser: 2.2.2
-      content-disposition: 1.1.0
-      content-type: 1.0.5
-      cookie: 0.7.2
-      cookie-signature: 1.2.2
-      debug: 4.4.3
-      depd: 2.0.0
-      encodeurl: 2.0.0
-      escape-html: 1.0.3
-      etag: 1.8.1
-      finalhandler: 2.1.1
-      fresh: 2.0.0
-      http-errors: 2.0.1
-      merge-descriptors: 2.0.0
-      mime-types: 3.0.2
-      on-finished: 2.4.1
-      once: 1.4.0
-      parseurl: 1.3.3
-      proxy-addr: 2.0.7
-      qs: 6.15.2
-      range-parser: 1.2.1
-      router: 2.2.0
-      send: 1.2.1
-      serve-static: 2.2.1
-      statuses: 2.0.2
-      type-is: 2.1.0
-      vary: 1.1.2
-    transitivePeerDependencies:
-      - supports-color
-
-  exsolve@1.0.8: {}
-
-  fast-check@3.23.2:
-    dependencies:
-      pure-rand: 6.1.0
-
-  fast-copy@4.0.3: {}
-
-  fast-deep-equal@3.1.3: {}
-
-  fast-json-stable-stringify@2.1.0: {}
-
-  fast-levenshtein@2.0.6: {}
-
-  fast-safe-stringify@2.1.1: {}
-
-  fast-uri@3.1.2: {}
-
-  fast-xml-builder@1.2.0:
-    dependencies:
-      path-expression-matcher: 1.5.0
-      xml-naming: 0.1.0
-
-  fast-xml-parser@5.7.3:
-    dependencies:
-      '@nodable/entities': 2.1.1
-      fast-xml-builder: 1.2.0
-      path-expression-matcher: 1.5.0
-      strnum: 2.3.0
-
-  fdir@6.5.0(picomatch@4.0.4):
-    optionalDependencies:
-      picomatch: 4.0.4
-
-  file-entry-cache@8.0.0:
-    dependencies:
-      flat-cache: 4.0.1
-
-  finalhandler@2.1.1:
-    dependencies:
-      debug: 4.4.3
-      encodeurl: 2.0.0
-      escape-html: 1.0.3
-      on-finished: 2.4.1
-      parseurl: 1.3.3
-      statuses: 2.0.2
-    transitivePeerDependencies:
-      - supports-color
-
-  find-up@5.0.0:
-    dependencies:
-      locate-path: 6.0.0
-      path-exists: 4.0.0
-
-  flat-cache@4.0.1:
-    dependencies:
-      flatted: 3.4.2
-      keyv: 4.5.4
-
-  flatted@3.4.2: {}
-
-  for-each@0.3.5:
-    dependencies:
-      is-callable: 1.2.7
-
-  foreground-child@3.3.1:
-    dependencies:
-      cross-spawn: 7.0.6
-      signal-exit: 4.1.0
-
-  forwarded@0.2.0: {}
-
-  fresh@2.0.0: {}
-
-  function-bind@1.1.2: {}
-
-  function.prototype.name@1.1.8:
-    dependencies:
-      call-bind: 1.0.9
-      call-bound: 1.0.4
-      define-properties: 1.2.1
-      functions-have-names: 1.2.3
-      hasown: 2.0.4
-      is-callable: 1.2.7
-
-  functions-have-names@1.2.3: {}
-
-  generate-function@2.3.1:
-    dependencies:
-      is-property: 1.0.2
-
-  generator-function@2.0.1: {}
-
-  get-intrinsic@1.3.0:
-    dependencies:
-      call-bind-apply-helpers: 1.0.2
-      es-define-property: 1.0.1
-      es-errors: 1.3.0
-      es-object-atoms: 1.1.2
-      function-bind: 1.1.2
-      get-proto: 1.0.1
-      gopd: 1.2.0
-      has-symbols: 1.1.0
-      hasown: 2.0.4
-      math-intrinsics: 1.1.0
-
-  get-port-please@3.2.0: {}
-
-  get-proto@1.0.1:
-    dependencies:
-      dunder-proto: 1.0.1
-      es-object-atoms: 1.1.2
-
-  get-symbol-description@1.1.0:
-    dependencies:
-      call-bound: 1.0.4
-      es-errors: 1.3.0
-      get-intrinsic: 1.3.0
-
-  giget@3.2.0: {}
-
-  glob-parent@6.0.2:
-    dependencies:
-      is-glob: 4.0.3
-
-  globals@17.5.0: {}
-
-  globalthis@1.0.4:
-    dependencies:
-      define-properties: 1.2.1
-      gopd: 1.2.0
-
-  gopd@1.2.0: {}
-
-  graceful-fs@4.2.11: {}
-
-  grammex@3.1.12: {}
-
-  graphmatch@1.1.1: {}
-
-  has-bigints@1.1.0: {}
-
-  has-property-descriptors@1.0.2:
-    dependencies:
-      es-define-property: 1.0.1
-
-  has-proto@1.2.0:
-    dependencies:
-      dunder-proto: 1.0.1
-
-  has-symbols@1.1.0: {}
-
-  has-tostringtag@1.0.2:
-    dependencies:
-      has-symbols: 1.1.0
-
-  hasown@2.0.4:
-    dependencies:
-      function-bind: 1.1.2
-
-  help-me@5.0.0: {}
-
-  hono@4.12.23: {}
-
-  http-errors@2.0.1:
-    dependencies:
-      depd: 2.0.0
-      inherits: 2.0.4
-      setprototypeof: 1.2.0
-      statuses: 2.0.2
-      toidentifier: 1.0.1
-
-  http-status-codes@2.3.0: {}
-
-  iconv-lite@0.7.2:
-    dependencies:
-      safer-buffer: 2.1.2
-
-  ieee754@1.2.1: {}
-
-  ignore@5.3.2: {}
-
-  ignore@7.0.5: {}
-
-  imurmurhash@0.1.4: {}
-
-  inherits@2.0.4: {}
-
-  internal-slot@1.1.0:
-    dependencies:
-      es-errors: 1.3.0
-      hasown: 2.0.4
-      side-channel: 1.1.0
-
-  ipaddr.js@1.9.1: {}
-
-  is-array-buffer@3.0.5:
-    dependencies:
-      call-bind: 1.0.9
-      call-bound: 1.0.4
-      get-intrinsic: 1.3.0
-
-  is-async-function@2.1.1:
-    dependencies:
-      async-function: 1.0.0
-      call-bound: 1.0.4
-      get-proto: 1.0.1
-      has-tostringtag: 1.0.2
-      safe-regex-test: 1.1.0
-
-  is-bigint@1.1.0:
-    dependencies:
-      has-bigints: 1.1.0
-
-  is-boolean-object@1.2.2:
-    dependencies:
-      call-bound: 1.0.4
-      has-tostringtag: 1.0.2
-
-  is-callable@1.2.7: {}
-
-  is-core-module@2.16.2:
-    dependencies:
-      hasown: 2.0.4
-
-  is-data-view@1.0.2:
-    dependencies:
-      call-bound: 1.0.4
-      get-intrinsic: 1.3.0
-      is-typed-array: 1.1.15
-
-  is-date-object@1.1.0:
-    dependencies:
-      call-bound: 1.0.4
-      has-tostringtag: 1.0.2
-
-  is-extglob@2.1.1: {}
-
-  is-finalizationregistry@1.1.1:
-    dependencies:
-      call-bound: 1.0.4
-
-  is-generator-function@1.1.2:
-    dependencies:
-      call-bound: 1.0.4
-      generator-function: 2.0.1
-      get-proto: 1.0.1
-      has-tostringtag: 1.0.2
-      safe-regex-test: 1.1.0
-
-  is-glob@4.0.3:
-    dependencies:
-      is-extglob: 2.1.1
-
-  is-map@2.0.3: {}
-
-  is-negative-zero@2.0.3: {}
-
-  is-number-object@1.1.1:
-    dependencies:
-      call-bound: 1.0.4
-      has-tostringtag: 1.0.2
-
-  is-promise@4.0.0: {}
-
-  is-property@1.0.2: {}
-
-  is-regex@1.2.1:
-    dependencies:
-      call-bound: 1.0.4
-      gopd: 1.2.0
-      has-tostringtag: 1.0.2
-      hasown: 2.0.4
-
-  is-set@2.0.3: {}
-
-  is-shared-array-buffer@1.0.4:
-    dependencies:
-      call-bound: 1.0.4
-
-  is-string@1.1.1:
-    dependencies:
-      call-bound: 1.0.4
-      has-tostringtag: 1.0.2
-
-  is-symbol@1.1.1:
-    dependencies:
-      call-bound: 1.0.4
-      has-symbols: 1.1.0
-      safe-regex-test: 1.1.0
-
-  is-typed-array@1.1.15:
-    dependencies:
-      which-typed-array: 1.1.22
-
-  is-weakmap@2.0.2: {}
-
-  is-weakref@1.1.1:
-    dependencies:
-      call-bound: 1.0.4
-
-  is-weakset@2.0.4:
-    dependencies:
-      call-bound: 1.0.4
-      get-intrinsic: 1.3.0
-
-  isarray@2.0.5: {}
-
-  isexe@2.0.0: {}
-
-  jiti@2.7.0: {}
-
-  jose@6.2.3: {}
-
-  joycon@3.1.1: {}
-
-  jsbi@4.3.2: {}
-
-  json-buffer@3.0.1: {}
-
-  json-schema-traverse@0.4.1: {}
-
-  json-schema-traverse@1.0.0: {}
-
-  json-stable-stringify-without-jsonify@1.0.1: {}
-
-  json5@1.0.2:
-    dependencies:
-      minimist: 1.2.8
-
-  keyv@4.5.4:
-    dependencies:
-      json-buffer: 3.0.1
-
-  levn@0.4.1:
-    dependencies:
-      prelude-ls: 1.2.1
-      type-check: 0.4.0
-
-  locate-path@6.0.0:
-    dependencies:
-      p-locate: 5.0.0
-
-  lodash.snakecase@4.1.1: {}
-
-  lodash@4.18.1: {}
-
-  long@5.3.2: {}
-
-  lru.min@1.1.4: {}
-
-  luxon@3.7.2: {}
-
-  magic-bytes.js@1.13.0: {}
-
-  math-intrinsics@1.1.0: {}
-
-  media-typer@1.1.0: {}
-
-  merge-descriptors@2.0.0: {}
-
-  mime-db@1.54.0: {}
-
-  mime-types@3.0.2:
-    dependencies:
-      mime-db: 1.54.0
-
-  minimatch@10.2.5:
-    dependencies:
-      brace-expansion: 5.0.6
-
-  minimatch@3.1.5:
-    dependencies:
-      brace-expansion: 1.1.15
-
-  minimist@1.2.8: {}
-
-  ms@2.1.3: {}
-
-  mysql2@3.15.3:
-    dependencies:
-      aws-ssl-profiles: 1.1.2
-      denque: 2.1.0
-      generate-function: 2.3.1
-      iconv-lite: 0.7.2
-      long: 5.3.2
-      lru.min: 1.1.4
-      named-placeholders: 1.1.6
-      seq-queue: 0.0.5
-      sqlstring: 2.3.3
-
-  named-placeholders@1.1.6:
-    dependencies:
-      lru.min: 1.1.4
-
-  natural-compare@1.4.0: {}
-
-  negotiator@1.0.0: {}
-
-  neverthrow@8.2.0:
-    optionalDependencies:
-      '@rollup/rollup-linux-x64-gnu': 4.61.1
-
-  node-addon-api@8.8.0: {}
-
-  node-exports-info@1.6.0:
-    dependencies:
-      array.prototype.flatmap: 1.3.3
-      es-errors: 1.3.0
-      object.entries: 1.1.9
-      semver: 6.3.1
-
-  node-gyp-build@4.8.4: {}
-
-  object-assign@4.1.1: {}
-
-  object-inspect@1.13.4: {}
-
-  object-keys@1.1.1: {}
-
-  object.assign@4.1.7:
-    dependencies:
-      call-bind: 1.0.9
-      call-bound: 1.0.4
-      define-properties: 1.2.1
-      es-object-atoms: 1.1.2
-      has-symbols: 1.1.0
-      object-keys: 1.1.1
-
-  object.entries@1.1.9:
-    dependencies:
-      call-bind: 1.0.9
-      call-bound: 1.0.4
-      define-properties: 1.2.1
-      es-object-atoms: 1.1.2
-
-  object.fromentries@2.0.8:
-    dependencies:
-      call-bind: 1.0.9
-      define-properties: 1.2.1
-      es-abstract: 1.24.2
-      es-object-atoms: 1.1.2
-
-  object.groupby@1.0.3:
-    dependencies:
-      call-bind: 1.0.9
-      define-properties: 1.2.1
-      es-abstract: 1.24.2
-
-  object.values@1.2.1:
-    dependencies:
-      call-bind: 1.0.9
-      call-bound: 1.0.4
-      define-properties: 1.2.1
-      es-object-atoms: 1.1.2
-
-  ohash@2.0.11: {}
-
-  on-exit-leak-free@2.1.2: {}
-
-  on-finished@2.4.1:
-    dependencies:
-      ee-first: 1.1.1
-
-  once@1.4.0:
-    dependencies:
-      wrappy: 1.0.2
-
-  optionator@0.9.4:
-    dependencies:
-      deep-is: 0.1.4
-      fast-levenshtein: 2.0.6
-      levn: 0.4.1
-      prelude-ls: 1.2.1
-      type-check: 0.4.0
-      word-wrap: 1.2.5
-
-  own-keys@1.0.1:
-    dependencies:
-      get-intrinsic: 1.3.0
-      object-keys: 1.1.1
-      safe-push-apply: 1.0.0
-
-  p-limit@3.1.0:
-    dependencies:
-      yocto-queue: 0.1.0
-
-  p-locate@5.0.0:
-    dependencies:
-      p-limit: 3.1.0
-
-  parseurl@1.3.3: {}
-
-  path-exists@4.0.0: {}
-
-  path-expression-matcher@1.5.0: {}
-
-  path-key@3.1.1: {}
-
-  path-parse@1.0.7: {}
-
-  path-to-regexp@8.4.2: {}
-
-  pathe@2.0.3: {}
-
-  perfect-debounce@2.1.0: {}
-
-  pg-cloudflare@1.4.0:
-    optional: true
-
-  pg-connection-string@2.13.0: {}
-
-  pg-int8@1.0.1: {}
-
-  pg-pool@3.14.0(pg@8.20.0):
-    dependencies:
-      pg: 8.20.0
-
-  pg-protocol@1.14.0: {}
-
-  pg-types@2.2.0:
-    dependencies:
-      pg-int8: 1.0.1
-      postgres-array: 2.0.0
-      postgres-bytea: 1.0.1
-      postgres-date: 1.0.7
-      postgres-interval: 1.2.0
-
-  pg@8.20.0:
-    dependencies:
-      pg-connection-string: 2.13.0
-      pg-pool: 3.14.0(pg@8.20.0)
-      pg-protocol: 1.14.0
-      pg-types: 2.2.0
-      pgpass: 1.0.5
-    optionalDependencies:
-      pg-cloudflare: 1.4.0
-
-  pgpass@1.0.5:
-    dependencies:
-      split2: 4.2.0
-
-  picomatch@4.0.4: {}
-
-  pino-abstract-transport@3.0.0:
-    dependencies:
-      split2: 4.2.0
-
-  pino-pretty@13.1.3:
-    dependencies:
-      colorette: 2.0.20
-      dateformat: 4.6.3
-      fast-copy: 4.0.3
-      fast-safe-stringify: 2.1.1
-      help-me: 5.0.0
-      joycon: 3.1.1
-      minimist: 1.2.8
-      on-exit-leak-free: 2.1.2
-      pino-abstract-transport: 3.0.0
-      pump: 3.0.4
-      secure-json-parse: 4.1.0
-      sonic-boom: 4.2.1
-      strip-json-comments: 5.0.3
-
-  pino-std-serializers@7.1.0: {}
-
-  pino@10.3.1:
-    dependencies:
-      '@pinojs/redact': 0.4.0
-      atomic-sleep: 1.0.0
-      on-exit-leak-free: 2.1.2
-      pino-abstract-transport: 3.0.0
-      pino-std-serializers: 7.1.0
-      process-warning: 5.0.0
-      quick-format-unescaped: 4.0.4
-      real-require: 0.2.0
-      safe-stable-stringify: 2.5.0
-      sonic-boom: 4.2.1
-      thread-stream: 4.2.0
-
-  pkg-types@2.3.1:
-    dependencies:
-      confbox: 0.2.4
-      exsolve: 1.0.8
-      pathe: 2.0.3
-
-  possible-typed-array-names@1.1.0: {}
-
-  postgres-array@2.0.0: {}
-
-  postgres-array@3.0.4: {}
-
-  postgres-bytea@1.0.1: {}
-
-  postgres-date@1.0.7: {}
-
-  postgres-interval@1.2.0:
-    dependencies:
-      xtend: 4.0.2
-
-  postgres@3.4.7: {}
-
-  prelude-ls@1.2.1: {}
-
-  prettier@3.8.3: {}
-
-  prisma@7.8.0(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3):
-    dependencies:
-      '@prisma/config': 7.8.0
-      '@prisma/dev': 0.24.3(typescript@6.0.3)
-      '@prisma/engines': 7.8.0
-      '@prisma/studio-core': 0.27.3(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      mysql2: 3.15.3
-      postgres: 3.4.7
-    optionalDependencies:
-      typescript: 6.0.3
-    transitivePeerDependencies:
-      - '@types/react'
-      - '@types/react-dom'
-      - magicast
-      - react
-      - react-dom
-
-  process-warning@5.0.0: {}
-
-  proper-lockfile@4.1.2:
-    dependencies:
-      graceful-fs: 4.2.11
-      retry: 0.12.0
-      signal-exit: 3.0.7
-
-  proxy-addr@2.0.7:
-    dependencies:
-      forwarded: 0.2.0
-      ipaddr.js: 1.9.1
-
-  pump@3.0.4:
-    dependencies:
-      end-of-stream: 1.4.5
-      once: 1.4.0
-
-  punycode@2.3.1: {}
-
-  pure-rand@6.1.0: {}
-
-  qs@6.15.2:
-    dependencies:
-      side-channel: 1.1.0
-
-  quick-format-unescaped@4.0.4: {}
-
-  range-parser@1.2.1: {}
-
-  raw-body@3.0.2:
-    dependencies:
-      bytes: 3.1.2
-      http-errors: 2.0.1
-      iconv-lite: 0.7.2
-      unpipe: 1.0.0
-
-  rc9@3.0.1:
-    dependencies:
-      defu: 6.1.7
-      destr: 2.0.5
-
-  react-dom@19.2.7(react@19.2.7):
-    dependencies:
-      react: 19.2.7
-      scheduler: 0.27.0
-
-  react@19.2.7: {}
-
-  readable-stream@3.6.2:
-    dependencies:
-      inherits: 2.0.4
-      string_decoder: 1.3.0
-      util-deprecate: 1.0.2
-
-  readdirp@5.0.0: {}
-
-  real-require@0.2.0: {}
-
-  real-require@1.0.0: {}
-
-  reflect.getprototypeof@1.0.10:
-    dependencies:
-      call-bind: 1.0.9
-      define-properties: 1.2.1
-      es-abstract: 1.24.2
-      es-errors: 1.3.0
-      es-object-atoms: 1.1.2
-      get-intrinsic: 1.3.0
-      get-proto: 1.0.1
-      which-builtin-type: 1.2.1
-
-  regexp.prototype.flags@1.5.4:
-    dependencies:
-      call-bind: 1.0.9
-      define-properties: 1.2.1
-      es-errors: 1.3.0
-      get-proto: 1.0.1
-      gopd: 1.2.0
-      set-function-name: 2.0.2
-
-  remeda@2.33.4: {}
-
-  require-from-string@2.0.2: {}
-
-  resolve@2.0.0-next.7:
-    dependencies:
-      es-errors: 1.3.0
-      is-core-module: 2.16.2
-      node-exports-info: 1.6.0
-      object-keys: 1.1.1
-      path-parse: 1.0.7
-      supports-preserve-symlinks-flag: 1.0.0
-
-  retry@0.12.0: {}
-
-  router@2.2.0:
-    dependencies:
-      debug: 4.4.3
-      depd: 2.0.0
-      is-promise: 4.0.0
-      parseurl: 1.3.3
-      path-to-regexp: 8.4.2
-    transitivePeerDependencies:
-      - supports-color
-
-  safe-array-concat@1.1.4:
-    dependencies:
-      call-bind: 1.0.9
-      call-bound: 1.0.4
-      get-intrinsic: 1.3.0
-      has-symbols: 1.1.0
-      isarray: 2.0.5
-
-  safe-buffer@5.2.1: {}
-
-  safe-push-apply@1.0.0:
-    dependencies:
-      es-errors: 1.3.0
-      isarray: 2.0.5
-
-  safe-regex-test@1.1.0:
-    dependencies:
-      call-bound: 1.0.4
-      es-errors: 1.3.0
-      is-regex: 1.2.1
-
-  safe-stable-stringify@2.5.0: {}
-
-  safer-buffer@2.1.2: {}
-
-  scheduler@0.27.0: {}
-
-  secure-json-parse@4.1.0: {}
-
-  semver@6.3.1: {}
-
-  semver@7.8.2: {}
-
-  send@1.2.1:
-    dependencies:
-      debug: 4.4.3
-      encodeurl: 2.0.0
-      escape-html: 1.0.3
-      etag: 1.8.1
-      fresh: 2.0.0
-      http-errors: 2.0.1
-      mime-types: 3.0.2
-      ms: 2.1.3
-      on-finished: 2.4.1
-      range-parser: 1.2.1
-      statuses: 2.0.2
-    transitivePeerDependencies:
-      - supports-color
-
-  seq-queue@0.0.5: {}
-
-  serve-static@2.2.1:
-    dependencies:
-      encodeurl: 2.0.0
-      escape-html: 1.0.3
-      parseurl: 1.3.3
-      send: 1.2.1
-    transitivePeerDependencies:
-      - supports-color
-
-  set-function-length@1.2.2:
-    dependencies:
-      define-data-property: 1.1.4
-      es-errors: 1.3.0
-      function-bind: 1.1.2
-      get-intrinsic: 1.3.0
-      gopd: 1.2.0
-      has-property-descriptors: 1.0.2
-
-  set-function-name@2.0.2:
-    dependencies:
-      define-data-property: 1.1.4
-      es-errors: 1.3.0
-      functions-have-names: 1.2.3
-      has-property-descriptors: 1.0.2
-
-  set-proto@1.0.0:
-    dependencies:
-      dunder-proto: 1.0.1
-      es-errors: 1.3.0
-      es-object-atoms: 1.1.2
-
-  setprototypeof@1.2.0: {}
-
-  shebang-command@2.0.0:
-    dependencies:
-      shebang-regex: 3.0.0
-
-  shebang-regex@3.0.0: {}
-
-  side-channel-list@1.0.1:
-    dependencies:
-      es-errors: 1.3.0
-      object-inspect: 1.13.4
-
-  side-channel-map@1.0.1:
-    dependencies:
-      call-bound: 1.0.4
-      es-errors: 1.3.0
-      get-intrinsic: 1.3.0
-      object-inspect: 1.13.4
-
-  side-channel-weakmap@1.0.2:
-    dependencies:
-      call-bound: 1.0.4
-      es-errors: 1.3.0
-      get-intrinsic: 1.3.0
-      object-inspect: 1.13.4
-      side-channel-map: 1.0.1
-
-  side-channel@1.1.0:
-    dependencies:
-      es-errors: 1.3.0
-      object-inspect: 1.13.4
-      side-channel-list: 1.0.1
-      side-channel-map: 1.0.1
-      side-channel-weakmap: 1.0.2
-
-  signal-exit@3.0.7: {}
-
-  signal-exit@4.1.0: {}
-
-  sonic-boom@4.2.1:
-    dependencies:
-      atomic-sleep: 1.0.0
-
-  split2@4.2.0: {}
-
-  sqlstring@2.3.3: {}
-
-  statuses@2.0.2: {}
-
-  std-env@3.10.0: {}
-
-  stop-iteration-iterator@1.1.0:
-    dependencies:
-      es-errors: 1.3.0
-      internal-slot: 1.1.0
-
-  stream-browserify@3.0.0:
-    dependencies:
-      inherits: 2.0.4
-      readable-stream: 3.6.2
-
-  streamsearch@1.1.0: {}
-
-  string.prototype.trim@1.2.11:
-    dependencies:
-      call-bind: 1.0.9
-      call-bound: 1.0.4
-      define-data-property: 1.1.4
-      define-properties: 1.2.1
-      es-abstract: 1.24.2
-      es-object-atoms: 1.1.2
-      has-property-descriptors: 1.0.2
-      safe-regex-test: 1.1.0
-
-  string.prototype.trimend@1.0.10:
-    dependencies:
-      call-bind: 1.0.9
-      call-bound: 1.0.4
-      define-properties: 1.2.1
-      es-object-atoms: 1.1.2
-
-  string.prototype.trimstart@1.0.8:
-    dependencies:
-      call-bind: 1.0.9
-      define-properties: 1.2.1
-      es-object-atoms: 1.1.2
-
-  string_decoder@1.3.0:
-    dependencies:
-      safe-buffer: 5.2.1
-
-  strip-bom@3.0.0: {}
-
-  strip-json-comments@5.0.3: {}
-
-  strnum@2.3.0: {}
-
-  supports-preserve-symlinks-flag@1.0.0: {}
-
-  thread-stream@4.2.0:
-    dependencies:
-      real-require: 1.0.0
-
-  tinyglobby@0.2.17:
-    dependencies:
-      fdir: 6.5.0(picomatch@4.0.4)
-      picomatch: 4.0.4
-
-  toidentifier@1.0.1: {}
-
-  ts-api-utils@2.5.0(typescript@6.0.3):
-    dependencies:
-      typescript: 6.0.3
-
-  ts-mixer@6.0.4: {}
-
-  tsconfig-paths@3.15.0:
-    dependencies:
-      '@types/json5': 0.0.29
-      json5: 1.0.2
-      minimist: 1.2.8
-      strip-bom: 3.0.0
-
-  tslib@2.8.1: {}
-
-  type-check@0.4.0:
-    dependencies:
-      prelude-ls: 1.2.1
-
-  type-is@2.1.0:
-    dependencies:
-      content-type: 2.0.0
-      media-typer: 1.1.0
-      mime-types: 3.0.2
-
-  typed-array-buffer@1.0.3:
-    dependencies:
-      call-bound: 1.0.4
-      es-errors: 1.3.0
-      is-typed-array: 1.1.15
-
-  typed-array-byte-length@1.0.3:
-    dependencies:
-      call-bind: 1.0.9
-      for-each: 0.3.5
-      gopd: 1.2.0
-      has-proto: 1.2.0
-      is-typed-array: 1.1.15
-
-  typed-array-byte-offset@1.0.4:
-    dependencies:
-      available-typed-arrays: 1.0.7
-      call-bind: 1.0.9
-      for-each: 0.3.5
-      gopd: 1.2.0
-      has-proto: 1.2.0
-      is-typed-array: 1.1.15
-      reflect.getprototypeof: 1.0.10
-
-  typed-array-length@1.0.8:
-    dependencies:
-      call-bind: 1.0.9
-      for-each: 0.3.5
-      gopd: 1.2.0
-      is-typed-array: 1.1.15
-      possible-typed-array-names: 1.1.0
-      reflect.getprototypeof: 1.0.10
-
-  typescript-eslint@8.59.1(eslint@10.2.1(jiti@2.7.0))(typescript@6.0.3):
-    dependencies:
-      '@typescript-eslint/eslint-plugin': 8.59.1(@typescript-eslint/parser@8.59.1(eslint@10.2.1(jiti@2.7.0))(typescript@6.0.3))(eslint@10.2.1(jiti@2.7.0))(typescript@6.0.3)
-      '@typescript-eslint/parser': 8.59.1(eslint@10.2.1(jiti@2.7.0))(typescript@6.0.3)
-      '@typescript-eslint/typescript-estree': 8.59.1(typescript@6.0.3)
-      '@typescript-eslint/utils': 8.59.1(eslint@10.2.1(jiti@2.7.0))(typescript@6.0.3)
-      eslint: 10.2.1(jiti@2.7.0)
-      typescript: 6.0.3
-    transitivePeerDependencies:
-      - supports-color
-
-  typescript@6.0.3: {}
-
-  unbox-primitive@1.1.0:
-    dependencies:
-      call-bound: 1.0.4
-      has-bigints: 1.1.0
-      has-symbols: 1.1.0
-      which-boxed-primitive: 1.1.1
-
-  undici-types@7.19.2: {}
-
-  undici@6.24.1: {}
-
-  unpipe@1.0.0: {}
-
-  uri-js@4.4.1:
-    dependencies:
-      punycode: 2.3.1
-
-  util-deprecate@1.0.2: {}
-
-  valibot@1.2.0(typescript@6.0.3):
-    optionalDependencies:
-      typescript: 6.0.3
-
-  vary@1.1.2: {}
-
-  which-boxed-primitive@1.1.1:
-    dependencies:
-      is-bigint: 1.1.0
-      is-boolean-object: 1.2.2
-      is-number-object: 1.1.1
-      is-string: 1.1.1
-      is-symbol: 1.1.1
-
-  which-builtin-type@1.2.1:
-    dependencies:
-      call-bound: 1.0.4
-      function.prototype.name: 1.1.8
-      has-tostringtag: 1.0.2
-      is-async-function: 2.1.1
-      is-date-object: 1.1.0
-      is-finalizationregistry: 1.1.1
-      is-generator-function: 1.1.2
-      is-regex: 1.2.1
-      is-weakref: 1.1.1
-      isarray: 2.0.5
-      which-boxed-primitive: 1.1.1
-      which-collection: 1.0.2
-      which-typed-array: 1.1.22
-
-  which-collection@1.0.2:
-    dependencies:
-      is-map: 2.0.3
-      is-set: 2.0.3
-      is-weakmap: 2.0.2
-      is-weakset: 2.0.4
-
-  which-typed-array@1.1.22:
-    dependencies:
-      available-typed-arrays: 1.0.7
-      call-bind: 1.0.9
-      call-bound: 1.0.4
-      for-each: 0.3.5
-      get-proto: 1.0.1
-      gopd: 1.2.0
-      has-tostringtag: 1.0.2
-
-  which@2.0.2:
-    dependencies:
-      isexe: 2.0.0
-
-  word-wrap@1.2.5: {}
-
-  wrappy@1.0.2: {}
-
-  ws@8.21.0: {}
-
-  xml-naming@0.1.0: {}
-
-  xtend@4.0.2: {}
-
-  yocto-queue@0.1.0: {}
-
-  zeptomatch@2.1.0:
-    dependencies:
-      grammex: 3.1.12
-      graphmatch: 1.1.1
-
-  zod@4.3.6: {}
-
-  zod@4.4.1: {}
+    '@aws-crypto/crc32@5.2.0':
+        dependencies:
+            '@aws-crypto/util': 5.2.0
+            '@aws-sdk/types': 3.973.11
+            tslib: 2.8.1
+
+    '@aws-crypto/crc32c@5.2.0':
+        dependencies:
+            '@aws-crypto/util': 5.2.0
+            '@aws-sdk/types': 3.973.11
+            tslib: 2.8.1
+
+    '@aws-crypto/sha1-browser@5.2.0':
+        dependencies:
+            '@aws-crypto/supports-web-crypto': 5.2.0
+            '@aws-crypto/util': 5.2.0
+            '@aws-sdk/types': 3.973.11
+            '@aws-sdk/util-locate-window': 3.965.6
+            '@smithy/util-utf8': 2.3.0
+            tslib: 2.8.1
+
+    '@aws-crypto/sha256-browser@5.2.0':
+        dependencies:
+            '@aws-crypto/sha256-js': 5.2.0
+            '@aws-crypto/supports-web-crypto': 5.2.0
+            '@aws-crypto/util': 5.2.0
+            '@aws-sdk/types': 3.973.11
+            '@aws-sdk/util-locate-window': 3.965.6
+            '@smithy/util-utf8': 2.3.0
+            tslib: 2.8.1
+
+    '@aws-crypto/sha256-js@5.2.0':
+        dependencies:
+            '@aws-crypto/util': 5.2.0
+            '@aws-sdk/types': 3.973.11
+            tslib: 2.8.1
+
+    '@aws-crypto/supports-web-crypto@5.2.0':
+        dependencies:
+            tslib: 2.8.1
+
+    '@aws-crypto/util@5.2.0':
+        dependencies:
+            '@aws-sdk/types': 3.973.11
+            '@smithy/util-utf8': 2.3.0
+            tslib: 2.8.1
+
+    '@aws-sdk/checksums@3.1000.2':
+        dependencies:
+            '@aws-crypto/crc32': 5.2.0
+            '@aws-crypto/crc32c': 5.2.0
+            '@aws-crypto/util': 5.2.0
+            '@aws-sdk/core': 3.974.18
+            '@aws-sdk/types': 3.973.11
+            '@smithy/core': 3.24.6
+            '@smithy/types': 4.14.3
+            tslib: 2.8.1
+
+    '@aws-sdk/client-s3@3.1039.0':
+        dependencies:
+            '@aws-crypto/sha1-browser': 5.2.0
+            '@aws-crypto/sha256-browser': 5.2.0
+            '@aws-crypto/sha256-js': 5.2.0
+            '@aws-sdk/core': 3.974.18
+            '@aws-sdk/credential-provider-node': 3.972.52
+            '@aws-sdk/middleware-bucket-endpoint': 3.972.21
+            '@aws-sdk/middleware-expect-continue': 3.972.17
+            '@aws-sdk/middleware-flexible-checksums': 3.974.27
+            '@aws-sdk/middleware-host-header': 3.972.19
+            '@aws-sdk/middleware-location-constraint': 3.972.14
+            '@aws-sdk/middleware-logger': 3.972.18
+            '@aws-sdk/middleware-recursion-detection': 3.972.20
+            '@aws-sdk/middleware-sdk-s3': 3.972.48
+            '@aws-sdk/middleware-ssec': 3.972.14
+            '@aws-sdk/middleware-user-agent': 3.972.48
+            '@aws-sdk/region-config-resolver': 3.972.22
+            '@aws-sdk/signature-v4-multi-region': 3.996.32
+            '@aws-sdk/types': 3.973.11
+            '@aws-sdk/util-endpoints': 3.996.17
+            '@aws-sdk/util-user-agent-browser': 3.972.19
+            '@aws-sdk/util-user-agent-node': 3.973.34
+            '@smithy/config-resolver': 4.5.6
+            '@smithy/core': 3.24.6
+            '@smithy/eventstream-serde-browser': 4.3.6
+            '@smithy/eventstream-serde-config-resolver': 4.4.6
+            '@smithy/eventstream-serde-node': 4.3.6
+            '@smithy/fetch-http-handler': 5.4.6
+            '@smithy/hash-blob-browser': 4.3.6
+            '@smithy/hash-node': 4.3.6
+            '@smithy/hash-stream-node': 4.3.6
+            '@smithy/invalid-dependency': 4.3.6
+            '@smithy/md5-js': 4.3.6
+            '@smithy/middleware-content-length': 4.3.6
+            '@smithy/middleware-endpoint': 4.5.6
+            '@smithy/middleware-retry': 4.6.6
+            '@smithy/middleware-serde': 4.3.6
+            '@smithy/middleware-stack': 4.3.6
+            '@smithy/node-config-provider': 4.4.6
+            '@smithy/node-http-handler': 4.7.7
+            '@smithy/protocol-http': 5.4.6
+            '@smithy/smithy-client': 4.13.6
+            '@smithy/types': 4.14.3
+            '@smithy/url-parser': 4.3.6
+            '@smithy/util-base64': 4.4.6
+            '@smithy/util-body-length-browser': 4.3.6
+            '@smithy/util-body-length-node': 4.3.6
+            '@smithy/util-defaults-mode-browser': 4.4.6
+            '@smithy/util-defaults-mode-node': 4.3.6
+            '@smithy/util-endpoints': 3.5.6
+            '@smithy/util-middleware': 4.3.6
+            '@smithy/util-retry': 4.4.6
+            '@smithy/util-stream': 4.6.6
+            '@smithy/util-utf8': 4.3.6
+            '@smithy/util-waiter': 4.4.6
+            tslib: 2.8.1
+
+    '@aws-sdk/core@3.974.18':
+        dependencies:
+            '@aws-sdk/types': 3.973.11
+            '@aws-sdk/xml-builder': 3.972.28
+            '@aws/lambda-invoke-store': 0.2.4
+            '@smithy/core': 3.24.6
+            '@smithy/signature-v4': 5.4.6
+            '@smithy/types': 4.14.3
+            bowser: 2.14.1
+            tslib: 2.8.1
+
+    '@aws-sdk/credential-provider-env@3.972.44':
+        dependencies:
+            '@aws-sdk/core': 3.974.18
+            '@aws-sdk/types': 3.973.11
+            '@smithy/core': 3.24.6
+            '@smithy/types': 4.14.3
+            tslib: 2.8.1
+
+    '@aws-sdk/credential-provider-http@3.972.46':
+        dependencies:
+            '@aws-sdk/core': 3.974.18
+            '@aws-sdk/types': 3.973.11
+            '@smithy/core': 3.24.6
+            '@smithy/fetch-http-handler': 5.4.6
+            '@smithy/node-http-handler': 4.7.7
+            '@smithy/types': 4.14.3
+            tslib: 2.8.1
+
+    '@aws-sdk/credential-provider-ini@3.972.50':
+        dependencies:
+            '@aws-sdk/core': 3.974.18
+            '@aws-sdk/credential-provider-env': 3.972.44
+            '@aws-sdk/credential-provider-http': 3.972.46
+            '@aws-sdk/credential-provider-login': 3.972.49
+            '@aws-sdk/credential-provider-process': 3.972.44
+            '@aws-sdk/credential-provider-sso': 3.972.49
+            '@aws-sdk/credential-provider-web-identity': 3.972.49
+            '@aws-sdk/nested-clients': 3.997.17
+            '@aws-sdk/types': 3.973.11
+            '@smithy/core': 3.24.6
+            '@smithy/credential-provider-imds': 4.3.8
+            '@smithy/types': 4.14.3
+            tslib: 2.8.1
+
+    '@aws-sdk/credential-provider-login@3.972.49':
+        dependencies:
+            '@aws-sdk/core': 3.974.18
+            '@aws-sdk/nested-clients': 3.997.17
+            '@aws-sdk/types': 3.973.11
+            '@smithy/core': 3.24.6
+            '@smithy/types': 4.14.3
+            tslib: 2.8.1
+
+    '@aws-sdk/credential-provider-node@3.972.52':
+        dependencies:
+            '@aws-sdk/credential-provider-env': 3.972.44
+            '@aws-sdk/credential-provider-http': 3.972.46
+            '@aws-sdk/credential-provider-ini': 3.972.50
+            '@aws-sdk/credential-provider-process': 3.972.44
+            '@aws-sdk/credential-provider-sso': 3.972.49
+            '@aws-sdk/credential-provider-web-identity': 3.972.49
+            '@aws-sdk/types': 3.973.11
+            '@smithy/core': 3.24.6
+            '@smithy/credential-provider-imds': 4.3.8
+            '@smithy/types': 4.14.3
+            tslib: 2.8.1
+
+    '@aws-sdk/credential-provider-process@3.972.44':
+        dependencies:
+            '@aws-sdk/core': 3.974.18
+            '@aws-sdk/types': 3.973.11
+            '@smithy/core': 3.24.6
+            '@smithy/types': 4.14.3
+            tslib: 2.8.1
+
+    '@aws-sdk/credential-provider-sso@3.972.49':
+        dependencies:
+            '@aws-sdk/core': 3.974.18
+            '@aws-sdk/nested-clients': 3.997.17
+            '@aws-sdk/token-providers': 3.1063.0
+            '@aws-sdk/types': 3.973.11
+            '@smithy/core': 3.24.6
+            '@smithy/types': 4.14.3
+            tslib: 2.8.1
+
+    '@aws-sdk/credential-provider-web-identity@3.972.49':
+        dependencies:
+            '@aws-sdk/core': 3.974.18
+            '@aws-sdk/nested-clients': 3.997.17
+            '@aws-sdk/types': 3.973.11
+            '@smithy/core': 3.24.6
+            '@smithy/types': 4.14.3
+            tslib: 2.8.1
+
+    '@aws-sdk/lib-storage@3.1038.0(@aws-sdk/client-s3@3.1039.0)':
+        dependencies:
+            '@aws-sdk/client-s3': 3.1039.0
+            '@smithy/middleware-endpoint': 4.5.6
+            '@smithy/protocol-http': 5.4.6
+            '@smithy/smithy-client': 4.13.6
+            '@smithy/types': 4.14.3
+            buffer: 5.6.0
+            events: 3.3.0
+            stream-browserify: 3.0.0
+            tslib: 2.8.1
+
+    '@aws-sdk/middleware-bucket-endpoint@3.972.21':
+        dependencies:
+            '@aws-sdk/middleware-sdk-s3': 3.972.48
+            tslib: 2.8.1
+
+    '@aws-sdk/middleware-expect-continue@3.972.17':
+        dependencies:
+            '@aws-sdk/middleware-sdk-s3': 3.972.48
+            tslib: 2.8.1
+
+    '@aws-sdk/middleware-flexible-checksums@3.974.27':
+        dependencies:
+            '@aws-sdk/checksums': 3.1000.2
+            tslib: 2.8.1
+
+    '@aws-sdk/middleware-host-header@3.972.19':
+        dependencies:
+            '@aws-sdk/core': 3.974.18
+            tslib: 2.8.1
+
+    '@aws-sdk/middleware-location-constraint@3.972.14':
+        dependencies:
+            '@aws-sdk/middleware-sdk-s3': 3.972.48
+            tslib: 2.8.1
+
+    '@aws-sdk/middleware-logger@3.972.18':
+        dependencies:
+            '@aws-sdk/core': 3.974.18
+            tslib: 2.8.1
+
+    '@aws-sdk/middleware-recursion-detection@3.972.20':
+        dependencies:
+            '@aws-sdk/core': 3.974.18
+            tslib: 2.8.1
+
+    '@aws-sdk/middleware-sdk-s3@3.972.48':
+        dependencies:
+            '@aws-sdk/core': 3.974.18
+            '@aws-sdk/signature-v4-multi-region': 3.996.32
+            '@aws-sdk/types': 3.973.11
+            '@smithy/core': 3.24.6
+            '@smithy/types': 4.14.3
+            tslib: 2.8.1
+
+    '@aws-sdk/middleware-ssec@3.972.14':
+        dependencies:
+            '@aws-sdk/middleware-sdk-s3': 3.972.48
+            tslib: 2.8.1
+
+    '@aws-sdk/middleware-user-agent@3.972.48':
+        dependencies:
+            '@aws-sdk/core': 3.974.18
+            tslib: 2.8.1
+
+    '@aws-sdk/nested-clients@3.997.17':
+        dependencies:
+            '@aws-crypto/sha256-browser': 5.2.0
+            '@aws-crypto/sha256-js': 5.2.0
+            '@aws-sdk/core': 3.974.18
+            '@aws-sdk/signature-v4-multi-region': 3.996.32
+            '@aws-sdk/types': 3.973.11
+            '@smithy/core': 3.24.6
+            '@smithy/fetch-http-handler': 5.4.6
+            '@smithy/node-http-handler': 4.7.7
+            '@smithy/types': 4.14.3
+            tslib: 2.8.1
+
+    '@aws-sdk/region-config-resolver@3.972.22':
+        dependencies:
+            '@aws-sdk/core': 3.974.18
+            tslib: 2.8.1
+
+    '@aws-sdk/signature-v4-multi-region@3.996.32':
+        dependencies:
+            '@aws-sdk/types': 3.973.11
+            '@smithy/signature-v4': 5.4.6
+            '@smithy/types': 4.14.3
+            tslib: 2.8.1
+
+    '@aws-sdk/token-providers@3.1063.0':
+        dependencies:
+            '@aws-sdk/core': 3.974.18
+            '@aws-sdk/nested-clients': 3.997.17
+            '@aws-sdk/types': 3.973.11
+            '@smithy/core': 3.24.6
+            '@smithy/types': 4.14.3
+            tslib: 2.8.1
+
+    '@aws-sdk/types@3.973.11':
+        dependencies:
+            '@smithy/types': 4.14.3
+            tslib: 2.8.1
+
+    '@aws-sdk/util-endpoints@3.996.17':
+        dependencies:
+            '@aws-sdk/core': 3.974.18
+            '@smithy/core': 3.24.6
+            tslib: 2.8.1
+
+    '@aws-sdk/util-locate-window@3.965.6':
+        dependencies:
+            tslib: 2.8.1
+
+    '@aws-sdk/util-user-agent-browser@3.972.19':
+        dependencies:
+            '@aws-sdk/core': 3.974.18
+            tslib: 2.8.1
+
+    '@aws-sdk/util-user-agent-node@3.973.34':
+        dependencies:
+            '@aws-sdk/core': 3.974.18
+            tslib: 2.8.1
+
+    '@aws-sdk/xml-builder@3.972.28':
+        dependencies:
+            '@smithy/types': 4.14.3
+            fast-xml-parser: 5.7.3
+            tslib: 2.8.1
+
+    '@aws/lambda-invoke-store@0.2.4': {}
+
+    '@discordjs/builders@1.14.1':
+        dependencies:
+            '@discordjs/formatters': 0.6.2
+            '@discordjs/util': 1.2.0
+            '@sapphire/shapeshift': 4.0.0
+            discord-api-types: 0.38.48
+            fast-deep-equal: 3.1.3
+            ts-mixer: 6.0.4
+            tslib: 2.8.1
+
+    '@discordjs/collection@1.5.3': {}
+
+    '@discordjs/collection@2.1.1': {}
+
+    '@discordjs/formatters@0.6.2':
+        dependencies:
+            discord-api-types: 0.38.48
+
+    '@discordjs/rest@2.6.1':
+        dependencies:
+            '@discordjs/collection': 2.1.1
+            '@discordjs/util': 1.2.0
+            '@sapphire/async-queue': 1.5.5
+            '@sapphire/snowflake': 3.5.5
+            '@vladfrangu/async_event_emitter': 2.4.7
+            discord-api-types: 0.38.48
+            magic-bytes.js: 1.13.0
+            tslib: 2.8.1
+            undici: 6.24.1
+
+    '@discordjs/util@1.2.0':
+        dependencies:
+            discord-api-types: 0.38.48
+
+    '@discordjs/ws@1.2.3':
+        dependencies:
+            '@discordjs/collection': 2.1.1
+            '@discordjs/rest': 2.6.1
+            '@discordjs/util': 1.2.0
+            '@sapphire/async-queue': 1.5.5
+            '@types/ws': 8.18.1
+            '@vladfrangu/async_event_emitter': 2.4.7
+            discord-api-types: 0.38.48
+            tslib: 2.8.1
+            ws: 8.21.0
+        transitivePeerDependencies:
+            - bufferutil
+            - utf-8-validate
+
+    '@electric-sql/pglite-socket@0.1.1(@electric-sql/pglite@0.4.1)':
+        dependencies:
+            '@electric-sql/pglite': 0.4.1
+
+    '@electric-sql/pglite-tools@0.3.1(@electric-sql/pglite@0.4.1)':
+        dependencies:
+            '@electric-sql/pglite': 0.4.1
+
+    '@electric-sql/pglite@0.4.1': {}
+
+    '@eliyya/flagged-bitfield@1.1.1': {}
+
+    '@epic-web/invariant@1.0.0': {}
+
+    '@eslint-community/eslint-utils@4.9.1(eslint@10.2.1(jiti@2.7.0))':
+        dependencies:
+            eslint: 10.2.1(jiti@2.7.0)
+            eslint-visitor-keys: 3.4.3
+
+    '@eslint-community/regexpp@4.12.2': {}
+
+    '@eslint/config-array@0.23.5':
+        dependencies:
+            '@eslint/object-schema': 3.0.5
+            debug: 4.4.3
+            minimatch: 10.2.5
+        transitivePeerDependencies:
+            - supports-color
+
+    '@eslint/config-helpers@0.5.5':
+        dependencies:
+            '@eslint/core': 1.2.1
+
+    '@eslint/core@1.2.1':
+        dependencies:
+            '@types/json-schema': 7.0.15
+
+    '@eslint/js@10.0.1(eslint@10.2.1(jiti@2.7.0))':
+        optionalDependencies:
+            eslint: 10.2.1(jiti@2.7.0)
+
+    '@eslint/json@1.2.0':
+        dependencies:
+            '@eslint/core': 1.2.1
+            '@eslint/plugin-kit': 0.6.1
+            '@humanwhocodes/momoa': 3.3.10
+            natural-compare: 1.4.0
+
+    '@eslint/object-schema@3.0.5': {}
+
+    '@eslint/plugin-kit@0.6.1':
+        dependencies:
+            '@eslint/core': 1.2.1
+            levn: 0.4.1
+
+    '@eslint/plugin-kit@0.7.2':
+        dependencies:
+            '@eslint/core': 1.2.1
+            levn: 0.4.1
+
+    '@hono/node-server@1.19.11(hono@4.12.23)':
+        dependencies:
+            hono: 4.12.23
+
+    '@humanfs/core@0.19.2':
+        dependencies:
+            '@humanfs/types': 0.15.0
+
+    '@humanfs/node@0.16.8':
+        dependencies:
+            '@humanfs/core': 0.19.2
+            '@humanfs/types': 0.15.0
+            '@humanwhocodes/retry': 0.4.3
+
+    '@humanfs/types@0.15.0': {}
+
+    '@humanwhocodes/module-importer@1.0.1': {}
+
+    '@humanwhocodes/momoa@3.3.10': {}
+
+    '@humanwhocodes/retry@0.4.3': {}
+
+    '@js-temporal/polyfill@0.5.1':
+        dependencies:
+            jsbi: 4.3.2
+
+    '@kurkle/color@0.3.4': {}
+
+    '@nodable/entities@2.1.1': {}
+
+    '@phc/format@1.0.0': {}
+
+    '@pinojs/redact@0.4.0': {}
+
+    '@prisma/adapter-pg@7.8.0':
+        dependencies:
+            '@prisma/driver-adapter-utils': 7.8.0
+            '@types/pg': 8.20.0
+            pg: 8.20.0
+            postgres-array: 3.0.4
+        transitivePeerDependencies:
+            - pg-native
+
+    '@prisma/client-runtime-utils@7.8.0': {}
+
+    '@prisma/client@7.8.0(prisma@7.8.0(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3))(typescript@6.0.3)':
+        dependencies:
+            '@prisma/client-runtime-utils': 7.8.0
+        optionalDependencies:
+            prisma: 7.8.0(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)
+            typescript: 6.0.3
+
+    '@prisma/config@7.8.0':
+        dependencies:
+            c12: 3.3.4
+            deepmerge-ts: 7.1.5
+            effect: 3.20.0
+            empathic: 2.0.0
+        transitivePeerDependencies:
+            - magicast
+
+    '@prisma/debug@7.2.0': {}
+
+    '@prisma/debug@7.8.0': {}
+
+    '@prisma/dev@0.24.3(typescript@6.0.3)':
+        dependencies:
+            '@electric-sql/pglite': 0.4.1
+            '@electric-sql/pglite-socket': 0.1.1(@electric-sql/pglite@0.4.1)
+            '@electric-sql/pglite-tools': 0.3.1(@electric-sql/pglite@0.4.1)
+            '@hono/node-server': 1.19.11(hono@4.12.23)
+            '@prisma/get-platform': 7.2.0
+            '@prisma/query-plan-executor': 7.2.0
+            '@prisma/streams-local': 0.1.2
+            foreground-child: 3.3.1
+            get-port-please: 3.2.0
+            hono: 4.12.23
+            http-status-codes: 2.3.0
+            pathe: 2.0.3
+            proper-lockfile: 4.1.2
+            remeda: 2.33.4
+            std-env: 3.10.0
+            valibot: 1.2.0(typescript@6.0.3)
+            zeptomatch: 2.1.0
+        transitivePeerDependencies:
+            - typescript
+
+    '@prisma/driver-adapter-utils@7.8.0':
+        dependencies:
+            '@prisma/debug': 7.8.0
+
+    '@prisma/engines-version@7.8.0-6.3c6e192761c0362d496ed980de936e2f3cebcd3a':
+        {}
+
+    '@prisma/engines@7.8.0':
+        dependencies:
+            '@prisma/debug': 7.8.0
+            '@prisma/engines-version': 7.8.0-6.3c6e192761c0362d496ed980de936e2f3cebcd3a
+            '@prisma/fetch-engine': 7.8.0
+            '@prisma/get-platform': 7.8.0
+
+    '@prisma/fetch-engine@7.8.0':
+        dependencies:
+            '@prisma/debug': 7.8.0
+            '@prisma/engines-version': 7.8.0-6.3c6e192761c0362d496ed980de936e2f3cebcd3a
+            '@prisma/get-platform': 7.8.0
+
+    '@prisma/get-platform@7.2.0':
+        dependencies:
+            '@prisma/debug': 7.2.0
+
+    '@prisma/get-platform@7.8.0':
+        dependencies:
+            '@prisma/debug': 7.8.0
+
+    '@prisma/query-plan-executor@7.2.0': {}
+
+    '@prisma/streams-local@0.1.2':
+        dependencies:
+            ajv: 8.20.0
+            better-result: 2.9.2
+            env-paths: 3.0.0
+            proper-lockfile: 4.1.2
+
+    '@prisma/studio-core@0.27.3(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+        dependencies:
+            '@radix-ui/react-toggle': 1.1.10(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+            '@types/react': 19.2.17
+            chart.js: 4.5.1
+            react: 19.2.7
+            react-dom: 19.2.7(react@19.2.7)
+        transitivePeerDependencies:
+            - '@types/react-dom'
+
+    '@radix-ui/primitive@1.1.3': {}
+
+    '@radix-ui/react-compose-refs@1.1.2(@types/react@19.2.17)(react@19.2.7)':
+        dependencies:
+            react: 19.2.7
+        optionalDependencies:
+            '@types/react': 19.2.17
+
+    '@radix-ui/react-primitive@2.1.3(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+        dependencies:
+            '@radix-ui/react-slot': 1.2.3(@types/react@19.2.17)(react@19.2.7)
+            react: 19.2.7
+            react-dom: 19.2.7(react@19.2.7)
+        optionalDependencies:
+            '@types/react': 19.2.17
+
+    '@radix-ui/react-slot@1.2.3(@types/react@19.2.17)(react@19.2.7)':
+        dependencies:
+            '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+            react: 19.2.7
+        optionalDependencies:
+            '@types/react': 19.2.17
+
+    '@radix-ui/react-toggle@1.1.10(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+        dependencies:
+            '@radix-ui/primitive': 1.1.3
+            '@radix-ui/react-primitive': 2.1.3(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+            '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.17)(react@19.2.7)
+            react: 19.2.7
+            react-dom: 19.2.7(react@19.2.7)
+        optionalDependencies:
+            '@types/react': 19.2.17
+
+    '@radix-ui/react-use-controllable-state@1.2.2(@types/react@19.2.17)(react@19.2.7)':
+        dependencies:
+            '@radix-ui/react-use-effect-event': 0.0.2(@types/react@19.2.17)(react@19.2.7)
+            '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.17)(react@19.2.7)
+            react: 19.2.7
+        optionalDependencies:
+            '@types/react': 19.2.17
+
+    '@radix-ui/react-use-effect-event@0.0.2(@types/react@19.2.17)(react@19.2.7)':
+        dependencies:
+            '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.17)(react@19.2.7)
+            react: 19.2.7
+        optionalDependencies:
+            '@types/react': 19.2.17
+
+    '@radix-ui/react-use-layout-effect@1.1.1(@types/react@19.2.17)(react@19.2.7)':
+        dependencies:
+            react: 19.2.7
+        optionalDependencies:
+            '@types/react': 19.2.17
+
+    '@rollup/rollup-linux-x64-gnu@4.61.1':
+        optional: true
+
+    '@rtsao/scc@1.1.0': {}
+
+    '@sapphire/async-queue@1.5.5': {}
+
+    '@sapphire/shapeshift@4.0.0':
+        dependencies:
+            fast-deep-equal: 3.1.3
+            lodash: 4.18.1
+
+    '@sapphire/snowflake@3.5.3': {}
+
+    '@sapphire/snowflake@3.5.5': {}
+
+    '@smithy/config-resolver@4.5.6':
+        dependencies:
+            '@smithy/core': 3.24.6
+            tslib: 2.8.1
+
+    '@smithy/core@3.24.6':
+        dependencies:
+            '@aws-crypto/crc32': 5.2.0
+            '@smithy/types': 4.14.3
+            tslib: 2.8.1
+
+    '@smithy/credential-provider-imds@4.3.8':
+        dependencies:
+            '@smithy/core': 3.24.6
+            '@smithy/types': 4.14.3
+            tslib: 2.8.1
+
+    '@smithy/eventstream-serde-browser@4.3.6':
+        dependencies:
+            '@smithy/core': 3.24.6
+            tslib: 2.8.1
+
+    '@smithy/eventstream-serde-config-resolver@4.4.6':
+        dependencies:
+            '@smithy/core': 3.24.6
+            tslib: 2.8.1
+
+    '@smithy/eventstream-serde-node@4.3.6':
+        dependencies:
+            '@smithy/core': 3.24.6
+            tslib: 2.8.1
+
+    '@smithy/fetch-http-handler@5.4.6':
+        dependencies:
+            '@smithy/core': 3.24.6
+            '@smithy/types': 4.14.3
+            tslib: 2.8.1
+
+    '@smithy/hash-blob-browser@4.3.6':
+        dependencies:
+            '@smithy/core': 3.24.6
+            tslib: 2.8.1
+
+    '@smithy/hash-node@4.3.6':
+        dependencies:
+            '@smithy/core': 3.24.6
+            tslib: 2.8.1
+
+    '@smithy/hash-stream-node@4.3.6':
+        dependencies:
+            '@smithy/core': 3.24.6
+            tslib: 2.8.1
+
+    '@smithy/invalid-dependency@4.3.6':
+        dependencies:
+            '@smithy/core': 3.24.6
+            tslib: 2.8.1
+
+    '@smithy/is-array-buffer@2.2.0':
+        dependencies:
+            tslib: 2.8.1
+
+    '@smithy/md5-js@4.3.6':
+        dependencies:
+            '@smithy/core': 3.24.6
+            tslib: 2.8.1
+
+    '@smithy/middleware-content-length@4.3.6':
+        dependencies:
+            '@smithy/core': 3.24.6
+            tslib: 2.8.1
+
+    '@smithy/middleware-endpoint@4.5.6':
+        dependencies:
+            '@smithy/core': 3.24.6
+            tslib: 2.8.1
+
+    '@smithy/middleware-retry@4.6.6':
+        dependencies:
+            '@smithy/core': 3.24.6
+            tslib: 2.8.1
+
+    '@smithy/middleware-serde@4.3.6':
+        dependencies:
+            '@smithy/core': 3.24.6
+            tslib: 2.8.1
+
+    '@smithy/middleware-stack@4.3.6':
+        dependencies:
+            '@smithy/core': 3.24.6
+            tslib: 2.8.1
+
+    '@smithy/node-config-provider@4.4.6':
+        dependencies:
+            '@smithy/core': 3.24.6
+            tslib: 2.8.1
+
+    '@smithy/node-http-handler@4.7.7':
+        dependencies:
+            '@smithy/core': 3.24.6
+            '@smithy/types': 4.14.3
+            tslib: 2.8.1
+
+    '@smithy/protocol-http@5.4.6':
+        dependencies:
+            '@smithy/core': 3.24.6
+            tslib: 2.8.1
+
+    '@smithy/signature-v4@5.4.6':
+        dependencies:
+            '@smithy/core': 3.24.6
+            '@smithy/types': 4.14.3
+            tslib: 2.8.1
+
+    '@smithy/smithy-client@4.13.6':
+        dependencies:
+            '@smithy/core': 3.24.6
+            '@smithy/types': 4.14.3
+            tslib: 2.8.1
+
+    '@smithy/types@4.14.3':
+        dependencies:
+            tslib: 2.8.1
+
+    '@smithy/url-parser@4.3.6':
+        dependencies:
+            '@smithy/core': 3.24.6
+            tslib: 2.8.1
+
+    '@smithy/util-base64@4.4.6':
+        dependencies:
+            '@smithy/core': 3.24.6
+            tslib: 2.8.1
+
+    '@smithy/util-body-length-browser@4.3.6':
+        dependencies:
+            '@smithy/core': 3.24.6
+            tslib: 2.8.1
+
+    '@smithy/util-body-length-node@4.3.6':
+        dependencies:
+            '@smithy/core': 3.24.6
+            tslib: 2.8.1
+
+    '@smithy/util-buffer-from@2.2.0':
+        dependencies:
+            '@smithy/is-array-buffer': 2.2.0
+            tslib: 2.8.1
+
+    '@smithy/util-defaults-mode-browser@4.4.6':
+        dependencies:
+            '@smithy/core': 3.24.6
+            tslib: 2.8.1
+
+    '@smithy/util-defaults-mode-node@4.3.6':
+        dependencies:
+            '@smithy/core': 3.24.6
+            tslib: 2.8.1
+
+    '@smithy/util-endpoints@3.5.6':
+        dependencies:
+            '@smithy/core': 3.24.6
+            tslib: 2.8.1
+
+    '@smithy/util-middleware@4.3.6':
+        dependencies:
+            '@smithy/core': 3.24.6
+            tslib: 2.8.1
+
+    '@smithy/util-retry@4.4.6':
+        dependencies:
+            '@smithy/core': 3.24.6
+            tslib: 2.8.1
+
+    '@smithy/util-stream@4.6.6':
+        dependencies:
+            '@smithy/core': 3.24.6
+            tslib: 2.8.1
+
+    '@smithy/util-utf8@2.3.0':
+        dependencies:
+            '@smithy/util-buffer-from': 2.2.0
+            tslib: 2.8.1
+
+    '@smithy/util-utf8@4.3.6':
+        dependencies:
+            '@smithy/core': 3.24.6
+            tslib: 2.8.1
+
+    '@smithy/util-waiter@4.4.6':
+        dependencies:
+            '@smithy/core': 3.24.6
+            tslib: 2.8.1
+
+    '@standard-schema/spec@1.1.0': {}
+
+    '@triskcraft/api-types@1.2.1':
+        dependencies:
+            zod: 4.4.1
+
+    '@types/body-parser@1.19.6':
+        dependencies:
+            '@types/connect': 3.4.38
+            '@types/node': 25.6.0
+
+    '@types/busboy@1.5.4':
+        dependencies:
+            '@types/node': 25.6.0
+
+    '@types/connect@3.4.38':
+        dependencies:
+            '@types/node': 25.6.0
+
+    '@types/cookie-parser@1.4.10(@types/express@5.0.6)':
+        dependencies:
+            '@types/express': 5.0.6
+
+    '@types/cors@2.8.19':
+        dependencies:
+            '@types/node': 25.6.0
+
+    '@types/esrecurse@4.3.1': {}
+
+    '@types/estree@1.0.9': {}
+
+    '@types/express-serve-static-core@5.1.1':
+        dependencies:
+            '@types/node': 25.6.0
+            '@types/qs': 6.15.1
+            '@types/range-parser': 1.2.7
+            '@types/send': 1.2.1
+
+    '@types/express@5.0.6':
+        dependencies:
+            '@types/body-parser': 1.19.6
+            '@types/express-serve-static-core': 5.1.1
+            '@types/serve-static': 2.2.0
+
+    '@types/http-errors@2.0.5': {}
+
+    '@types/json-schema@7.0.15': {}
+
+    '@types/json5@0.0.29': {}
+
+    '@types/luxon@3.7.1': {}
+
+    '@types/multer@2.1.0':
+        dependencies:
+            '@types/express': 5.0.6
+
+    '@types/node@25.6.0':
+        dependencies:
+            undici-types: 7.19.2
+
+    '@types/pg@8.20.0':
+        dependencies:
+            '@types/node': 25.6.0
+            pg-protocol: 1.14.0
+            pg-types: 2.2.0
+
+    '@types/qs@6.15.1': {}
+
+    '@types/range-parser@1.2.7': {}
+
+    '@types/react@19.2.17':
+        dependencies:
+            csstype: 3.2.3
+
+    '@types/send@1.2.1':
+        dependencies:
+            '@types/node': 25.6.0
+
+    '@types/serve-static@2.2.0':
+        dependencies:
+            '@types/http-errors': 2.0.5
+            '@types/node': 25.6.0
+
+    '@types/ws@8.18.1':
+        dependencies:
+            '@types/node': 25.6.0
+
+    '@typescript-eslint/eslint-plugin@8.59.1(@typescript-eslint/parser@8.59.1(eslint@10.2.1(jiti@2.7.0))(typescript@6.0.3))(eslint@10.2.1(jiti@2.7.0))(typescript@6.0.3)':
+        dependencies:
+            '@eslint-community/regexpp': 4.12.2
+            '@typescript-eslint/parser': 8.59.1(eslint@10.2.1(jiti@2.7.0))(typescript@6.0.3)
+            '@typescript-eslint/scope-manager': 8.59.1
+            '@typescript-eslint/type-utils': 8.59.1(eslint@10.2.1(jiti@2.7.0))(typescript@6.0.3)
+            '@typescript-eslint/utils': 8.59.1(eslint@10.2.1(jiti@2.7.0))(typescript@6.0.3)
+            '@typescript-eslint/visitor-keys': 8.59.1
+            eslint: 10.2.1(jiti@2.7.0)
+            ignore: 7.0.5
+            natural-compare: 1.4.0
+            ts-api-utils: 2.5.0(typescript@6.0.3)
+            typescript: 6.0.3
+        transitivePeerDependencies:
+            - supports-color
+
+    '@typescript-eslint/parser@8.59.1(eslint@10.2.1(jiti@2.7.0))(typescript@6.0.3)':
+        dependencies:
+            '@typescript-eslint/scope-manager': 8.59.1
+            '@typescript-eslint/types': 8.59.1
+            '@typescript-eslint/typescript-estree': 8.59.1(typescript@6.0.3)
+            '@typescript-eslint/visitor-keys': 8.59.1
+            debug: 4.4.3
+            eslint: 10.2.1(jiti@2.7.0)
+            typescript: 6.0.3
+        transitivePeerDependencies:
+            - supports-color
+
+    '@typescript-eslint/project-service@8.59.1(typescript@6.0.3)':
+        dependencies:
+            '@typescript-eslint/tsconfig-utils': 8.59.1(typescript@6.0.3)
+            '@typescript-eslint/types': 8.59.1
+            debug: 4.4.3
+            typescript: 6.0.3
+        transitivePeerDependencies:
+            - supports-color
+
+    '@typescript-eslint/scope-manager@8.59.1':
+        dependencies:
+            '@typescript-eslint/types': 8.59.1
+            '@typescript-eslint/visitor-keys': 8.59.1
+
+    '@typescript-eslint/tsconfig-utils@8.59.1(typescript@6.0.3)':
+        dependencies:
+            typescript: 6.0.3
+
+    '@typescript-eslint/type-utils@8.59.1(eslint@10.2.1(jiti@2.7.0))(typescript@6.0.3)':
+        dependencies:
+            '@typescript-eslint/types': 8.59.1
+            '@typescript-eslint/typescript-estree': 8.59.1(typescript@6.0.3)
+            '@typescript-eslint/utils': 8.59.1(eslint@10.2.1(jiti@2.7.0))(typescript@6.0.3)
+            debug: 4.4.3
+            eslint: 10.2.1(jiti@2.7.0)
+            ts-api-utils: 2.5.0(typescript@6.0.3)
+            typescript: 6.0.3
+        transitivePeerDependencies:
+            - supports-color
+
+    '@typescript-eslint/types@8.59.1': {}
+
+    '@typescript-eslint/typescript-estree@8.59.1(typescript@6.0.3)':
+        dependencies:
+            '@typescript-eslint/project-service': 8.59.1(typescript@6.0.3)
+            '@typescript-eslint/tsconfig-utils': 8.59.1(typescript@6.0.3)
+            '@typescript-eslint/types': 8.59.1
+            '@typescript-eslint/visitor-keys': 8.59.1
+            debug: 4.4.3
+            minimatch: 10.2.5
+            semver: 7.8.2
+            tinyglobby: 0.2.17
+            ts-api-utils: 2.5.0(typescript@6.0.3)
+            typescript: 6.0.3
+        transitivePeerDependencies:
+            - supports-color
+
+    '@typescript-eslint/utils@8.59.1(eslint@10.2.1(jiti@2.7.0))(typescript@6.0.3)':
+        dependencies:
+            '@eslint-community/eslint-utils': 4.9.1(eslint@10.2.1(jiti@2.7.0))
+            '@typescript-eslint/scope-manager': 8.59.1
+            '@typescript-eslint/types': 8.59.1
+            '@typescript-eslint/typescript-estree': 8.59.1(typescript@6.0.3)
+            eslint: 10.2.1(jiti@2.7.0)
+            typescript: 6.0.3
+        transitivePeerDependencies:
+            - supports-color
+
+    '@typescript-eslint/visitor-keys@8.59.1':
+        dependencies:
+            '@typescript-eslint/types': 8.59.1
+            eslint-visitor-keys: 5.0.1
+
+    '@vladfrangu/async_event_emitter@2.4.7': {}
+
+    accepts@2.0.0:
+        dependencies:
+            mime-types: 3.0.2
+            negotiator: 1.0.0
+
+    acorn-jsx@5.3.2(acorn@8.16.0):
+        dependencies:
+            acorn: 8.16.0
+
+    acorn@8.16.0: {}
+
+    ajv@6.15.0:
+        dependencies:
+            fast-deep-equal: 3.1.3
+            fast-json-stable-stringify: 2.1.0
+            json-schema-traverse: 0.4.1
+            uri-js: 4.4.1
+
+    ajv@8.20.0:
+        dependencies:
+            fast-deep-equal: 3.1.3
+            fast-uri: 3.1.2
+            json-schema-traverse: 1.0.0
+            require-from-string: 2.0.2
+
+    argon2@0.44.0:
+        dependencies:
+            '@phc/format': 1.0.0
+            cross-env: 10.1.0
+            node-addon-api: 8.8.0
+            node-gyp-build: 4.8.4
+
+    array-buffer-byte-length@1.0.2:
+        dependencies:
+            call-bound: 1.0.4
+            is-array-buffer: 3.0.5
+
+    array-includes@3.1.9:
+        dependencies:
+            call-bind: 1.0.9
+            call-bound: 1.0.4
+            define-properties: 1.2.1
+            es-abstract: 1.24.2
+            es-object-atoms: 1.1.2
+            get-intrinsic: 1.3.0
+            is-string: 1.1.1
+            math-intrinsics: 1.1.0
+
+    array.prototype.findlastindex@1.2.6:
+        dependencies:
+            call-bind: 1.0.9
+            call-bound: 1.0.4
+            define-properties: 1.2.1
+            es-abstract: 1.24.2
+            es-errors: 1.3.0
+            es-object-atoms: 1.1.2
+            es-shim-unscopables: 1.1.0
+
+    array.prototype.flat@1.3.3:
+        dependencies:
+            call-bind: 1.0.9
+            define-properties: 1.2.1
+            es-abstract: 1.24.2
+            es-shim-unscopables: 1.1.0
+
+    array.prototype.flatmap@1.3.3:
+        dependencies:
+            call-bind: 1.0.9
+            define-properties: 1.2.1
+            es-abstract: 1.24.2
+            es-shim-unscopables: 1.1.0
+
+    arraybuffer.prototype.slice@1.0.4:
+        dependencies:
+            array-buffer-byte-length: 1.0.2
+            call-bind: 1.0.9
+            define-properties: 1.2.1
+            es-abstract: 1.24.2
+            es-errors: 1.3.0
+            get-intrinsic: 1.3.0
+            is-array-buffer: 3.0.5
+
+    async-function@1.0.0: {}
+
+    atomic-sleep@1.0.0: {}
+
+    available-typed-arrays@1.0.7:
+        dependencies:
+            possible-typed-array-names: 1.1.0
+
+    aws-ssl-profiles@1.1.2: {}
+
+    balanced-match@1.0.2: {}
+
+    balanced-match@4.0.4: {}
+
+    base64-js@1.5.1: {}
+
+    better-result@2.9.2: {}
+
+    body-parser@2.2.2:
+        dependencies:
+            bytes: 3.1.2
+            content-type: 1.0.5
+            debug: 4.4.3
+            http-errors: 2.0.1
+            iconv-lite: 0.7.2
+            on-finished: 2.4.1
+            qs: 6.15.2
+            raw-body: 3.0.2
+            type-is: 2.1.0
+        transitivePeerDependencies:
+            - supports-color
+
+    bowser@2.14.1: {}
+
+    brace-expansion@1.1.15:
+        dependencies:
+            balanced-match: 1.0.2
+            concat-map: 0.0.1
+
+    brace-expansion@5.0.6:
+        dependencies:
+            balanced-match: 4.0.4
+
+    buffer@5.6.0:
+        dependencies:
+            base64-js: 1.5.1
+            ieee754: 1.2.1
+
+    busboy@1.6.0:
+        dependencies:
+            streamsearch: 1.1.0
+
+    bytes@3.1.2: {}
+
+    c12@3.3.4:
+        dependencies:
+            chokidar: 5.0.0
+            confbox: 0.2.4
+            defu: 6.1.7
+            dotenv: 17.4.2
+            exsolve: 1.0.8
+            giget: 3.2.0
+            jiti: 2.7.0
+            ohash: 2.0.11
+            pathe: 2.0.3
+            perfect-debounce: 2.1.0
+            pkg-types: 2.3.1
+            rc9: 3.0.1
+
+    call-bind-apply-helpers@1.0.2:
+        dependencies:
+            es-errors: 1.3.0
+            function-bind: 1.1.2
+
+    call-bind@1.0.9:
+        dependencies:
+            call-bind-apply-helpers: 1.0.2
+            es-define-property: 1.0.1
+            get-intrinsic: 1.3.0
+            set-function-length: 1.2.2
+
+    call-bound@1.0.4:
+        dependencies:
+            call-bind-apply-helpers: 1.0.2
+            get-intrinsic: 1.3.0
+
+    chart.js@4.5.1:
+        dependencies:
+            '@kurkle/color': 0.3.4
+
+    chokidar@5.0.0:
+        dependencies:
+            readdirp: 5.0.0
+
+    colorette@2.0.20: {}
+
+    concat-map@0.0.1: {}
+
+    confbox@0.2.4: {}
+
+    content-disposition@1.1.0: {}
+
+    content-type@1.0.5: {}
+
+    content-type@2.0.0: {}
+
+    cookie-parser@1.4.7:
+        dependencies:
+            cookie: 0.7.2
+            cookie-signature: 1.0.6
+
+    cookie-signature@1.0.6: {}
+
+    cookie-signature@1.2.2: {}
+
+    cookie@0.7.2: {}
+
+    cors@2.8.6:
+        dependencies:
+            object-assign: 4.1.1
+            vary: 1.1.2
+
+    cross-env@10.1.0:
+        dependencies:
+            '@epic-web/invariant': 1.0.0
+            cross-spawn: 7.0.6
+
+    cross-spawn@7.0.6:
+        dependencies:
+            path-key: 3.1.1
+            shebang-command: 2.0.0
+            which: 2.0.2
+
+    csstype@3.2.3: {}
+
+    data-view-buffer@1.0.2:
+        dependencies:
+            call-bound: 1.0.4
+            es-errors: 1.3.0
+            is-data-view: 1.0.2
+
+    data-view-byte-length@1.0.2:
+        dependencies:
+            call-bound: 1.0.4
+            es-errors: 1.3.0
+            is-data-view: 1.0.2
+
+    data-view-byte-offset@1.0.1:
+        dependencies:
+            call-bound: 1.0.4
+            es-errors: 1.3.0
+            is-data-view: 1.0.2
+
+    dateformat@4.6.3: {}
+
+    debug@3.2.7:
+        dependencies:
+            ms: 2.1.3
+
+    debug@4.4.3:
+        dependencies:
+            ms: 2.1.3
+
+    deep-is@0.1.4: {}
+
+    deepmerge-ts@7.1.5: {}
+
+    define-data-property@1.1.4:
+        dependencies:
+            es-define-property: 1.0.1
+            es-errors: 1.3.0
+            gopd: 1.2.0
+
+    define-properties@1.2.1:
+        dependencies:
+            define-data-property: 1.1.4
+            has-property-descriptors: 1.0.2
+            object-keys: 1.1.1
+
+    defu@6.1.7: {}
+
+    denque@2.1.0: {}
+
+    depd@2.0.0: {}
+
+    destr@2.0.5: {}
+
+    discord-api-types@0.38.48: {}
+
+    discord.js@14.26.3:
+        dependencies:
+            '@discordjs/builders': 1.14.1
+            '@discordjs/collection': 1.5.3
+            '@discordjs/formatters': 0.6.2
+            '@discordjs/rest': 2.6.1
+            '@discordjs/util': 1.2.0
+            '@discordjs/ws': 1.2.3
+            '@sapphire/snowflake': 3.5.3
+            discord-api-types: 0.38.48
+            fast-deep-equal: 3.1.3
+            lodash.snakecase: 4.1.1
+            magic-bytes.js: 1.13.0
+            tslib: 2.8.1
+            undici: 6.24.1
+        transitivePeerDependencies:
+            - bufferutil
+            - utf-8-validate
+
+    doctrine@2.1.0:
+        dependencies:
+            esutils: 2.0.3
+
+    dotenv@17.4.2: {}
+
+    dunder-proto@1.0.1:
+        dependencies:
+            call-bind-apply-helpers: 1.0.2
+            es-errors: 1.3.0
+            gopd: 1.2.0
+
+    ee-first@1.1.1: {}
+
+    effect@3.20.0:
+        dependencies:
+            '@standard-schema/spec': 1.1.0
+            fast-check: 3.23.2
+
+    empathic@2.0.0: {}
+
+    encodeurl@2.0.0: {}
+
+    end-of-stream@1.4.5:
+        dependencies:
+            once: 1.4.0
+
+    env-paths@3.0.0: {}
+
+    es-abstract@1.24.2:
+        dependencies:
+            array-buffer-byte-length: 1.0.2
+            arraybuffer.prototype.slice: 1.0.4
+            available-typed-arrays: 1.0.7
+            call-bind: 1.0.9
+            call-bound: 1.0.4
+            data-view-buffer: 1.0.2
+            data-view-byte-length: 1.0.2
+            data-view-byte-offset: 1.0.1
+            es-define-property: 1.0.1
+            es-errors: 1.3.0
+            es-object-atoms: 1.1.2
+            es-set-tostringtag: 2.1.0
+            es-to-primitive: 1.3.0
+            function.prototype.name: 1.1.8
+            get-intrinsic: 1.3.0
+            get-proto: 1.0.1
+            get-symbol-description: 1.1.0
+            globalthis: 1.0.4
+            gopd: 1.2.0
+            has-property-descriptors: 1.0.2
+            has-proto: 1.2.0
+            has-symbols: 1.1.0
+            hasown: 2.0.4
+            internal-slot: 1.1.0
+            is-array-buffer: 3.0.5
+            is-callable: 1.2.7
+            is-data-view: 1.0.2
+            is-negative-zero: 2.0.3
+            is-regex: 1.2.1
+            is-set: 2.0.3
+            is-shared-array-buffer: 1.0.4
+            is-string: 1.1.1
+            is-typed-array: 1.1.15
+            is-weakref: 1.1.1
+            math-intrinsics: 1.1.0
+            object-inspect: 1.13.4
+            object-keys: 1.1.1
+            object.assign: 4.1.7
+            own-keys: 1.0.1
+            regexp.prototype.flags: 1.5.4
+            safe-array-concat: 1.1.4
+            safe-push-apply: 1.0.0
+            safe-regex-test: 1.1.0
+            set-proto: 1.0.0
+            stop-iteration-iterator: 1.1.0
+            string.prototype.trim: 1.2.11
+            string.prototype.trimend: 1.0.10
+            string.prototype.trimstart: 1.0.8
+            typed-array-buffer: 1.0.3
+            typed-array-byte-length: 1.0.3
+            typed-array-byte-offset: 1.0.4
+            typed-array-length: 1.0.8
+            unbox-primitive: 1.1.0
+            which-typed-array: 1.1.22
+
+    es-define-property@1.0.1: {}
+
+    es-errors@1.3.0: {}
+
+    es-object-atoms@1.1.2:
+        dependencies:
+            es-errors: 1.3.0
+
+    es-set-tostringtag@2.1.0:
+        dependencies:
+            es-errors: 1.3.0
+            get-intrinsic: 1.3.0
+            has-tostringtag: 1.0.2
+            hasown: 2.0.4
+
+    es-shim-unscopables@1.1.0:
+        dependencies:
+            hasown: 2.0.4
+
+    es-to-primitive@1.3.0:
+        dependencies:
+            is-callable: 1.2.7
+            is-date-object: 1.1.0
+            is-symbol: 1.1.1
+
+    escape-html@1.0.3: {}
+
+    escape-string-regexp@4.0.0: {}
+
+    eslint-config-prettier@10.1.8(eslint@10.2.1(jiti@2.7.0)):
+        dependencies:
+            eslint: 10.2.1(jiti@2.7.0)
+
+    eslint-import-resolver-node@0.3.10:
+        dependencies:
+            debug: 3.2.7
+            is-core-module: 2.16.2
+            resolve: 2.0.0-next.7
+        transitivePeerDependencies:
+            - supports-color
+
+    eslint-module-utils@2.13.0(@typescript-eslint/parser@8.59.1(eslint@10.2.1(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint@10.2.1(jiti@2.7.0)):
+        dependencies:
+            debug: 3.2.7
+        optionalDependencies:
+            '@typescript-eslint/parser': 8.59.1(eslint@10.2.1(jiti@2.7.0))(typescript@6.0.3)
+            eslint: 10.2.1(jiti@2.7.0)
+            eslint-import-resolver-node: 0.3.10
+        transitivePeerDependencies:
+            - supports-color
+
+    eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.1(eslint@10.2.1(jiti@2.7.0))(typescript@6.0.3))(eslint@10.2.1(jiti@2.7.0)):
+        dependencies:
+            '@rtsao/scc': 1.1.0
+            array-includes: 3.1.9
+            array.prototype.findlastindex: 1.2.6
+            array.prototype.flat: 1.3.3
+            array.prototype.flatmap: 1.3.3
+            debug: 3.2.7
+            doctrine: 2.1.0
+            eslint: 10.2.1(jiti@2.7.0)
+            eslint-import-resolver-node: 0.3.10
+            eslint-module-utils: 2.13.0(@typescript-eslint/parser@8.59.1(eslint@10.2.1(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint@10.2.1(jiti@2.7.0))
+            hasown: 2.0.4
+            is-core-module: 2.16.2
+            is-glob: 4.0.3
+            minimatch: 3.1.5
+            object.fromentries: 2.0.8
+            object.groupby: 1.0.3
+            object.values: 1.2.1
+            semver: 6.3.1
+            string.prototype.trimend: 1.0.10
+            tsconfig-paths: 3.15.0
+        optionalDependencies:
+            '@typescript-eslint/parser': 8.59.1(eslint@10.2.1(jiti@2.7.0))(typescript@6.0.3)
+        transitivePeerDependencies:
+            - eslint-import-resolver-typescript
+            - eslint-import-resolver-webpack
+            - supports-color
+
+    eslint-scope@9.1.2:
+        dependencies:
+            '@types/esrecurse': 4.3.1
+            '@types/estree': 1.0.9
+            esrecurse: 4.3.0
+            estraverse: 5.3.0
+
+    eslint-visitor-keys@3.4.3: {}
+
+    eslint-visitor-keys@5.0.1: {}
+
+    eslint@10.2.1(jiti@2.7.0):
+        dependencies:
+            '@eslint-community/eslint-utils': 4.9.1(eslint@10.2.1(jiti@2.7.0))
+            '@eslint-community/regexpp': 4.12.2
+            '@eslint/config-array': 0.23.5
+            '@eslint/config-helpers': 0.5.5
+            '@eslint/core': 1.2.1
+            '@eslint/plugin-kit': 0.7.2
+            '@humanfs/node': 0.16.8
+            '@humanwhocodes/module-importer': 1.0.1
+            '@humanwhocodes/retry': 0.4.3
+            '@types/estree': 1.0.9
+            ajv: 6.15.0
+            cross-spawn: 7.0.6
+            debug: 4.4.3
+            escape-string-regexp: 4.0.0
+            eslint-scope: 9.1.2
+            eslint-visitor-keys: 5.0.1
+            espree: 11.2.0
+            esquery: 1.7.0
+            esutils: 2.0.3
+            fast-deep-equal: 3.1.3
+            file-entry-cache: 8.0.0
+            find-up: 5.0.0
+            glob-parent: 6.0.2
+            ignore: 5.3.2
+            imurmurhash: 0.1.4
+            is-glob: 4.0.3
+            json-stable-stringify-without-jsonify: 1.0.1
+            minimatch: 10.2.5
+            natural-compare: 1.4.0
+            optionator: 0.9.4
+        optionalDependencies:
+            jiti: 2.7.0
+        transitivePeerDependencies:
+            - supports-color
+
+    espree@11.2.0:
+        dependencies:
+            acorn: 8.16.0
+            acorn-jsx: 5.3.2(acorn@8.16.0)
+            eslint-visitor-keys: 5.0.1
+
+    esquery@1.7.0:
+        dependencies:
+            estraverse: 5.3.0
+
+    esrecurse@4.3.0:
+        dependencies:
+            estraverse: 5.3.0
+
+    estraverse@5.3.0: {}
+
+    esutils@2.0.3: {}
+
+    etag@1.8.1: {}
+
+    events@3.3.0: {}
+
+    express@5.2.1:
+        dependencies:
+            accepts: 2.0.0
+            body-parser: 2.2.2
+            content-disposition: 1.1.0
+            content-type: 1.0.5
+            cookie: 0.7.2
+            cookie-signature: 1.2.2
+            debug: 4.4.3
+            depd: 2.0.0
+            encodeurl: 2.0.0
+            escape-html: 1.0.3
+            etag: 1.8.1
+            finalhandler: 2.1.1
+            fresh: 2.0.0
+            http-errors: 2.0.1
+            merge-descriptors: 2.0.0
+            mime-types: 3.0.2
+            on-finished: 2.4.1
+            once: 1.4.0
+            parseurl: 1.3.3
+            proxy-addr: 2.0.7
+            qs: 6.15.2
+            range-parser: 1.2.1
+            router: 2.2.0
+            send: 1.2.1
+            serve-static: 2.2.1
+            statuses: 2.0.2
+            type-is: 2.1.0
+            vary: 1.1.2
+        transitivePeerDependencies:
+            - supports-color
+
+    exsolve@1.0.8: {}
+
+    fast-check@3.23.2:
+        dependencies:
+            pure-rand: 6.1.0
+
+    fast-copy@4.0.3: {}
+
+    fast-deep-equal@3.1.3: {}
+
+    fast-json-stable-stringify@2.1.0: {}
+
+    fast-levenshtein@2.0.6: {}
+
+    fast-safe-stringify@2.1.1: {}
+
+    fast-uri@3.1.2: {}
+
+    fast-xml-builder@1.2.0:
+        dependencies:
+            path-expression-matcher: 1.5.0
+            xml-naming: 0.1.0
+
+    fast-xml-parser@5.7.3:
+        dependencies:
+            '@nodable/entities': 2.1.1
+            fast-xml-builder: 1.2.0
+            path-expression-matcher: 1.5.0
+            strnum: 2.3.0
+
+    fdir@6.5.0(picomatch@4.0.4):
+        optionalDependencies:
+            picomatch: 4.0.4
+
+    file-entry-cache@8.0.0:
+        dependencies:
+            flat-cache: 4.0.1
+
+    finalhandler@2.1.1:
+        dependencies:
+            debug: 4.4.3
+            encodeurl: 2.0.0
+            escape-html: 1.0.3
+            on-finished: 2.4.1
+            parseurl: 1.3.3
+            statuses: 2.0.2
+        transitivePeerDependencies:
+            - supports-color
+
+    find-up@5.0.0:
+        dependencies:
+            locate-path: 6.0.0
+            path-exists: 4.0.0
+
+    flat-cache@4.0.1:
+        dependencies:
+            flatted: 3.4.2
+            keyv: 4.5.4
+
+    flatted@3.4.2: {}
+
+    for-each@0.3.5:
+        dependencies:
+            is-callable: 1.2.7
+
+    foreground-child@3.3.1:
+        dependencies:
+            cross-spawn: 7.0.6
+            signal-exit: 4.1.0
+
+    forwarded@0.2.0: {}
+
+    fresh@2.0.0: {}
+
+    function-bind@1.1.2: {}
+
+    function.prototype.name@1.1.8:
+        dependencies:
+            call-bind: 1.0.9
+            call-bound: 1.0.4
+            define-properties: 1.2.1
+            functions-have-names: 1.2.3
+            hasown: 2.0.4
+            is-callable: 1.2.7
+
+    functions-have-names@1.2.3: {}
+
+    generate-function@2.3.1:
+        dependencies:
+            is-property: 1.0.2
+
+    generator-function@2.0.1: {}
+
+    get-intrinsic@1.3.0:
+        dependencies:
+            call-bind-apply-helpers: 1.0.2
+            es-define-property: 1.0.1
+            es-errors: 1.3.0
+            es-object-atoms: 1.1.2
+            function-bind: 1.1.2
+            get-proto: 1.0.1
+            gopd: 1.2.0
+            has-symbols: 1.1.0
+            hasown: 2.0.4
+            math-intrinsics: 1.1.0
+
+    get-port-please@3.2.0: {}
+
+    get-proto@1.0.1:
+        dependencies:
+            dunder-proto: 1.0.1
+            es-object-atoms: 1.1.2
+
+    get-symbol-description@1.1.0:
+        dependencies:
+            call-bound: 1.0.4
+            es-errors: 1.3.0
+            get-intrinsic: 1.3.0
+
+    giget@3.2.0: {}
+
+    glob-parent@6.0.2:
+        dependencies:
+            is-glob: 4.0.3
+
+    globals@17.5.0: {}
+
+    globalthis@1.0.4:
+        dependencies:
+            define-properties: 1.2.1
+            gopd: 1.2.0
+
+    gopd@1.2.0: {}
+
+    graceful-fs@4.2.11: {}
+
+    grammex@3.1.12: {}
+
+    graphmatch@1.1.1: {}
+
+    has-bigints@1.1.0: {}
+
+    has-property-descriptors@1.0.2:
+        dependencies:
+            es-define-property: 1.0.1
+
+    has-proto@1.2.0:
+        dependencies:
+            dunder-proto: 1.0.1
+
+    has-symbols@1.1.0: {}
+
+    has-tostringtag@1.0.2:
+        dependencies:
+            has-symbols: 1.1.0
+
+    hasown@2.0.4:
+        dependencies:
+            function-bind: 1.1.2
+
+    help-me@5.0.0: {}
+
+    hono@4.12.23: {}
+
+    http-errors@2.0.1:
+        dependencies:
+            depd: 2.0.0
+            inherits: 2.0.4
+            setprototypeof: 1.2.0
+            statuses: 2.0.2
+            toidentifier: 1.0.1
+
+    http-status-codes@2.3.0: {}
+
+    iconv-lite@0.7.2:
+        dependencies:
+            safer-buffer: 2.1.2
+
+    ieee754@1.2.1: {}
+
+    ignore@5.3.2: {}
+
+    ignore@7.0.5: {}
+
+    imurmurhash@0.1.4: {}
+
+    inherits@2.0.4: {}
+
+    internal-slot@1.1.0:
+        dependencies:
+            es-errors: 1.3.0
+            hasown: 2.0.4
+            side-channel: 1.1.0
+
+    ipaddr.js@1.9.1: {}
+
+    is-array-buffer@3.0.5:
+        dependencies:
+            call-bind: 1.0.9
+            call-bound: 1.0.4
+            get-intrinsic: 1.3.0
+
+    is-async-function@2.1.1:
+        dependencies:
+            async-function: 1.0.0
+            call-bound: 1.0.4
+            get-proto: 1.0.1
+            has-tostringtag: 1.0.2
+            safe-regex-test: 1.1.0
+
+    is-bigint@1.1.0:
+        dependencies:
+            has-bigints: 1.1.0
+
+    is-boolean-object@1.2.2:
+        dependencies:
+            call-bound: 1.0.4
+            has-tostringtag: 1.0.2
+
+    is-callable@1.2.7: {}
+
+    is-core-module@2.16.2:
+        dependencies:
+            hasown: 2.0.4
+
+    is-data-view@1.0.2:
+        dependencies:
+            call-bound: 1.0.4
+            get-intrinsic: 1.3.0
+            is-typed-array: 1.1.15
+
+    is-date-object@1.1.0:
+        dependencies:
+            call-bound: 1.0.4
+            has-tostringtag: 1.0.2
+
+    is-extglob@2.1.1: {}
+
+    is-finalizationregistry@1.1.1:
+        dependencies:
+            call-bound: 1.0.4
+
+    is-generator-function@1.1.2:
+        dependencies:
+            call-bound: 1.0.4
+            generator-function: 2.0.1
+            get-proto: 1.0.1
+            has-tostringtag: 1.0.2
+            safe-regex-test: 1.1.0
+
+    is-glob@4.0.3:
+        dependencies:
+            is-extglob: 2.1.1
+
+    is-map@2.0.3: {}
+
+    is-negative-zero@2.0.3: {}
+
+    is-number-object@1.1.1:
+        dependencies:
+            call-bound: 1.0.4
+            has-tostringtag: 1.0.2
+
+    is-promise@4.0.0: {}
+
+    is-property@1.0.2: {}
+
+    is-regex@1.2.1:
+        dependencies:
+            call-bound: 1.0.4
+            gopd: 1.2.0
+            has-tostringtag: 1.0.2
+            hasown: 2.0.4
+
+    is-set@2.0.3: {}
+
+    is-shared-array-buffer@1.0.4:
+        dependencies:
+            call-bound: 1.0.4
+
+    is-string@1.1.1:
+        dependencies:
+            call-bound: 1.0.4
+            has-tostringtag: 1.0.2
+
+    is-symbol@1.1.1:
+        dependencies:
+            call-bound: 1.0.4
+            has-symbols: 1.1.0
+            safe-regex-test: 1.1.0
+
+    is-typed-array@1.1.15:
+        dependencies:
+            which-typed-array: 1.1.22
+
+    is-weakmap@2.0.2: {}
+
+    is-weakref@1.1.1:
+        dependencies:
+            call-bound: 1.0.4
+
+    is-weakset@2.0.4:
+        dependencies:
+            call-bound: 1.0.4
+            get-intrinsic: 1.3.0
+
+    isarray@2.0.5: {}
+
+    isexe@2.0.0: {}
+
+    jiti@2.7.0: {}
+
+    jose@6.2.3: {}
+
+    joycon@3.1.1: {}
+
+    jsbi@4.3.2: {}
+
+    json-buffer@3.0.1: {}
+
+    json-schema-traverse@0.4.1: {}
+
+    json-schema-traverse@1.0.0: {}
+
+    json-stable-stringify-without-jsonify@1.0.1: {}
+
+    json5@1.0.2:
+        dependencies:
+            minimist: 1.2.8
+
+    keyv@4.5.4:
+        dependencies:
+            json-buffer: 3.0.1
+
+    levn@0.4.1:
+        dependencies:
+            prelude-ls: 1.2.1
+            type-check: 0.4.0
+
+    locate-path@6.0.0:
+        dependencies:
+            p-locate: 5.0.0
+
+    lodash.snakecase@4.1.1: {}
+
+    lodash@4.18.1: {}
+
+    long@5.3.2: {}
+
+    lru.min@1.1.4: {}
+
+    luxon@3.7.2: {}
+
+    magic-bytes.js@1.13.0: {}
+
+    math-intrinsics@1.1.0: {}
+
+    media-typer@1.1.0: {}
+
+    merge-descriptors@2.0.0: {}
+
+    mime-db@1.54.0: {}
+
+    mime-types@3.0.2:
+        dependencies:
+            mime-db: 1.54.0
+
+    minimatch@10.2.5:
+        dependencies:
+            brace-expansion: 5.0.6
+
+    minimatch@3.1.5:
+        dependencies:
+            brace-expansion: 1.1.15
+
+    minimist@1.2.8: {}
+
+    ms@2.1.3: {}
+
+    mysql2@3.15.3:
+        dependencies:
+            aws-ssl-profiles: 1.1.2
+            denque: 2.1.0
+            generate-function: 2.3.1
+            iconv-lite: 0.7.2
+            long: 5.3.2
+            lru.min: 1.1.4
+            named-placeholders: 1.1.6
+            seq-queue: 0.0.5
+            sqlstring: 2.3.3
+
+    named-placeholders@1.1.6:
+        dependencies:
+            lru.min: 1.1.4
+
+    natural-compare@1.4.0: {}
+
+    negotiator@1.0.0: {}
+
+    neverthrow@8.2.0:
+        optionalDependencies:
+            '@rollup/rollup-linux-x64-gnu': 4.61.1
+
+    node-addon-api@8.8.0: {}
+
+    node-exports-info@1.6.0:
+        dependencies:
+            array.prototype.flatmap: 1.3.3
+            es-errors: 1.3.0
+            object.entries: 1.1.9
+            semver: 6.3.1
+
+    node-gyp-build@4.8.4: {}
+
+    object-assign@4.1.1: {}
+
+    object-inspect@1.13.4: {}
+
+    object-keys@1.1.1: {}
+
+    object.assign@4.1.7:
+        dependencies:
+            call-bind: 1.0.9
+            call-bound: 1.0.4
+            define-properties: 1.2.1
+            es-object-atoms: 1.1.2
+            has-symbols: 1.1.0
+            object-keys: 1.1.1
+
+    object.entries@1.1.9:
+        dependencies:
+            call-bind: 1.0.9
+            call-bound: 1.0.4
+            define-properties: 1.2.1
+            es-object-atoms: 1.1.2
+
+    object.fromentries@2.0.8:
+        dependencies:
+            call-bind: 1.0.9
+            define-properties: 1.2.1
+            es-abstract: 1.24.2
+            es-object-atoms: 1.1.2
+
+    object.groupby@1.0.3:
+        dependencies:
+            call-bind: 1.0.9
+            define-properties: 1.2.1
+            es-abstract: 1.24.2
+
+    object.values@1.2.1:
+        dependencies:
+            call-bind: 1.0.9
+            call-bound: 1.0.4
+            define-properties: 1.2.1
+            es-object-atoms: 1.1.2
+
+    ohash@2.0.11: {}
+
+    on-exit-leak-free@2.1.2: {}
+
+    on-finished@2.4.1:
+        dependencies:
+            ee-first: 1.1.1
+
+    once@1.4.0:
+        dependencies:
+            wrappy: 1.0.2
+
+    optionator@0.9.4:
+        dependencies:
+            deep-is: 0.1.4
+            fast-levenshtein: 2.0.6
+            levn: 0.4.1
+            prelude-ls: 1.2.1
+            type-check: 0.4.0
+            word-wrap: 1.2.5
+
+    own-keys@1.0.1:
+        dependencies:
+            get-intrinsic: 1.3.0
+            object-keys: 1.1.1
+            safe-push-apply: 1.0.0
+
+    p-limit@3.1.0:
+        dependencies:
+            yocto-queue: 0.1.0
+
+    p-locate@5.0.0:
+        dependencies:
+            p-limit: 3.1.0
+
+    parseurl@1.3.3: {}
+
+    path-exists@4.0.0: {}
+
+    path-expression-matcher@1.5.0: {}
+
+    path-key@3.1.1: {}
+
+    path-parse@1.0.7: {}
+
+    path-to-regexp@8.4.2: {}
+
+    pathe@2.0.3: {}
+
+    perfect-debounce@2.1.0: {}
+
+    pg-cloudflare@1.4.0:
+        optional: true
+
+    pg-connection-string@2.13.0: {}
+
+    pg-int8@1.0.1: {}
+
+    pg-pool@3.14.0(pg@8.20.0):
+        dependencies:
+            pg: 8.20.0
+
+    pg-protocol@1.14.0: {}
+
+    pg-types@2.2.0:
+        dependencies:
+            pg-int8: 1.0.1
+            postgres-array: 2.0.0
+            postgres-bytea: 1.0.1
+            postgres-date: 1.0.7
+            postgres-interval: 1.2.0
+
+    pg@8.20.0:
+        dependencies:
+            pg-connection-string: 2.13.0
+            pg-pool: 3.14.0(pg@8.20.0)
+            pg-protocol: 1.14.0
+            pg-types: 2.2.0
+            pgpass: 1.0.5
+        optionalDependencies:
+            pg-cloudflare: 1.4.0
+
+    pgpass@1.0.5:
+        dependencies:
+            split2: 4.2.0
+
+    picomatch@4.0.4: {}
+
+    pino-abstract-transport@3.0.0:
+        dependencies:
+            split2: 4.2.0
+
+    pino-pretty@13.1.3:
+        dependencies:
+            colorette: 2.0.20
+            dateformat: 4.6.3
+            fast-copy: 4.0.3
+            fast-safe-stringify: 2.1.1
+            help-me: 5.0.0
+            joycon: 3.1.1
+            minimist: 1.2.8
+            on-exit-leak-free: 2.1.2
+            pino-abstract-transport: 3.0.0
+            pump: 3.0.4
+            secure-json-parse: 4.1.0
+            sonic-boom: 4.2.1
+            strip-json-comments: 5.0.3
+
+    pino-std-serializers@7.1.0: {}
+
+    pino@10.3.1:
+        dependencies:
+            '@pinojs/redact': 0.4.0
+            atomic-sleep: 1.0.0
+            on-exit-leak-free: 2.1.2
+            pino-abstract-transport: 3.0.0
+            pino-std-serializers: 7.1.0
+            process-warning: 5.0.0
+            quick-format-unescaped: 4.0.4
+            real-require: 0.2.0
+            safe-stable-stringify: 2.5.0
+            sonic-boom: 4.2.1
+            thread-stream: 4.2.0
+
+    pkg-types@2.3.1:
+        dependencies:
+            confbox: 0.2.4
+            exsolve: 1.0.8
+            pathe: 2.0.3
+
+    possible-typed-array-names@1.1.0: {}
+
+    postgres-array@2.0.0: {}
+
+    postgres-array@3.0.4: {}
+
+    postgres-bytea@1.0.1: {}
+
+    postgres-date@1.0.7: {}
+
+    postgres-interval@1.2.0:
+        dependencies:
+            xtend: 4.0.2
+
+    postgres@3.4.7: {}
+
+    prelude-ls@1.2.1: {}
+
+    prettier@3.8.3: {}
+
+    prisma@7.8.0(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3):
+        dependencies:
+            '@prisma/config': 7.8.0
+            '@prisma/dev': 0.24.3(typescript@6.0.3)
+            '@prisma/engines': 7.8.0
+            '@prisma/studio-core': 0.27.3(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+            mysql2: 3.15.3
+            postgres: 3.4.7
+        optionalDependencies:
+            typescript: 6.0.3
+        transitivePeerDependencies:
+            - '@types/react'
+            - '@types/react-dom'
+            - magicast
+            - react
+            - react-dom
+
+    process-warning@5.0.0: {}
+
+    proper-lockfile@4.1.2:
+        dependencies:
+            graceful-fs: 4.2.11
+            retry: 0.12.0
+            signal-exit: 3.0.7
+
+    proxy-addr@2.0.7:
+        dependencies:
+            forwarded: 0.2.0
+            ipaddr.js: 1.9.1
+
+    pump@3.0.4:
+        dependencies:
+            end-of-stream: 1.4.5
+            once: 1.4.0
+
+    punycode@2.3.1: {}
+
+    pure-rand@6.1.0: {}
+
+    qs@6.15.2:
+        dependencies:
+            side-channel: 1.1.0
+
+    quick-format-unescaped@4.0.4: {}
+
+    range-parser@1.2.1: {}
+
+    raw-body@3.0.2:
+        dependencies:
+            bytes: 3.1.2
+            http-errors: 2.0.1
+            iconv-lite: 0.7.2
+            unpipe: 1.0.0
+
+    rc9@3.0.1:
+        dependencies:
+            defu: 6.1.7
+            destr: 2.0.5
+
+    react-dom@19.2.7(react@19.2.7):
+        dependencies:
+            react: 19.2.7
+            scheduler: 0.27.0
+
+    react@19.2.7: {}
+
+    readable-stream@3.6.2:
+        dependencies:
+            inherits: 2.0.4
+            string_decoder: 1.3.0
+            util-deprecate: 1.0.2
+
+    readdirp@5.0.0: {}
+
+    real-require@0.2.0: {}
+
+    real-require@1.0.0: {}
+
+    reflect.getprototypeof@1.0.10:
+        dependencies:
+            call-bind: 1.0.9
+            define-properties: 1.2.1
+            es-abstract: 1.24.2
+            es-errors: 1.3.0
+            es-object-atoms: 1.1.2
+            get-intrinsic: 1.3.0
+            get-proto: 1.0.1
+            which-builtin-type: 1.2.1
+
+    regexp.prototype.flags@1.5.4:
+        dependencies:
+            call-bind: 1.0.9
+            define-properties: 1.2.1
+            es-errors: 1.3.0
+            get-proto: 1.0.1
+            gopd: 1.2.0
+            set-function-name: 2.0.2
+
+    remeda@2.33.4: {}
+
+    require-from-string@2.0.2: {}
+
+    resolve@2.0.0-next.7:
+        dependencies:
+            es-errors: 1.3.0
+            is-core-module: 2.16.2
+            node-exports-info: 1.6.0
+            object-keys: 1.1.1
+            path-parse: 1.0.7
+            supports-preserve-symlinks-flag: 1.0.0
+
+    retry@0.12.0: {}
+
+    router@2.2.0:
+        dependencies:
+            debug: 4.4.3
+            depd: 2.0.0
+            is-promise: 4.0.0
+            parseurl: 1.3.3
+            path-to-regexp: 8.4.2
+        transitivePeerDependencies:
+            - supports-color
+
+    safe-array-concat@1.1.4:
+        dependencies:
+            call-bind: 1.0.9
+            call-bound: 1.0.4
+            get-intrinsic: 1.3.0
+            has-symbols: 1.1.0
+            isarray: 2.0.5
+
+    safe-buffer@5.2.1: {}
+
+    safe-push-apply@1.0.0:
+        dependencies:
+            es-errors: 1.3.0
+            isarray: 2.0.5
+
+    safe-regex-test@1.1.0:
+        dependencies:
+            call-bound: 1.0.4
+            es-errors: 1.3.0
+            is-regex: 1.2.1
+
+    safe-stable-stringify@2.5.0: {}
+
+    safer-buffer@2.1.2: {}
+
+    scheduler@0.27.0: {}
+
+    secure-json-parse@4.1.0: {}
+
+    semver@6.3.1: {}
+
+    semver@7.8.2: {}
+
+    send@1.2.1:
+        dependencies:
+            debug: 4.4.3
+            encodeurl: 2.0.0
+            escape-html: 1.0.3
+            etag: 1.8.1
+            fresh: 2.0.0
+            http-errors: 2.0.1
+            mime-types: 3.0.2
+            ms: 2.1.3
+            on-finished: 2.4.1
+            range-parser: 1.2.1
+            statuses: 2.0.2
+        transitivePeerDependencies:
+            - supports-color
+
+    seq-queue@0.0.5: {}
+
+    serve-static@2.2.1:
+        dependencies:
+            encodeurl: 2.0.0
+            escape-html: 1.0.3
+            parseurl: 1.3.3
+            send: 1.2.1
+        transitivePeerDependencies:
+            - supports-color
+
+    set-function-length@1.2.2:
+        dependencies:
+            define-data-property: 1.1.4
+            es-errors: 1.3.0
+            function-bind: 1.1.2
+            get-intrinsic: 1.3.0
+            gopd: 1.2.0
+            has-property-descriptors: 1.0.2
+
+    set-function-name@2.0.2:
+        dependencies:
+            define-data-property: 1.1.4
+            es-errors: 1.3.0
+            functions-have-names: 1.2.3
+            has-property-descriptors: 1.0.2
+
+    set-proto@1.0.0:
+        dependencies:
+            dunder-proto: 1.0.1
+            es-errors: 1.3.0
+            es-object-atoms: 1.1.2
+
+    setprototypeof@1.2.0: {}
+
+    shebang-command@2.0.0:
+        dependencies:
+            shebang-regex: 3.0.0
+
+    shebang-regex@3.0.0: {}
+
+    side-channel-list@1.0.1:
+        dependencies:
+            es-errors: 1.3.0
+            object-inspect: 1.13.4
+
+    side-channel-map@1.0.1:
+        dependencies:
+            call-bound: 1.0.4
+            es-errors: 1.3.0
+            get-intrinsic: 1.3.0
+            object-inspect: 1.13.4
+
+    side-channel-weakmap@1.0.2:
+        dependencies:
+            call-bound: 1.0.4
+            es-errors: 1.3.0
+            get-intrinsic: 1.3.0
+            object-inspect: 1.13.4
+            side-channel-map: 1.0.1
+
+    side-channel@1.1.0:
+        dependencies:
+            es-errors: 1.3.0
+            object-inspect: 1.13.4
+            side-channel-list: 1.0.1
+            side-channel-map: 1.0.1
+            side-channel-weakmap: 1.0.2
+
+    signal-exit@3.0.7: {}
+
+    signal-exit@4.1.0: {}
+
+    sonic-boom@4.2.1:
+        dependencies:
+            atomic-sleep: 1.0.0
+
+    split2@4.2.0: {}
+
+    sqlstring@2.3.3: {}
+
+    statuses@2.0.2: {}
+
+    std-env@3.10.0: {}
+
+    stop-iteration-iterator@1.1.0:
+        dependencies:
+            es-errors: 1.3.0
+            internal-slot: 1.1.0
+
+    stream-browserify@3.0.0:
+        dependencies:
+            inherits: 2.0.4
+            readable-stream: 3.6.2
+
+    streamsearch@1.1.0: {}
+
+    string.prototype.trim@1.2.11:
+        dependencies:
+            call-bind: 1.0.9
+            call-bound: 1.0.4
+            define-data-property: 1.1.4
+            define-properties: 1.2.1
+            es-abstract: 1.24.2
+            es-object-atoms: 1.1.2
+            has-property-descriptors: 1.0.2
+            safe-regex-test: 1.1.0
+
+    string.prototype.trimend@1.0.10:
+        dependencies:
+            call-bind: 1.0.9
+            call-bound: 1.0.4
+            define-properties: 1.2.1
+            es-object-atoms: 1.1.2
+
+    string.prototype.trimstart@1.0.8:
+        dependencies:
+            call-bind: 1.0.9
+            define-properties: 1.2.1
+            es-object-atoms: 1.1.2
+
+    string_decoder@1.3.0:
+        dependencies:
+            safe-buffer: 5.2.1
+
+    strip-bom@3.0.0: {}
+
+    strip-json-comments@5.0.3: {}
+
+    strnum@2.3.0: {}
+
+    supports-preserve-symlinks-flag@1.0.0: {}
+
+    thread-stream@4.2.0:
+        dependencies:
+            real-require: 1.0.0
+
+    tinyglobby@0.2.17:
+        dependencies:
+            fdir: 6.5.0(picomatch@4.0.4)
+            picomatch: 4.0.4
+
+    toidentifier@1.0.1: {}
+
+    ts-api-utils@2.5.0(typescript@6.0.3):
+        dependencies:
+            typescript: 6.0.3
+
+    ts-mixer@6.0.4: {}
+
+    tsconfig-paths@3.15.0:
+        dependencies:
+            '@types/json5': 0.0.29
+            json5: 1.0.2
+            minimist: 1.2.8
+            strip-bom: 3.0.0
+
+    tslib@2.8.1: {}
+
+    type-check@0.4.0:
+        dependencies:
+            prelude-ls: 1.2.1
+
+    type-is@2.1.0:
+        dependencies:
+            content-type: 2.0.0
+            media-typer: 1.1.0
+            mime-types: 3.0.2
+
+    typed-array-buffer@1.0.3:
+        dependencies:
+            call-bound: 1.0.4
+            es-errors: 1.3.0
+            is-typed-array: 1.1.15
+
+    typed-array-byte-length@1.0.3:
+        dependencies:
+            call-bind: 1.0.9
+            for-each: 0.3.5
+            gopd: 1.2.0
+            has-proto: 1.2.0
+            is-typed-array: 1.1.15
+
+    typed-array-byte-offset@1.0.4:
+        dependencies:
+            available-typed-arrays: 1.0.7
+            call-bind: 1.0.9
+            for-each: 0.3.5
+            gopd: 1.2.0
+            has-proto: 1.2.0
+            is-typed-array: 1.1.15
+            reflect.getprototypeof: 1.0.10
+
+    typed-array-length@1.0.8:
+        dependencies:
+            call-bind: 1.0.9
+            for-each: 0.3.5
+            gopd: 1.2.0
+            is-typed-array: 1.1.15
+            possible-typed-array-names: 1.1.0
+            reflect.getprototypeof: 1.0.10
+
+    typescript-eslint@8.59.1(eslint@10.2.1(jiti@2.7.0))(typescript@6.0.3):
+        dependencies:
+            '@typescript-eslint/eslint-plugin': 8.59.1(@typescript-eslint/parser@8.59.1(eslint@10.2.1(jiti@2.7.0))(typescript@6.0.3))(eslint@10.2.1(jiti@2.7.0))(typescript@6.0.3)
+            '@typescript-eslint/parser': 8.59.1(eslint@10.2.1(jiti@2.7.0))(typescript@6.0.3)
+            '@typescript-eslint/typescript-estree': 8.59.1(typescript@6.0.3)
+            '@typescript-eslint/utils': 8.59.1(eslint@10.2.1(jiti@2.7.0))(typescript@6.0.3)
+            eslint: 10.2.1(jiti@2.7.0)
+            typescript: 6.0.3
+        transitivePeerDependencies:
+            - supports-color
+
+    typescript@6.0.3: {}
+
+    unbox-primitive@1.1.0:
+        dependencies:
+            call-bound: 1.0.4
+            has-bigints: 1.1.0
+            has-symbols: 1.1.0
+            which-boxed-primitive: 1.1.1
+
+    undici-types@7.19.2: {}
+
+    undici@6.24.1: {}
+
+    unpipe@1.0.0: {}
+
+    uri-js@4.4.1:
+        dependencies:
+            punycode: 2.3.1
+
+    util-deprecate@1.0.2: {}
+
+    valibot@1.2.0(typescript@6.0.3):
+        optionalDependencies:
+            typescript: 6.0.3
+
+    vary@1.1.2: {}
+
+    which-boxed-primitive@1.1.1:
+        dependencies:
+            is-bigint: 1.1.0
+            is-boolean-object: 1.2.2
+            is-number-object: 1.1.1
+            is-string: 1.1.1
+            is-symbol: 1.1.1
+
+    which-builtin-type@1.2.1:
+        dependencies:
+            call-bound: 1.0.4
+            function.prototype.name: 1.1.8
+            has-tostringtag: 1.0.2
+            is-async-function: 2.1.1
+            is-date-object: 1.1.0
+            is-finalizationregistry: 1.1.1
+            is-generator-function: 1.1.2
+            is-regex: 1.2.1
+            is-weakref: 1.1.1
+            isarray: 2.0.5
+            which-boxed-primitive: 1.1.1
+            which-collection: 1.0.2
+            which-typed-array: 1.1.22
+
+    which-collection@1.0.2:
+        dependencies:
+            is-map: 2.0.3
+            is-set: 2.0.3
+            is-weakmap: 2.0.2
+            is-weakset: 2.0.4
+
+    which-typed-array@1.1.22:
+        dependencies:
+            available-typed-arrays: 1.0.7
+            call-bind: 1.0.9
+            call-bound: 1.0.4
+            for-each: 0.3.5
+            get-proto: 1.0.1
+            gopd: 1.2.0
+            has-tostringtag: 1.0.2
+
+    which@2.0.2:
+        dependencies:
+            isexe: 2.0.0
+
+    word-wrap@1.2.5: {}
+
+    wrappy@1.0.2: {}
+
+    ws@8.21.0: {}
+
+    xml-naming@0.1.0: {}
+
+    xtend@4.0.2: {}
+
+    yocto-queue@0.1.0: {}
+
+    zeptomatch@2.1.0:
+        dependencies:
+            grammex: 3.1.12
+            graphmatch: 1.1.1
+
+    zod@4.3.6: {}
+
+    zod@4.4.1: {}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -112,7 +112,7 @@ importers:
         specifier: 13.1.3
         version: 13.1.3
       prettier:
-        specifier: ^3.8.3
+        specifier: 3.8.3
         version: 3.8.3
       prisma:
         specifier: 7.8.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,8 @@
 packages:
     - .
 
+saveExact: true
+
 minimumReleaseAgeExclude:
     - '@triskcraft/api-types'
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,13 +1,13 @@
 packages:
-  - .
+    - .
 
 minimumReleaseAgeExclude:
-  - '@triskcraft/api-types'
+    - '@triskcraft/api-types'
 
 allowBuilds:
-  '@prisma/engines': true
-  argon2: true
-  prisma: true
+    '@prisma/engines': true
+    argon2: true
+    prisma: true
 
 overrides:
-  eslint-plugin-import>eslint: 10.2.1
+    eslint-plugin-import>eslint: 10.2.1

--- a/process.excalidraw
+++ b/process.excalidraw
@@ -1,0 +1,13 @@
+{
+  "type": "excalidraw",
+  "version": 2,
+  "source": "https://marketplace.visualstudio.com/items?itemName=pomdtr.excalidraw-editor",
+  "elements": [],
+  "appState": {
+    "gridSize": 20,
+    "gridStep": 5,
+    "gridModeEnabled": false,
+    "viewBackgroundColor": "#ffffff"
+  },
+  "files": {}
+}

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -1,0 +1,50 @@
+{
+  "version": 1,
+  "skills": {
+    "nodejs-backend-patterns": {
+      "source": "wshobson/agents",
+      "sourceType": "autoskills-registry",
+      "computedHash": "710a5e6f83c46e8f6c43356df55c143a7375c4414559a581654ce51709138c55"
+    },
+    "nodejs-best-practices": {
+      "source": "sickn33/antigravity-awesome-skills",
+      "sourceType": "autoskills-registry",
+      "computedHash": "7361ab02fb6b09913e3bdd9cf61c629ed6c17de9485e6a781054e5d437ccfc29"
+    },
+    "nodejs-express-server": {
+      "source": "aj-geddes/useful-ai-prompts",
+      "sourceType": "autoskills-registry",
+      "computedHash": "b15b3e6dda23d3f3c230285a122de9df3aabae6408dc2bd52038445e60ba745e"
+    },
+    "prisma-cli": {
+      "source": "prisma/skills",
+      "sourceType": "autoskills-registry",
+      "computedHash": "d2b4e410bb24df07e0a399cf1fd70ca6a2f696079f7e6445eb602116566d2278"
+    },
+    "prisma-client-api": {
+      "source": "prisma/skills",
+      "sourceType": "autoskills-registry",
+      "computedHash": "922d6b5b4eb4387e72e409fa063f8e1bffb9037aed595cba0d3c257f418b6c18"
+    },
+    "prisma-database-setup": {
+      "source": "prisma/skills",
+      "sourceType": "autoskills-registry",
+      "computedHash": "50c6cbc7090ef356c026cb76352952b83b65bee8b3f3c7ac337461f5b352e9b9"
+    },
+    "prisma-postgres": {
+      "source": "prisma/skills",
+      "sourceType": "autoskills-registry",
+      "computedHash": "3adda04ae85b8593cfca45d48d5d410ddffb2797ea53f6dc9dfe34b8d71d35e9"
+    },
+    "typescript-advanced-types": {
+      "source": "wshobson/agents",
+      "sourceType": "autoskills-registry",
+      "computedHash": "5ca0e177c6aaaba1889255691224daafdb7d71f317cc70bede1590d3907ded42"
+    },
+    "zod": {
+      "source": "pproenca/dot-skills",
+      "sourceType": "autoskills-registry",
+      "computedHash": "aa8a97195b07763d37494b511f48be90979fd6826c031956c831cfc58f6a24b8"
+    }
+  }
+}

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -1,50 +1,50 @@
 {
-  "version": 1,
-  "skills": {
-    "nodejs-backend-patterns": {
-      "source": "wshobson/agents",
-      "sourceType": "autoskills-registry",
-      "computedHash": "710a5e6f83c46e8f6c43356df55c143a7375c4414559a581654ce51709138c55"
-    },
-    "nodejs-best-practices": {
-      "source": "sickn33/antigravity-awesome-skills",
-      "sourceType": "autoskills-registry",
-      "computedHash": "7361ab02fb6b09913e3bdd9cf61c629ed6c17de9485e6a781054e5d437ccfc29"
-    },
-    "nodejs-express-server": {
-      "source": "aj-geddes/useful-ai-prompts",
-      "sourceType": "autoskills-registry",
-      "computedHash": "b15b3e6dda23d3f3c230285a122de9df3aabae6408dc2bd52038445e60ba745e"
-    },
-    "prisma-cli": {
-      "source": "prisma/skills",
-      "sourceType": "autoskills-registry",
-      "computedHash": "d2b4e410bb24df07e0a399cf1fd70ca6a2f696079f7e6445eb602116566d2278"
-    },
-    "prisma-client-api": {
-      "source": "prisma/skills",
-      "sourceType": "autoskills-registry",
-      "computedHash": "922d6b5b4eb4387e72e409fa063f8e1bffb9037aed595cba0d3c257f418b6c18"
-    },
-    "prisma-database-setup": {
-      "source": "prisma/skills",
-      "sourceType": "autoskills-registry",
-      "computedHash": "50c6cbc7090ef356c026cb76352952b83b65bee8b3f3c7ac337461f5b352e9b9"
-    },
-    "prisma-postgres": {
-      "source": "prisma/skills",
-      "sourceType": "autoskills-registry",
-      "computedHash": "3adda04ae85b8593cfca45d48d5d410ddffb2797ea53f6dc9dfe34b8d71d35e9"
-    },
-    "typescript-advanced-types": {
-      "source": "wshobson/agents",
-      "sourceType": "autoskills-registry",
-      "computedHash": "5ca0e177c6aaaba1889255691224daafdb7d71f317cc70bede1590d3907ded42"
-    },
-    "zod": {
-      "source": "pproenca/dot-skills",
-      "sourceType": "autoskills-registry",
-      "computedHash": "aa8a97195b07763d37494b511f48be90979fd6826c031956c831cfc58f6a24b8"
+    "version": 1,
+    "skills": {
+        "nodejs-backend-patterns": {
+            "source": "wshobson/agents",
+            "sourceType": "autoskills-registry",
+            "computedHash": "710a5e6f83c46e8f6c43356df55c143a7375c4414559a581654ce51709138c55"
+        },
+        "nodejs-best-practices": {
+            "source": "sickn33/antigravity-awesome-skills",
+            "sourceType": "autoskills-registry",
+            "computedHash": "7361ab02fb6b09913e3bdd9cf61c629ed6c17de9485e6a781054e5d437ccfc29"
+        },
+        "nodejs-express-server": {
+            "source": "aj-geddes/useful-ai-prompts",
+            "sourceType": "autoskills-registry",
+            "computedHash": "b15b3e6dda23d3f3c230285a122de9df3aabae6408dc2bd52038445e60ba745e"
+        },
+        "prisma-cli": {
+            "source": "prisma/skills",
+            "sourceType": "autoskills-registry",
+            "computedHash": "d2b4e410bb24df07e0a399cf1fd70ca6a2f696079f7e6445eb602116566d2278"
+        },
+        "prisma-client-api": {
+            "source": "prisma/skills",
+            "sourceType": "autoskills-registry",
+            "computedHash": "922d6b5b4eb4387e72e409fa063f8e1bffb9037aed595cba0d3c257f418b6c18"
+        },
+        "prisma-database-setup": {
+            "source": "prisma/skills",
+            "sourceType": "autoskills-registry",
+            "computedHash": "50c6cbc7090ef356c026cb76352952b83b65bee8b3f3c7ac337461f5b352e9b9"
+        },
+        "prisma-postgres": {
+            "source": "prisma/skills",
+            "sourceType": "autoskills-registry",
+            "computedHash": "3adda04ae85b8593cfca45d48d5d410ddffb2797ea53f6dc9dfe34b8d71d35e9"
+        },
+        "typescript-advanced-types": {
+            "source": "wshobson/agents",
+            "sourceType": "autoskills-registry",
+            "computedHash": "5ca0e177c6aaaba1889255691224daafdb7d71f317cc70bede1590d3907ded42"
+        },
+        "zod": {
+            "source": "pproenca/dot-skills",
+            "sourceType": "autoskills-registry",
+            "computedHash": "aa8a97195b07763d37494b511f48be90979fd6826c031956c831cfc58f6a24b8"
+        }
     }
-  }
 }

--- a/src/api/console/auth-middleware.ts
+++ b/src/api/console/auth-middleware.ts
@@ -82,15 +82,10 @@ export async function requireModpackPermission(
         return res.redirect('/console/login')
     }
 
-    const canManageModpack = oauthSession.user.linked_roles.some(
-        ({ role }) => {
-            const permissions = new Permissions(role.permissions)
-            return (
-                permissions.has('ADMIN') ||
-                permissions.has('MANNAGE_MODPACK')
-            )
-        },
-    )
+    const canManageModpack = oauthSession.user.linked_roles.some(({ role }) => {
+        const permissions = new Permissions(role.permissions)
+        return permissions.has('ADMIN') || permissions.has('MANNAGE_MODPACK')
+    })
 
     if (!canManageModpack) {
         return res.status(403).json({ error: 'Forbidden' })

--- a/src/api/oauth/authorize/route.ts
+++ b/src/api/oauth/authorize/route.ts
@@ -237,8 +237,7 @@ router.get('/', cookieParser(), async (req, res) => {
     const discordUser = (await request.json()) as APIUser
     const roleName =
         discordUser.id === envs.SUPER_USER_DISCORD_ID ? 'super' : 'user'
-    const rolePermissions =
-        roleName === 'super' ? Permissions.Flags.ADMIN : 0n
+    const rolePermissions = roleName === 'super' ? Permissions.Flags.ADMIN : 0n
 
     const user = await db.user.upsert({
         create: {

--- a/src/api/oauth/me/route.ts
+++ b/src/api/oauth/me/route.ts
@@ -1,4 +1,8 @@
-import { ForbiddenError, InternalServerError, UnauthorizedError } from '#/api/errors.ts'
+import {
+    ForbiddenError,
+    InternalServerError,
+    UnauthorizedError,
+} from '#/api/errors.ts'
 import { db } from '#/db/prisma.ts'
 import { verifyToken } from '#/utils/encript.ts'
 import { parseScopes } from '#/utils/api.ts'

--- a/src/classes/post.ts
+++ b/src/classes/post.ts
@@ -1,9 +1,6 @@
 import { createHash } from 'node:crypto'
 import { inspect } from 'node:util'
-import {
-    POST_BLOCK_MEDIA_TYPE,
-    POST_STATUS,
-} from '#/db/generated/enums.ts'
+import { POST_BLOCK_MEDIA_TYPE, POST_STATUS } from '#/db/generated/enums.ts'
 import { db } from '#/db/prisma.ts'
 import { envs } from '#/config.ts'
 import { BUCKETS, s3 } from '#/db/s3.ts'

--- a/src/db/seed.ts
+++ b/src/db/seed.ts
@@ -34,6 +34,7 @@ if (!clientCount) {
             redirect_uris: [
                 'http://localhost:8080/oauth/callback',
                 'https://api.triskcraft.com/oauth/callback',
+                'https://api.triskcraft.com/console/login',
             ],
             scopes: ['openid', 'identify', 'minecraft'],
         },


### PR DESCRIPTION
## Resumen
- Migra el bot de npm a pnpm 11.5.2 y reemplaza `package-lock.json` por `pnpm-lock.yaml`.
- Ajusta el deploy para instalar con `pnpm install --frozen-lockfile` en modo CI.
- Agrega workflow de pruebas para PRs hacia `main`.
- Incluye configuración pnpm para builds aprobados y exclusión de `minimumReleaseAge` para `@triskcraft/api-types`.

## Contexto
La migración a pnpm endurece la instalación de dependencias ante riesgos recientes en el ecosistema npm. La rama también incluye archivos `.agents/` y `skills-lock.json`; quedan visibles en esta PR para revisión.

## Validación
- `CI=true pnpm install --frozen-lockfile`
- `pnpm run lint`
- `pnpm run build`
