### PR TITLE
[codex] Completa la migración de webhooks a usuarios

### DIFF
--- a/src/api/webhook-auth.middleware.ts
+++ b/src/api/webhook-auth.middleware.ts
@@ -59,7 +59,6 @@ export function webhookAuth(permissions: WebhookPermission[]) {
         }
         const tokendb = await db.webhookToken.findUnique({
             where: { id: jwtPayload.payload.id },
-            include: { discord_user: true },
         })
         if (!tokendb) {
             throw new UnauthorizedError()

--- a/src/db/migrations/20260612210328_remove_webhook_discord_user/migration.sql
+++ b/src/db/migrations/20260612210328_remove_webhook_discord_user/migration.sql
@@ -1,0 +1,19 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `discord_user_id` on the `webhook_tokens` table. All the data in the column will be lost.
+  - Made the column `user_id` on table `webhook_tokens` required. This step will fail if there are existing NULL values in that column.
+
+*/
+-- DropForeignKey
+ALTER TABLE "webhook_tokens" DROP CONSTRAINT "webhook_tokens_discord_user_id_fkey";
+
+-- DropForeignKey
+ALTER TABLE "webhook_tokens" DROP CONSTRAINT "webhook_tokens_user_id_fkey";
+
+-- AlterTable
+ALTER TABLE "webhook_tokens" DROP COLUMN "discord_user_id",
+ALTER COLUMN "user_id" SET NOT NULL;
+
+-- AddForeignKey
+ALTER TABLE "webhook_tokens" ADD CONSTRAINT "webhook_tokens_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/src/db/schema.erd
+++ b/src/db/schema.erd
@@ -59,7 +59,6 @@
       "rel_linked_roles_role",
       "rel_linked_roles_player",
       "rel_medias_player",
-      "rel_webhook_tokens_discord_user",
       "rel_webhook_tokens_user",
       "rel_posts_user",
       "rel_posts_cover_media",
@@ -104,15 +103,15 @@
           "col_inactivity_periods_notified"
         ],
         "ui": {
-          "x": 42.4602,
-          "y": 972.7519,
+          "x": 43.5591,
+          "y": 429.1622,
           "zIndex": 1,
           "widthName": 93,
           "widthComment": 60,
           "color": ""
         },
         "meta": {
-          "updateAt": 1781293324313,
+          "updateAt": 1781297903307,
           "createAt": 1780469686502
         }
       },
@@ -131,15 +130,15 @@
           "col_tracked_roles_created_at"
         ],
         "ui": {
-          "x": 1632.4336,
-          "y": 1345.6541,
+          "x": 1683.7157,
+          "y": 1222.5772,
           "zIndex": 1,
           "widthName": 72,
           "widthComment": 60,
           "color": ""
         },
         "meta": {
-          "updateAt": 1781293370302,
+          "updateAt": 1781297857298,
           "createAt": 1780469686502
         }
       },
@@ -164,15 +163,15 @@
           "col_role_statistics_captured_at"
         ],
         "ui": {
-          "x": 1639.5686,
-          "y": 1115.4823,
+          "x": 1365.2097,
+          "y": 1382.149,
           "zIndex": 1,
           "widthName": 72,
           "widthComment": 60,
           "color": ""
         },
         "meta": {
-          "updateAt": 1781293367299,
+          "updateAt": 1781297919311,
           "createAt": 1780469686502
         }
       },
@@ -193,15 +192,15 @@
           "col_link_codes_code"
         ],
         "ui": {
-          "x": 29.7797,
-          "y": 731.4036,
+          "x": 44.1876,
+          "y": 697.0934,
           "zIndex": 1,
           "widthName": 60,
           "widthComment": 60,
           "color": ""
         },
         "meta": {
-          "updateAt": 1781293319305,
+          "updateAt": 1781297903307,
           "createAt": 1780469686502
         }
       },
@@ -330,15 +329,15 @@
           "col_discord_users_username"
         ],
         "ui": {
-          "x": 561.4218,
-          "y": 759.0113,
+          "x": 547.1361,
+          "y": 560.5986,
           "zIndex": 1,
           "widthName": 73,
           "widthComment": 60,
           "color": ""
         },
         "meta": {
-          "updateAt": 1781293308314,
+          "updateAt": 1781297806302,
           "createAt": 1780469686502
         }
       },
@@ -349,7 +348,6 @@
         "columnIds": [
           "col_webhook_tokens_id",
           "col_webhook_tokens_name",
-          "col_webhook_tokens_discord_user_id",
           "col_webhook_tokens_user_id",
           "col_webhook_tokens_secret",
           "col_webhook_tokens_permissions",
@@ -365,15 +363,15 @@
           "col_webhook_tokens_created_at"
         ],
         "ui": {
-          "x": 444.5694,
-          "y": 464.3846,
+          "x": 1674.1176,
+          "y": 987.8278,
           "zIndex": 1,
           "widthName": 91,
           "widthComment": 60,
           "color": ""
         },
         "meta": {
-          "updateAt": 1781293315306,
+          "updateAt": 1781297853309,
           "createAt": 1780469686502
         }
       },
@@ -431,15 +429,15 @@
           "col_posts_updated_at"
         ],
         "ui": {
-          "x": 1128.2346,
-          "y": 807.8815,
+          "x": 1107.966,
+          "y": 785.6593,
           "zIndex": 1,
           "widthName": 60,
           "widthComment": 60,
           "color": ""
         },
         "meta": {
-          "updateAt": 1781293273310,
+          "updateAt": 1781297871301,
           "createAt": 1780469686502
         }
       },
@@ -466,15 +464,15 @@
           "col_post_blocks_author_id"
         ],
         "ui": {
-          "x": 561.8425,
-          "y": 980.4837,
+          "x": 565.0171,
+          "y": 756.6742,
           "zIndex": 1,
           "widthName": 64,
           "widthComment": 60,
           "color": ""
         },
         "meta": {
-          "updateAt": 1781293321302,
+          "updateAt": 1781297896304,
           "createAt": 1780469686502
         }
       },
@@ -507,15 +505,15 @@
           "col_post_media_hash"
         ],
         "ui": {
-          "x": 1000.7407,
-          "y": 1153.7037,
+          "x": 714.5381,
+          "y": 1230.8711,
           "zIndex": 1,
           "widthName": 63,
           "widthComment": 60,
           "color": ""
         },
         "meta": {
-          "updateAt": 1781293334304,
+          "updateAt": 1781297919311,
           "createAt": 1781292951982
         }
       },
@@ -534,15 +532,15 @@
           "col_post_block_media_position"
         ],
         "ui": {
-          "x": 162.9629,
-          "y": 1266.6666,
+          "x": 168.9458,
+          "y": 1017.094,
           "zIndex": 1,
           "widthName": 96,
           "widthComment": 60,
           "color": ""
         },
         "meta": {
-          "updateAt": 1781293331303,
+          "updateAt": 1781297915310,
           "createAt": 1781292951982
         }
       },
@@ -565,15 +563,15 @@
           "col_users_updated_at"
         ],
         "ui": {
-          "x": 1083.809,
-          "y": 547.3528,
+          "x": 1086.3731,
+          "y": 531.9682,
           "zIndex": 1,
           "widthName": 60,
           "widthComment": 60,
           "color": ""
         },
         "meta": {
-          "updateAt": 1781293260300,
+          "updateAt": 1781297865310,
           "createAt": 1780469686502
         }
       },
@@ -637,15 +635,15 @@
           "col_authorization_codes_scope"
         ],
         "ui": {
-          "x": 1641.1591,
-          "y": 384.5368,
+          "x": 1674.4924,
+          "y": 320.4342,
           "zIndex": 1,
           "widthName": 108,
           "widthComment": 60,
           "color": ""
         },
         "meta": {
-          "updateAt": 1781293256307,
+          "updateAt": 1781297845299,
           "createAt": 1780469686502
         }
       },
@@ -699,15 +697,15 @@
           "col_user_roles_permissions"
         ],
         "ui": {
-          "x": 1648.1481,
-          "y": 955.5556,
+          "x": 1714.3264,
+          "y": 800.6105,
           "zIndex": 1,
           "widthName": 60,
           "widthComment": 60,
           "color": ""
         },
         "meta": {
-          "updateAt": 1781293266306,
+          "updateAt": 1781297850303,
           "createAt": 1781292951982
         }
       },
@@ -724,15 +722,15 @@
           "col_linked_user_roles_role_id"
         ],
         "ui": {
-          "x": 1650,
-          "y": 727.7775,
+          "x": 1703.3578,
+          "y": 617.0327,
           "zIndex": 1,
           "widthName": 92,
           "widthComment": 60,
           "color": ""
         },
         "meta": {
-          "updateAt": 1781293264307,
+          "updateAt": 1781297847300,
           "createAt": 1781292951982
         }
       }
@@ -1507,7 +1505,7 @@
         "default": "",
         "options": 10,
         "ui": {
-          "keys": 2,
+          "keys": 0,
           "widthName": 83,
           "widthComment": 60,
           "widthDataType": 60,
@@ -2890,8 +2888,8 @@
           "columnIds": [
             "col_discord_users_id"
           ],
-          "x": 561.4218,
-          "y": 837.0113,
+          "x": 547.1361,
+          "y": 586.5986,
           "direction": 1
         },
         "end": {
@@ -2899,8 +2897,8 @@
           "columnIds": [
             "col_inactivity_periods_user_id"
           ],
-          "x": 452.4602,
-          "y": 1084.7519,
+          "x": 453.5591,
+          "y": 541.1622,
           "direction": 2
         },
         "meta": {
@@ -2918,8 +2916,8 @@
           "columnIds": [
             "col_discord_users_id"
           ],
-          "x": 561.4218,
-          "y": 785.0113,
+          "x": 547.1361,
+          "y": 638.5986,
           "direction": 1
         },
         "end": {
@@ -2927,8 +2925,8 @@
           "columnIds": [
             "col_link_codes_discord_id"
           ],
-          "x": 463.7797,
-          "y": 807.4036,
+          "x": 478.1876,
+          "y": 773.0934,
           "direction": 2
         },
         "meta": {
@@ -3058,18 +3056,18 @@
           "columnIds": [
             "col_users_id"
           ],
-          "x": 1083.809,
-          "y": 635.3527999999999,
-          "direction": 1
+          "x": 1507.3731,
+          "y": 678.6348666666667,
+          "direction": 2
         },
         "end": {
           "tableId": "tbl_webhook_tokens",
           "columnIds": [
             "col_webhook_tokens_user_id"
           ],
-          "x": 864.5694,
-          "y": 576.3846,
-          "direction": 2
+          "x": 1674.1176,
+          "y": 1087.8278,
+          "direction": 1
         },
         "meta": {
           "updateAt": 1781292951982,
@@ -3086,8 +3084,8 @@
           "columnIds": [
             "col_users_id"
           ],
-          "x": 1294.309,
-          "y": 723.3528,
+          "x": 1296.8731,
+          "y": 707.9682,
           "direction": 8
         },
         "end": {
@@ -3095,8 +3093,8 @@
           "columnIds": [
             "col_posts_user_id"
           ],
-          "x": 1345.7346,
-          "y": 807.8815,
+          "x": 1325.466,
+          "y": 785.6593,
           "direction": 4
         },
         "meta": {
@@ -3114,8 +3112,8 @@
           "columnIds": [
             "col_post_media_id"
           ],
-          "x": 1246.2406999999998,
-          "y": 1153.7037,
+          "x": 960.0381,
+          "y": 1230.8711,
           "direction": 4
         },
         "end": {
@@ -3123,9 +3121,9 @@
           "columnIds": [
             "col_posts_cover_media_id"
           ],
-          "x": 1345.7346,
-          "y": 1055.8815,
-          "direction": 8
+          "x": 1107.966,
+          "y": 971.6593,
+          "direction": 1
         },
         "meta": {
           "updateAt": 1781292951982,
@@ -3142,8 +3140,8 @@
           "columnIds": [
             "col_discord_users_id"
           ],
-          "x": 758.9218,
-          "y": 863.0113,
+          "x": 744.6361,
+          "y": 664.5986,
           "direction": 8
         },
         "end": {
@@ -3151,8 +3149,8 @@
           "columnIds": [
             "col_post_blocks_author_id"
           ],
-          "x": 763.3425,
-          "y": 980.4837,
+          "x": 766.5171,
+          "y": 756.6742,
           "direction": 4
         },
         "meta": {
@@ -3170,8 +3168,8 @@
           "columnIds": [
             "col_posts_id"
           ],
-          "x": 1128.2346,
-          "y": 931.8815,
+          "x": 1107.966,
+          "y": 847.6593,
           "direction": 1
         },
         "end": {
@@ -3179,8 +3177,8 @@
           "columnIds": [
             "col_post_blocks_post_id"
           ],
-          "x": 964.8425,
-          "y": 1092.4837,
+          "x": 968.0171,
+          "y": 868.6742,
           "direction": 2
         },
         "meta": {
@@ -3198,8 +3196,8 @@
           "columnIds": [
             "col_post_blocks_message_id"
           ],
-          "x": 763.3425,
-          "y": 1204.4837,
+          "x": 766.5171,
+          "y": 980.6742,
           "direction": 8
         },
         "end": {
@@ -3207,8 +3205,8 @@
           "columnIds": [
             "col_post_block_media_post_block_message_id"
           ],
-          "x": 622.9629,
-          "y": 1298.6666,
+          "x": 628.9458,
+          "y": 1049.094,
           "direction": 2
         },
         "meta": {
@@ -3226,8 +3224,8 @@
           "columnIds": [
             "col_post_media_id"
           ],
-          "x": 1000.7407,
-          "y": 1301.7037,
+          "x": 714.5381,
+          "y": 1378.8711,
           "direction": 1
         },
         "end": {
@@ -3235,8 +3233,8 @@
           "columnIds": [
             "col_post_block_media_media_id"
           ],
-          "x": 622.9629,
-          "y": 1362.6666,
+          "x": 628.9458,
+          "y": 1113.094,
           "direction": 2
         },
         "meta": {
@@ -3263,8 +3261,8 @@
           "columnIds": [
             "col_users_mc_player_uuid"
           ],
-          "x": 1083.809,
-          "y": 576.6861333333333,
+          "x": 1086.3731,
+          "y": 575.9682,
           "direction": 1
         },
         "meta": {
@@ -3282,8 +3280,8 @@
           "columnIds": [
             "col_discord_users_id"
           ],
-          "x": 956.4218,
-          "y": 811.0113,
+          "x": 942.1361,
+          "y": 612.5986,
           "direction": 2
         },
         "end": {
@@ -3291,8 +3289,8 @@
           "columnIds": [
             "col_users_discord_user_id"
           ],
-          "x": 1083.809,
-          "y": 694.0194666666665,
+          "x": 1086.3731,
+          "y": 663.9682,
           "direction": 1
         },
         "meta": {
@@ -3310,8 +3308,8 @@
           "columnIds": [
             "col_users_id"
           ],
-          "x": 1504.809,
-          "y": 591.3528,
+          "x": 1507.3731,
+          "y": 561.3015333333334,
           "direction": 2
         },
         "end": {
@@ -3319,8 +3317,8 @@
           "columnIds": [
             "col_authorization_codes_user_id"
           ],
-          "x": 1641.1591,
-          "y": 520.5368000000001,
+          "x": 1674.4924,
+          "y": 456.4342,
           "direction": 1
         },
         "meta": {
@@ -3347,8 +3345,8 @@
           "columnIds": [
             "col_authorization_codes_client_id"
           ],
-          "x": 1851.6591,
-          "y": 384.5368,
+          "x": 1884.9924,
+          "y": 320.4342,
           "direction": 4
         },
         "meta": {
@@ -3366,8 +3364,8 @@
           "columnIds": [
             "col_users_id"
           ],
-          "x": 1294.309,
-          "y": 547.3528,
+          "x": 1296.8731,
+          "y": 531.9682,
           "direction": 4
         },
         "end": {
@@ -3422,8 +3420,8 @@
           "columnIds": [
             "col_users_id"
           ],
-          "x": 1504.809,
-          "y": 679.3528,
+          "x": 1507.3731,
+          "y": 619.9682,
           "direction": 2
         },
         "end": {
@@ -3431,8 +3429,8 @@
           "columnIds": [
             "col_linked_user_roles_user_id"
           ],
-          "x": 1650,
-          "y": 779.7775,
+          "x": 1703.3578,
+          "y": 669.0327,
           "direction": 1
         },
         "meta": {
@@ -3450,8 +3448,8 @@
           "columnIds": [
             "col_user_roles_id"
           ],
-          "x": 1849.1481,
-          "y": 955.5556,
+          "x": 1915.3264,
+          "y": 800.6105,
           "direction": 4
         },
         "end": {
@@ -3459,8 +3457,8 @@
           "columnIds": [
             "col_linked_user_roles_role_id"
           ],
-          "x": 1847.5,
-          "y": 831.7775,
+          "x": 1900.8578,
+          "y": 721.0327,
           "direction": 8
         },
         "meta": {

--- a/src/db/schema.prisma
+++ b/src/db/schema.prisma
@@ -129,7 +129,6 @@ model DiscordUser {
 
     inactivity_periods InactivityPeriod[]
     link_code          LinkCode?
-    webhook_tokens     WebhookToken[]
     post_blocks        PostBlocks[]
     user               User?
 
@@ -137,16 +136,14 @@ model DiscordUser {
 }
 
 model WebhookToken {
-    id              String   @id @default(dbgenerated("snowflake()"))
-    name            String   @unique
-    discord_user_id String
-    user_id         String?
-    secret          String
-    permissions     String[]
-    created_at      DateTime @default(now())
+    id          String   @id @default(dbgenerated("snowflake()"))
+    name        String   @unique
+    user_id     String
+    secret      String
+    permissions String[]
+    created_at  DateTime @default(now())
 
-    discord_user DiscordUser @relation(fields: [discord_user_id], references: [id])
-    user         User?       @relation(fields: [user_id], references: [id])
+    user User @relation(fields: [user_id], references: [id])
 
     @@map("webhook_tokens")
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,51 +30,6 @@ async function shutdown(signal: string) {
 process.on('SIGINT', () => shutdown('SIGINT'))
 process.on('SIGTERM', () => shutdown('SIGTERM'))
 
-async function migrateWebhookUsers() {
-    const webhooks = await db.webhookToken.findMany({
-        where: {
-            user_id: null,
-        },
-        select: {
-            id: true,
-            discord_user: {
-                select: {
-                    user: {
-                        select: {
-                            id: true,
-                        },
-                    },
-                },
-            },
-        },
-    })
-
-    const webhooksWithUser = webhooks.filter(
-        webhook => webhook.discord_user.user,
-    )
-
-    await db.$transaction(
-        webhooksWithUser.map(webhook =>
-            db.webhookToken.update({
-                where: {
-                    id: webhook.id,
-                },
-                data: {
-                    user_id: webhook.discord_user.user!.id,
-                },
-            }),
-        ),
-    )
-
-    logger.info(
-        {
-            linkedWebhooks: webhooksWithUser.length,
-            missingUsers: webhooks.length - webhooksWithUser.length,
-        },
-        'Migración de usuarios de webhooks completada',
-    )
-}
-
 /**
  * Punto de entrada principal del bot. Aquí se inicializan los servicios
  * compartidos (API HTTP, cliente de Discord, acceso a base de datos y
@@ -98,7 +53,6 @@ if (envs.DEPLOY_INACTIVITY_PANEL) {
     logger.info('Saltando el despliegue del panel de inactividad')
 }
 // Activa los jobs programados que mantienen el sistema actualizado.
-await migrateWebhookUsers()
 await deployWebhookPanel()
 scheduler.start()
 await blogService.start()

--- a/src/interactions/modals/webhook-add.ts
+++ b/src/interactions/modals/webhook-add.ts
@@ -82,6 +82,7 @@ export default class extends ModalInteractionHandler {
             interaction.fields.getStringSelectValues('permissions')
         const name = interaction.fields.getTextInputValue('name')
         let wt: WebhookToken
+        let userId: string
         try {
             const user = await db.user.upsert({
                 where: {
@@ -108,6 +109,7 @@ export default class extends ModalInteractionHandler {
                     },
                 },
             })
+            userId = user.id
             wt = await db.webhookToken.create({
                 data: {
                     secret: encrypt(secret).payload,
@@ -116,11 +118,6 @@ export default class extends ModalInteractionHandler {
                     user: {
                         connect: {
                             id: user.id,
-                        },
-                    },
-                    discord_user: {
-                        connect: {
-                            id: interaction.user.id,
                         },
                     },
                 },
@@ -148,7 +145,7 @@ export default class extends ModalInteractionHandler {
 
         const jwt = await new SignJWT({
             id: wt.id,
-            user: interaction.user.id,
+            user: userId,
             permissions,
             name,
         })

--- a/src/interactions/modals/webhook-delete.ts
+++ b/src/interactions/modals/webhook-delete.ts
@@ -17,6 +17,13 @@ export default class extends ModalInteractionHandler {
     static override async build({ id }: { id: string }) {
         const token = await db.webhookToken.findUnique({
             where: { id },
+            include: {
+                user: {
+                    select: {
+                        discord_user_id: true,
+                    },
+                },
+            },
         })
         if (!token) {
             return new ModalBuilder()
@@ -31,7 +38,7 @@ export default class extends ModalInteractionHandler {
             .addTextDisplayComponents(
                 new TextDisplayBuilder().setContent(
                     `Creado el <t:${Math.floor(token.created_at.getTime() / 1000)}:d>\n` +
-                        `por <@${token.discord_user_id}>\n` +
+                        `por <@${token.user.discord_user_id}>\n` +
                         `permisos:\n` +
                         token.permissions.map(p => `- ${p}`).join('\n'),
                 ),

--- a/src/services/webhook.service.ts
+++ b/src/services/webhook.service.ts
@@ -38,6 +38,13 @@ export async function deployWebhookPanel() {
 
     const tokens = await db.webhookToken.findMany({
         orderBy: { created_at: 'desc' },
+        include: {
+            user: {
+                select: {
+                    discord_user_id: true,
+                },
+            },
+        },
     })
     for (const token of tokens) {
         container.addSectionComponents(
@@ -45,7 +52,7 @@ export async function deployWebhookPanel() {
                 .addTextDisplayComponents(
                     new TextDisplayBuilder().setContent(
                         `- **${token.name}**\n` +
-                            `Creado el <t:${Math.floor(token.created_at.getTime() / 1000)}:d> por <@${token.discord_user_id}>\n` +
+                            `Creado el <t:${Math.floor(token.created_at.getTime() / 1000)}:d> por <@${token.user.discord_user_id}>\n` +
                             `Permisos: ${new Intl.ListFormat('es', {
                                 style: 'long',
                                 type: 'conjunction',


### PR DESCRIPTION
## Resumen

Completa la migración de webhooks para utilizar `User` como entidad principal y elimina la relación directa heredada con `DiscordUser`.

## Cambios

- Hace obligatorio `WebhookToken.user_id`.
- Elimina `WebhookToken.discord_user_id` y su relación directa con `DiscordUser`.
- Actualiza la creación de tokens para vincular únicamente el usuario normal.
- Firma los JWT de webhooks con el ID de `User`.
- Obtiene el usuario de Discord mediante `webhook.user.discord_user` cuando se necesita mostrar una mención.
- Actualiza el panel y el modal de eliminación de webhooks al nuevo modelo.
- Elimina del arranque el script temporal de backfill.
- Actualiza el ERD con las relaciones finales.

## Migración

La nueva migración elimina la columna heredada `webhook_tokens.discord_user_id`, establece `user_id` como obligatorio y conserva la relación con `users`.

El backfill de `user_id` fue realizado antes de hacer obligatoria la columna.

## Impacto

Los webhooks, su autenticación y sus JWT parten ahora del usuario normal. Discord queda como una relación secundaria accesible desde `User`.

## Validación

- `pnpm run build`
- `pnpm run lint`
- `pnpm exec prisma validate`
- Prettier sobre los archivos modificados
- `git diff --check`
