### PR TITLE
Corrige contexto OAuth de la consola

### DIFF
--- a/src/api/oauth/authorize/route.ts
+++ b/src/api/oauth/authorize/route.ts
@@ -337,8 +337,9 @@ function discordLogin(req: Request, res: Response) {
     res.cookie('oauth_ctx', JSON.stringify(req.query), {
         httpOnly: true,
         secure: envs.NODE_ENV === 'production',
-        sameSite: 'strict',
+        sameSite: 'lax',
         path: '/',
+        maxAge: 10 * 60 * 1000,
     })
     return res.redirect(
         `https://discord.com/oauth2/authorize?client_id=${envs.DISCORD_CLIENT_ID}&response_type=code&redirect_uri=${encodeURIComponent(envs.DISCORD_REDIRECT_URI)}&scope=identify`,

--- a/src/api/oauth/authorize/route.ts
+++ b/src/api/oauth/authorize/route.ts
@@ -334,7 +334,18 @@ export default router
 // test http://localhost:8080/oauth/authorize?response_type=code&client_id=api-panel&code_challenge=eIVsW83uLPZmbiKwsR7J86HuUoMqpAWFuoLyo36gpaU&code_challenge_method=S256&redirect_uri=http://localhost:8080/oauth/callback
 
 function discordLogin(req: Request, res: Response) {
-    res.cookie('oauth_ctx', JSON.stringify(req.query), {
+    const discordState = randomBytes(32).toString('base64url')
+    const oauthCtx: Record<string, string> = {}
+
+    for (const [key, value] of Object.entries(req.query)) {
+        if (typeof value === 'string') {
+            oauthCtx[key] = value
+        }
+    }
+
+    oauthCtx.discord_state = discordState
+
+    res.cookie('oauth_ctx', JSON.stringify(oauthCtx), {
         httpOnly: true,
         secure: envs.NODE_ENV === 'production',
         sameSite: 'lax',
@@ -342,6 +353,12 @@ function discordLogin(req: Request, res: Response) {
         maxAge: 10 * 60 * 1000,
     })
     return res.redirect(
-        `https://discord.com/oauth2/authorize?client_id=${envs.DISCORD_CLIENT_ID}&response_type=code&redirect_uri=${encodeURIComponent(envs.DISCORD_REDIRECT_URI)}&scope=identify`,
+        `https://discord.com/oauth2/authorize?${new URLSearchParams({
+            client_id: envs.DISCORD_CLIENT_ID,
+            response_type: 'code',
+            redirect_uri: envs.DISCORD_REDIRECT_URI,
+            scope: 'identify',
+            state: discordState,
+        })}`,
     )
 }

--- a/src/api/oauth/discord/route.ts
+++ b/src/api/oauth/discord/route.ts
@@ -29,11 +29,23 @@ router.get('/', cookieParser(), async (req, res) => {
         },
         body: params,
     })
+    if (!request.ok) {
+        return render(
+            res,
+            Layout({
+                children: ErrorCard({
+                    title: 'Discord Login Failed',
+                    message:
+                        'Discord rejected the authorization code. Please try again.',
+                }),
+            }),
+        )
+    }
     const response = (await request.json()) as DiscordAccessTokenResponse
     res.cookie('discord_access', JSON.stringify(response), {
         httpOnly: true,
-        secure: true,
-        sameSite: 'strict',
+        secure: envs.NODE_ENV === 'production',
+        sameSite: 'lax',
         maxAge: response.expires_in * 1000,
     })
     const oauthCtx = getOauthCtxCookie(req)
@@ -48,6 +60,7 @@ router.get('/', cookieParser(), async (req, res) => {
             }),
         )
     }
+    res.clearCookie('oauth_ctx', { path: '/' })
     res.redirect(`/oauth/authorize?${new URLSearchParams(oauthCtx)}`)
 })
 

--- a/src/api/oauth/discord/route.ts
+++ b/src/api/oauth/discord/route.ts
@@ -15,6 +15,26 @@ router.get('/', cookieParser(), async (req, res) => {
     if (typeof req.query.code !== 'string') {
         return res.redirect('/oauth/authorize')
     }
+
+    const oauthCtx = getOauthCtxCookie(req)
+    if (
+        !oauthCtx ||
+        typeof req.query.state !== 'string' ||
+        oauthCtx.discord_state !== req.query.state
+    ) {
+        res.clearCookie('oauth_ctx', { path: '/' })
+
+        return render(
+            res,
+            Layout({
+                children: ErrorCard({
+                    title: 'Invalid Request',
+                    message: 'Invalid OAuth context. Please try again.',
+                }),
+            }),
+        )
+    }
+
     const params = new URLSearchParams({
         client_id: envs.DISCORD_CLIENT_ID,
         client_secret: envs.DISCORD_CLIENT_SECRET,
@@ -48,20 +68,12 @@ router.get('/', cookieParser(), async (req, res) => {
         sameSite: 'lax',
         maxAge: response.expires_in * 1000,
     })
-    const oauthCtx = getOauthCtxCookie(req)
-    if (!oauthCtx) {
-        return render(
-            res,
-            Layout({
-                children: ErrorCard({
-                    title: 'Invalid Request',
-                    message: 'Invalid OAuth context. Please try again.',
-                }),
-            }),
-        )
-    }
+
+    const oauthParams = { ...oauthCtx }
+    delete oauthParams.discord_state
+
     res.clearCookie('oauth_ctx', { path: '/' })
-    res.redirect(`/oauth/authorize?${new URLSearchParams(oauthCtx)}`)
+    res.redirect(`/oauth/authorize?${new URLSearchParams(oauthParams)}`)
 })
 
 export default router


### PR DESCRIPTION
## Resumen
- Corrige la cookie `oauth_ctx` para que sobreviva al regreso desde Discord durante el login OAuth.
- Ajusta `discord_access` para funcionar en local y limpia el contexto OAuth tras usarlo.
- Maneja errores del intercambio de token con Discord antes de guardar cookies.

## Validación
- `pnpm build`
