### PR TITLE
Corrige loop de login en la consola

### DIFF
--- a/src/api/console/login/route.ts
+++ b/src/api/console/login/route.ts
@@ -1,11 +1,31 @@
 import { envs } from '#/config.ts'
 import { generateCodeChallenge, generateCodeVerifier } from '#/utils/encript.ts'
-import { Router, type Response } from 'express'
+import { Router, type Request, type Response } from 'express'
 import { randomUUID } from 'node:crypto'
 
 const router = Router()
-const states = new Map<string, string>()
 const CONSOLE_CLIENT_ID = 'api-panel'
+const CONSOLE_OAUTH_COOKIE = 'console-oauth'
+
+interface ConsoleOAuthContext {
+    code_verifier: string
+    state: string
+}
+
+function getConsoleOAuthContext(req: Request): ConsoleOAuthContext | null {
+    try {
+        const raw = JSON.parse(req.cookies[CONSOLE_OAUTH_COOKIE])
+        if (
+            typeof raw.code_verifier !== 'string' ||
+            typeof raw.state !== 'string'
+        ) {
+            return null
+        }
+        return raw as ConsoleOAuthContext
+    } catch {
+        return null
+    }
+}
 
 router.get('/', async (req, res) => {
     const { code, state } = req.query
@@ -14,11 +34,16 @@ router.get('/', async (req, res) => {
         return login(res)
     }
 
-    const code_verifier = states.get(state)
-    if (!code_verifier || typeof code !== 'string') {
+    const context = getConsoleOAuthContext(req)
+    if (
+        !context ||
+        context.state !== state ||
+        typeof code !== 'string'
+    ) {
+        res.clearCookie(CONSOLE_OAUTH_COOKIE, { path: '/console/login' })
         return login(res)
     }
-    states.delete(state)
+    res.clearCookie(CONSOLE_OAUTH_COOKIE, { path: '/console/login' })
 
     const request = await fetch(new URL('/oauth/token', envs.API_URL), {
         method: 'POST',
@@ -29,7 +54,7 @@ router.get('/', async (req, res) => {
             redirect_uri: envs.CONSOLE_LOGIN_REDIRECT,
             grant_type: 'authorization_code',
             client_id: CONSOLE_CLIENT_ID,
-            code_verifier,
+            code_verifier: context.code_verifier,
             code,
         }),
     })
@@ -43,7 +68,7 @@ router.get('/', async (req, res) => {
     res.cookie('console-session', JSON.stringify(response), {
         httpOnly: true,
         secure: envs.NODE_ENV === 'production',
-        sameSite: 'strict',
+        sameSite: 'lax',
         path: '/console',
     })
 
@@ -54,7 +79,18 @@ function login(res: Response) {
     const verifier = generateCodeVerifier()
     const state = randomUUID()
     const code_challenge = generateCodeChallenge(verifier)
-    states.set(state, verifier)
+
+    res.cookie(
+        CONSOLE_OAUTH_COOKIE,
+        JSON.stringify({ code_verifier: verifier, state }),
+        {
+            httpOnly: true,
+            secure: envs.NODE_ENV === 'production',
+            sameSite: 'lax',
+            path: '/console/login',
+            maxAge: 10 * 60 * 1000,
+        },
+    )
 
     return res.redirect(
         `/oauth/authorize?${new URLSearchParams({

--- a/src/api/console/login/route.ts
+++ b/src/api/console/login/route.ts
@@ -35,11 +35,7 @@ router.get('/', async (req, res) => {
     }
 
     const context = getConsoleOAuthContext(req)
-    if (
-        !context ||
-        context.state !== state ||
-        typeof code !== 'string'
-    ) {
+    if (!context || context.state !== state || typeof code !== 'string') {
         res.clearCookie(CONSOLE_OAUTH_COOKIE, { path: '/console/login' })
         return login(res)
     }


### PR DESCRIPTION
## Resumen
- Reemplaza el almacenamiento en memoria del `state`/`code_verifier` de la consola por una cookie HTTP-only de corta duración.
- Valida el `state` del callback contra la cookie antes de intercambiar el código OAuth.
- Cambia `console-session` a `SameSite: lax` para evitar bucles tras redirects del flujo OAuth.

## Validación
- `pnpm build`
