### PR TITLE
Completar incorporación al gremio mediante OAuth de Discord

### DIFF
--- a/.github/workflows/pings.yml
+++ b/.github/workflows/pings.yml
@@ -6,4 +6,4 @@ on:
 
 jobs:
     notify:
-        uses: Triskcraft/.github/workflows/pings.yml@main
+        uses: Triskcraft/.github/.github/workflows/pings.yml@main

--- a/src/api/oauth/authorize/route.ts
+++ b/src/api/oauth/authorize/route.ts
@@ -357,7 +357,7 @@ function discordLogin(req: Request, res: Response) {
             client_id: envs.DISCORD_CLIENT_ID,
             response_type: 'code',
             redirect_uri: envs.DISCORD_REDIRECT_URI,
-            scope: 'identify',
+            scope: 'identify guilds guilds.join',
             state: discordState,
         })}`,
     )

--- a/src/api/oauth/discord/route.ts
+++ b/src/api/oauth/discord/route.ts
@@ -4,10 +4,12 @@ import { ErrorCard } from '#/web/components/error-card.ts'
 import { Layout } from '#/web/components/layout.ts'
 import { Router } from 'express'
 import cookieParser from 'cookie-parser'
+import type { APIUser } from 'discord.js'
 import {
     getOauthCtxCookie,
     type DiscordAccessTokenResponse,
 } from '#/utils/api.ts'
+import { logger } from '#/logger.ts'
 
 const router = Router()
 
@@ -62,6 +64,74 @@ router.get('/', cookieParser(), async (req, res) => {
         )
     }
     const response = (await request.json()) as DiscordAccessTokenResponse
+
+    const userRequest = await fetch('https://discord.com/api/v10/users/@me', {
+        headers: {
+            Authorization: `Bearer ${response.access_token}`,
+        },
+    })
+    const guildsRequest = await fetch(
+        'https://discord.com/api/v10/users/@me/guilds?limit=200',
+        {
+            headers: {
+                Authorization: `Bearer ${response.access_token}`,
+            },
+        },
+    )
+
+    if (!userRequest.ok || !guildsRequest.ok) {
+        logger.error(
+            {
+                userStatus: userRequest.status,
+                guildsStatus: guildsRequest.status,
+            },
+            'No se pudo consultar el usuario o sus gremios durante OAuth',
+        )
+
+        return discordLoginError(
+            res,
+            'Discord did not provide the account information required to complete the login.',
+        )
+    }
+
+    const discordUser = (await userRequest.json()) as APIUser
+    const discordGuilds = (await guildsRequest.json()) as { id: string }[]
+    const isGuildMember = discordGuilds.some(
+        guild => guild.id === envs.DISCORD_GUILD_ID,
+    )
+
+    if (!isGuildMember) {
+        const joinRequest = await fetch(
+            `https://discord.com/api/v10/guilds/${envs.DISCORD_GUILD_ID}/members/${discordUser.id}`,
+            {
+                method: 'PUT',
+                headers: {
+                    Authorization: `Bot ${envs.token}`,
+                    'Content-Type': 'application/json',
+                },
+                body: JSON.stringify({
+                    access_token: response.access_token,
+                }),
+            },
+        )
+
+        if (!joinRequest.ok) {
+            logger.error(
+                {
+                    status: joinRequest.status,
+                    userId: discordUser.id,
+                    guildId: envs.DISCORD_GUILD_ID,
+                },
+                'No se pudo unir al usuario al gremio durante OAuth',
+            )
+
+            return discordLoginError(
+                res,
+                'Discord could not add your account to the server. Please try again.',
+            )
+        }
+    }
+
     res.cookie('discord_access', JSON.stringify(response), {
         httpOnly: true,
         secure: envs.NODE_ENV === 'production',
@@ -77,3 +147,15 @@ router.get('/', cookieParser(), async (req, res) => {
 })
 
 export default router
+
+function discordLoginError(res: Parameters<typeof render>[0], message: string) {
+    return render(
+        res,
+        Layout({
+            children: ErrorCard({
+                title: 'Discord Login Failed',
+                message,
+            }),
+        }),
+    )
+}

--- a/src/db/seed.ts
+++ b/src/db/seed.ts
@@ -26,37 +26,43 @@ try {
 }
 logger.info('Por favor actualize el DEFAULT_ROLE_ID en .env')
 
-const consoleLoginCallback = new URL(
-    '/console/login/callback',
-    envs.CONSOLE_LOGIN_REDIRECT,
-).toString()
-const apiPanelClient = await db.client.findUnique({
+const webClientRedirectUris = [
+    'http://localhost:3000/api/auth/callback',
+    'https://triskcraft.com/api/auth/callback',
+    'https://www.triskcraft.com/api/auth/callback',
+]
+
+await db.client.upsert({
     where: { id: 'api-panel' },
+    create: {
+        id: 'api-panel',
+        redirect_uris: [
+            'http://localhost:8080/console/login/callback',
+            'https://api.triskcraft.com/console/login/callback',
+        ],
+        scopes: ['openid', 'identify', 'minecraft'],
+    },
+    update: {
+        redirect_uris: [
+            'http://localhost:8080/console/login/callback',
+            'https://api.triskcraft.com/console/login/callback',
+        ],
+        scopes: ['openid', 'identify', 'minecraft'],
+    },
 })
 
-if (!apiPanelClient) {
-    await db.client.create({
-        data: {
-            id: 'api-panel',
-            redirect_uris: [
-                'http://localhost:8080/oauth/callback',
-                'https://api.triskcraft.com/oauth/callback',
-                consoleLoginCallback,
-            ],
-            scopes: ['openid', 'identify', 'minecraft'],
-        },
-    })
-} else if (!apiPanelClient.redirect_uris.includes(consoleLoginCallback)) {
-    await db.client.update({
-        where: { id: 'api-panel' },
-        data: {
-            redirect_uris: [
-                ...apiPanelClient.redirect_uris,
-                consoleLoginCallback,
-            ],
-        },
-    })
-}
+await db.client.upsert({
+    where: { id: 'triskcraft-web' },
+    create: {
+        id: 'triskcraft-web',
+        redirect_uris: webClientRedirectUris,
+        scopes: ['openid', 'identify', 'minecraft'],
+    },
+    update: {
+        redirect_uris: webClientRedirectUris,
+        scopes: ['openid', 'identify', 'minecraft'],
+    },
+})
 
 const superRole = await db.role.findUnique({
     where: { name: 'super' },


### PR DESCRIPTION
## Resumen

- solicita los scopes `identify`, `guilds` y `guilds.join` durante el OAuth de Discord
- comprueba si el usuario ya pertenece al gremio configurado y, si falta, lo incorpora mediante la API de Discord con el token del bot
- evita completar el callback y guardar la sesión cuando Discord no permite consultar o unir al usuario
- actualiza los clientes OAuth sembrados y sus URI de redirección
- corrige la referencia utilizada por el workflow de pings

## Motivo

El inicio de sesión con Discord debía garantizar que cada usuario autenticado también perteneciera al gremio de Triskcraft, sin intentar incorporarlo de nuevo cuando ya era miembro.

## Validación

- `pnpm lint`
- `pnpm build`
