### PR TITLE
Separa la página y callback del login de consola

### DIFF
--- a/.github/workflows/pings.yml
+++ b/.github/workflows/pings.yml
@@ -1,0 +1,9 @@
+name: PR Assignment Notifications
+
+on:
+    pull_request:
+        types: [assigned]
+
+jobs:
+    notify:
+        uses: Triskcraft/.github/workflows/pings.yml@main

--- a/src/api/console/login/route.ts
+++ b/src/api/console/login/route.ts
@@ -1,11 +1,19 @@
 import { envs } from '#/config.ts'
+import { db } from '#/db/prisma.ts'
 import { generateCodeChallenge, generateCodeVerifier } from '#/utils/encript.ts'
+import { html, render } from '#/utils/html.ts'
+import { ErrorCard } from '#/web/components/error-card.ts'
+import { Layout } from '#/web/components/layout.ts'
 import { Router, type Request, type Response } from 'express'
 import { randomUUID } from 'node:crypto'
 
 const router = Router()
 const CONSOLE_CLIENT_ID = 'api-panel'
 const CONSOLE_OAUTH_COOKIE = 'console-oauth'
+const CONSOLE_LOGIN_CALLBACK = new URL(
+    '/console/login/callback',
+    envs.CONSOLE_LOGIN_REDIRECT,
+).toString()
 
 interface ConsoleOAuthContext {
     code_verifier: string
@@ -27,18 +35,91 @@ function getConsoleOAuthContext(req: Request): ConsoleOAuthContext | null {
     }
 }
 
-router.get('/', async (req, res) => {
+router.get('/', async (_req, res) => {
+    const callbackRegistered = await ensureConsoleCallbackRegistered()
+    if (!callbackRegistered) {
+        return renderLoginError(
+            res,
+            'El cliente OAuth de la consola no está configurado.',
+        )
+    }
+
+    const loginUrl = createLoginUrl(res)
+
+    return render(
+        res,
+        Layout({
+            title: 'Acceso a la consola',
+            children: html`
+                <main class="container">
+                    <section class="login-panel">
+                        <p class="login-label">Consola administrativa</p>
+                        <h1>Acceso restringido</h1>
+                        <p class="login-message">
+                            Estás entrando a una consola exclusiva para personal
+                            autorizado de Triskcraft.
+                        </p>
+                        <a class="btn" href="${loginUrl}">
+                            Iniciar sesión con Discord
+                        </a>
+                    </section>
+                </main>
+
+                <style>
+                    .login-panel {
+                        background-color: white;
+                        border: 1px solid #d9dce3;
+                        border-top: 5px solid #5865f2;
+                        border-radius: 8px;
+                        box-shadow: 0 12px 32px rgba(31, 35, 48, 0.12);
+                        padding: 36px 30px;
+                    }
+
+                    .login-label {
+                        color: #5865f2;
+                        font-size: 0.8rem;
+                        font-weight: 700;
+                        margin: 0 0 8px;
+                        text-transform: uppercase;
+                    }
+
+                    .login-message {
+                        color: #5d6270;
+                        line-height: 1.6;
+                        margin: 0 0 28px;
+                    }
+
+                    .login-panel .btn {
+                        display: block;
+                        background-color: #5865f2;
+                    }
+
+                    .login-panel .btn:hover {
+                        background-color: #4752c4;
+                    }
+                </style>
+            `,
+        }),
+    )
+})
+
+router.get('/callback', async (req, res) => {
     const { code, state } = req.query
-
-    if (!code || typeof state !== 'string') {
-        return login(res)
-    }
-
     const context = getConsoleOAuthContext(req)
-    if (!context || context.state !== state || typeof code !== 'string') {
+
+    if (
+        !context ||
+        context.state !== state ||
+        typeof code !== 'string' ||
+        typeof state !== 'string'
+    ) {
         res.clearCookie(CONSOLE_OAUTH_COOKIE, { path: '/console/login' })
-        return login(res)
+        return renderLoginError(
+            res,
+            'El contexto de inicio de sesión no es válido o expiró.',
+        )
     }
+
     res.clearCookie(CONSOLE_OAUTH_COOKIE, { path: '/console/login' })
 
     const request = await fetch(new URL('/oauth/token', envs.API_URL), {
@@ -47,7 +128,7 @@ router.get('/', async (req, res) => {
             'Content-Type': 'application/json',
         },
         body: JSON.stringify({
-            redirect_uri: envs.CONSOLE_LOGIN_REDIRECT,
+            redirect_uri: CONSOLE_LOGIN_CALLBACK,
             grant_type: 'authorization_code',
             client_id: CONSOLE_CLIENT_ID,
             code_verifier: context.code_verifier,
@@ -56,7 +137,10 @@ router.get('/', async (req, res) => {
     })
 
     if (!request.ok) {
-        return login(res)
+        return renderLoginError(
+            res,
+            'No se pudo completar el inicio de sesión. Inténtalo de nuevo.',
+        )
     }
 
     const response = await request.json()
@@ -68,13 +152,13 @@ router.get('/', async (req, res) => {
         path: '/console',
     })
 
-    res.redirect('/console')
+    return res.redirect('/console')
 })
 
-function login(res: Response) {
+function createLoginUrl(res: Response) {
     const verifier = generateCodeVerifier()
     const state = randomUUID()
-    const code_challenge = generateCodeChallenge(verifier)
+    const codeChallenge = generateCodeChallenge(verifier)
 
     res.cookie(
         CONSOLE_OAUTH_COOKIE,
@@ -88,16 +172,54 @@ function login(res: Response) {
         },
     )
 
-    return res.redirect(
-        `/oauth/authorize?${new URLSearchParams({
-            response_type: 'code',
-            client_id: CONSOLE_CLIENT_ID,
-            code_challenge,
-            code_challenge_method: 'S256',
-            redirect_uri: envs.CONSOLE_LOGIN_REDIRECT,
-            scope: 'openid identify',
-            state,
-        })}`,
+    return `/oauth/authorize?${new URLSearchParams({
+        response_type: 'code',
+        client_id: CONSOLE_CLIENT_ID,
+        code_challenge: codeChallenge,
+        code_challenge_method: 'S256',
+        redirect_uri: CONSOLE_LOGIN_CALLBACK,
+        scope: 'openid identify',
+        state,
+    })}`
+}
+
+async function ensureConsoleCallbackRegistered() {
+    const client = await db.client.findUnique({
+        where: { id: CONSOLE_CLIENT_ID },
+        select: { redirect_uris: true },
+    })
+
+    if (!client) {
+        return false
+    }
+
+    if (!client.redirect_uris.includes(CONSOLE_LOGIN_CALLBACK)) {
+        await db.client.update({
+            where: { id: CONSOLE_CLIENT_ID },
+            data: {
+                redirect_uris: [
+                    ...client.redirect_uris,
+                    CONSOLE_LOGIN_CALLBACK,
+                ],
+            },
+        })
+    }
+
+    return true
+}
+
+function renderLoginError(res: Response, message: string) {
+    return render(
+        res,
+        Layout({
+            title: 'Error de inicio de sesión',
+            children: ErrorCard({
+                code: 400,
+                title: 'No se pudo iniciar sesión',
+                message,
+                backUrl: '/console/login',
+            }),
+        }),
     )
 }
 

--- a/src/api/oauth/refresh/route.ts
+++ b/src/api/oauth/refresh/route.ts
@@ -53,7 +53,7 @@ router.post('/', async (req, res) => {
 
     const expires_at = new Date(
         Temporal.Now.instant().add({
-            days: 7,
+            hours: 24 * 7,
         }).epochMilliseconds,
     )
 

--- a/src/api/oauth/token/route.ts
+++ b/src/api/oauth/token/route.ts
@@ -84,7 +84,7 @@ router.post<'/', null, OAuthTokenResponse, OAuthTokenRequest>(
 
         const expires_at = new Date(
             Temporal.Now.instant().add({
-                days: 7,
+                hours: 24 * 7,
             }).epochMilliseconds,
         )
 

--- a/src/db/seed.ts
+++ b/src/db/seed.ts
@@ -26,17 +26,34 @@ try {
 }
 logger.info('Por favor actualize el DEFAULT_ROLE_ID en .env')
 
-const clientCount = await db.client.count()
-if (!clientCount) {
+const consoleLoginCallback = new URL(
+    '/console/login/callback',
+    envs.CONSOLE_LOGIN_REDIRECT,
+).toString()
+const apiPanelClient = await db.client.findUnique({
+    where: { id: 'api-panel' },
+})
+
+if (!apiPanelClient) {
     await db.client.create({
         data: {
             id: 'api-panel',
             redirect_uris: [
                 'http://localhost:8080/oauth/callback',
                 'https://api.triskcraft.com/oauth/callback',
-                'https://api.triskcraft.com/console/login',
+                consoleLoginCallback,
             ],
             scopes: ['openid', 'identify', 'minecraft'],
+        },
+    })
+} else if (!apiPanelClient.redirect_uris.includes(consoleLoginCallback)) {
+    await db.client.update({
+        where: { id: 'api-panel' },
+        data: {
+            redirect_uris: [
+                ...apiPanelClient.redirect_uris,
+                consoleLoginCallback,
+            ],
         },
     })
 }


### PR DESCRIPTION
## Resumen
- Convierte `/console/login` en una página informativa para personal autorizado con un botón de acceso mediante Discord.
- Separa el retorno OAuth en `/console/login/callback` y evita que la ruta de entrada procese códigos automáticamente.
- Conserva PKCE y `state` en una cookie HTTP-only y muestra errores recuperables sin generar ciclos de redirección.
- Registra de forma idempotente la nueva callback en el cliente OAuth interno `api-panel` y en el seed.

## Flujo
1. `/console` redirige a `/console/login` si no existe una sesión válida.
2. `/console/login` muestra el aviso y el botón de acceso.
3. El botón abre `/oauth/authorize` con callback `/console/login/callback`.
4. El callback intercambia el código, guarda `console-session` y redirige a `/console`.

## Validación
- `pnpm build`
